### PR TITLE
feat: extract run() out of Solver trait

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,13 +41,13 @@ For semantic versions, `bump` corresponds to an increment of the patch number.
 ## API
 
 ```rust
-solution = solver.run(package, version)?;
+let solution = resolve(&dependency_provider, package, version)?;
 ```
 
-Where `solver` provides the list of available packages and versions,
+Where `dependency_provider` supplies the list of available packages and versions,
 as well as the dependencies of every available package
-by implementing the `Solver` trait.
-The call to `run` for a given package at a given version
+by implementing the `DependencyProvider` trait.
+The call to `resolve` for a given package at a given version
 will compute the set of packages and versions needed
 to satisfy the dependencies of that package and version pair.
 If there is no solution, the reason will be provided as clear as possible.

--- a/examples/branching_error_reporting.rs
+++ b/examples/branching_error_reporting.rs
@@ -1,21 +1,21 @@
 use pubgrub::error::PubGrubError;
 use pubgrub::range::Range;
 use pubgrub::report::{DefaultStringReporter, Reporter};
-use pubgrub::solver::{OfflineSolver, Solver};
+use pubgrub::solver::{resolve, OfflineDependencyProvider};
 use pubgrub::version::SemanticVersion;
 
 // https://github.com/dart-lang/pub/blob/master/doc/solver.md#branching-error-reporting
 fn main() {
-    let mut solver = OfflineSolver::<&str, SemanticVersion>::new();
+    let mut dependency_provider = OfflineDependencyProvider::<&str, SemanticVersion>::new();
     #[rustfmt::skip]
     // root 1.0.0 depends on foo ^1.0.0
-    solver.add_dependencies(
+        dependency_provider.add_dependencies(
         "root", (1, 0, 0),
         vec![("foo", Range::between((1, 0, 0), (2, 0, 0)))],
     );
     #[rustfmt::skip]
     // foo 1.0.0 depends on a ^1.0.0 and b ^1.0.0
-    solver.add_dependencies(
+        dependency_provider.add_dependencies(
         "foo", (1, 0, 0),
         vec![
             ("a", Range::between((1, 0, 0), (2, 0, 0))),
@@ -24,7 +24,7 @@ fn main() {
     );
     #[rustfmt::skip]
     // foo 1.1.0 depends on x ^1.0.0 and y ^1.0.0
-    solver.add_dependencies(
+        dependency_provider.add_dependencies(
         "foo", (1, 1, 0),
         vec![
             ("x", Range::between((1, 0, 0), (2, 0, 0))),
@@ -33,25 +33,25 @@ fn main() {
     );
     #[rustfmt::skip]
     // a 1.0.0 depends on b ^2.0.0
-    solver.add_dependencies(
+        dependency_provider.add_dependencies(
         "a", (1, 0, 0),
         vec![("b", Range::between((2, 0, 0), (3, 0, 0)))],
     );
     // b 1.0.0 and 2.0.0 have no dependencies.
-    solver.add_dependencies("b", (1, 0, 0), vec![]);
-    solver.add_dependencies("b", (2, 0, 0), vec![]);
+    dependency_provider.add_dependencies("b", (1, 0, 0), vec![]);
+    dependency_provider.add_dependencies("b", (2, 0, 0), vec![]);
     #[rustfmt::skip]
     // x 1.0.0 depends on y ^2.0.0.
-    solver.add_dependencies(
+        dependency_provider.add_dependencies(
         "x", (1, 0, 0),
         vec![("y", Range::between((2, 0, 0), (3, 0, 0)))],
     );
     // y 1.0.0 and 2.0.0 have no dependencies.
-    solver.add_dependencies("y", (1, 0, 0), vec![]);
-    solver.add_dependencies("y", (2, 0, 0), vec![]);
+    dependency_provider.add_dependencies("y", (1, 0, 0), vec![]);
+    dependency_provider.add_dependencies("y", (2, 0, 0), vec![]);
 
-    // Run the solver.
-    match solver.run("root", (1, 0, 0)) {
+    // Run the algorithm.
+    match resolve(&dependency_provider, "root", (1, 0, 0)) {
         Ok(sol) => println!("{:?}", sol),
         Err(PubGrubError::NoSolution(mut derivation_tree)) => {
             derivation_tree.collapse_noversion();

--- a/examples/caching_dependency_provider.rs
+++ b/examples/caching_dependency_provider.rs
@@ -1,0 +1,73 @@
+use proptest::std_facade::hash_map::RandomState;
+use proptest::std_facade::HashMap;
+use pubgrub::package::Package;
+use pubgrub::range::Range;
+use pubgrub::solver::{resolve, DependencyProvider, OfflineDependencyProvider};
+use pubgrub::version::{NumberVersion, Version};
+use std::cell::RefCell;
+use std::error::Error;
+use std::hash::Hash;
+
+// An example implementing caching dependency provider that will
+// store queried dependencies in memory and check them before querying more from remote.
+struct CachingDependencyProvider<P: Package, V: Version + Hash> {
+    remote_dependencies: Box<dyn DependencyProvider<P, V>>,
+    cached_dependencies: RefCell<OfflineDependencyProvider<P, V>>,
+}
+
+impl<P: Package, V: Version + Hash> CachingDependencyProvider<P, V> {
+    pub fn new(remote_dependencies_provider: Box<dyn DependencyProvider<P, V>>) -> Self {
+        CachingDependencyProvider {
+            remote_dependencies: remote_dependencies_provider,
+            cached_dependencies: RefCell::new(OfflineDependencyProvider::new()),
+        }
+    }
+}
+
+impl<P: Package, V: Version + Hash> DependencyProvider<P, V> for CachingDependencyProvider<P, V> {
+    // Lists only from remote for simplicity
+    fn list_available_versions(&self, package: &P) -> Result<Vec<V>, Box<dyn Error>> {
+        self.remote_dependencies.list_available_versions(package)
+    }
+
+    // Caches dependencies if they were already queried
+    fn get_dependencies(
+        &self,
+        package: &P,
+        version: &V,
+    ) -> Result<Option<HashMap<P, Range<V>, RandomState>>, Box<dyn Error>> {
+        let mut cache = self.cached_dependencies.borrow_mut();
+        match cache.get_dependencies(package, version) {
+            Ok(None) => {
+                let dependencies = self.remote_dependencies.get_dependencies(package, version);
+                match dependencies {
+                    Ok(dependencies) => {
+                        cache.add_dependencies(
+                            package.clone(),
+                            version.clone(),
+                            dependencies.clone().unwrap_or_default(),
+                        );
+                        Ok(dependencies)
+                    }
+                    error @ Err(_) => error,
+                }
+            }
+            dependencies @ Ok(_) => dependencies,
+            error @ Err(_) => error,
+        }
+    }
+}
+
+fn main() {
+    // Simulating remote provider locally.
+    let mut remote_dependencies_provider = OfflineDependencyProvider::<&str, NumberVersion>::new();
+
+    // Add dependencies as needed. Here only root package is added.
+    remote_dependencies_provider.add_dependencies("root", 1, Vec::new());
+
+    let caching_dependencies_provider =
+        CachingDependencyProvider::new(Box::new(remote_dependencies_provider));
+
+    let solution = resolve(&caching_dependencies_provider, "root", 1);
+    println!("Solution: {:?}", solution);
+}

--- a/examples/doc_interface.rs
+++ b/examples/doc_interface.rs
@@ -1,5 +1,5 @@
 use pubgrub::range::Range;
-use pubgrub::solver::{OfflineSolver, Solver};
+use pubgrub::solver::{resolve, OfflineDependencyProvider};
 use pubgrub::version::NumberVersion;
 
 // `root` depends on `menu` and `icons`
@@ -8,15 +8,15 @@ use pubgrub::version::NumberVersion;
 // `icons` has no dependency
 #[rustfmt::skip]
 fn main() {
-    let mut solver = OfflineSolver::<&str, NumberVersion>::new();
-    solver.add_dependencies(
+    let mut dependency_provider = OfflineDependencyProvider::<&str, NumberVersion>::new();
+    dependency_provider.add_dependencies(
         "root", 1, vec![("menu", Range::any()), ("icons", Range::any())],
     );
-    solver.add_dependencies("menu", 1, vec![("dropdown", Range::any())]);
-    solver.add_dependencies("dropdown", 1, vec![("icons", Range::any())]);
-    solver.add_dependencies("icons", 1, vec![]);
+    dependency_provider.add_dependencies("menu", 1, vec![("dropdown", Range::any())]);
+    dependency_provider.add_dependencies("dropdown", 1, vec![("icons", Range::any())]);
+    dependency_provider.add_dependencies("icons", 1, vec![]);
 
-    // Run the solver.
-    let solution = solver.run("root", 1).unwrap();
+    // Run the algorithm.
+    let solution = resolve(&dependency_provider, "root", 1).unwrap();
     println!("Solution: {:?}", solution);
 }

--- a/examples/doc_interface.rs
+++ b/examples/doc_interface.rs
@@ -17,6 +17,6 @@ fn main() {
     dependency_provider.add_dependencies("icons", 1, vec![]);
 
     // Run the algorithm.
-    let solution = resolve(&dependency_provider, "root", 1).unwrap();
+    let solution = resolve(&dependency_provider, "root", 1);
     println!("Solution: {:?}", solution);
 }

--- a/examples/doc_interface_error.rs
+++ b/examples/doc_interface_error.rs
@@ -1,7 +1,7 @@
 use pubgrub::error::PubGrubError;
 use pubgrub::range::Range;
 use pubgrub::report::{DefaultStringReporter, Reporter};
-use pubgrub::solver::{OfflineSolver, Solver};
+use pubgrub::solver::{resolve, OfflineDependencyProvider};
 use pubgrub::version::SemanticVersion;
 
 // `root` depends on `menu`, `icons 1.0.0` and `intl 5.0.0`
@@ -13,62 +13,62 @@ use pubgrub::version::SemanticVersion;
 // `intl` has no dependency
 #[rustfmt::skip]
 fn main() {
-    let mut solver = OfflineSolver::<&str, SemanticVersion>::new();
+    let mut dependency_provider = OfflineDependencyProvider::<&str, SemanticVersion>::new();
     // Direct dependencies: menu and icons.
-    solver.add_dependencies("root", (1, 0, 0), vec![
+    dependency_provider.add_dependencies("root", (1, 0, 0), vec![
         ("menu", Range::any()),
         ("icons", Range::exact((1, 0, 0))),
         ("intl", Range::exact((5, 0, 0))),
     ]);
 
     // Dependencies of the menu lib.
-    solver.add_dependencies("menu", (1, 0, 0), vec![
+    dependency_provider.add_dependencies("menu", (1, 0, 0), vec![
         ("dropdown", Range::strictly_lower_than((2, 0, 0))),
     ]);
-    solver.add_dependencies("menu", (1, 1, 0), vec![
+    dependency_provider.add_dependencies("menu", (1, 1, 0), vec![
         ("dropdown", Range::higher_than((2, 0, 0))),
     ]);
-    solver.add_dependencies("menu", (1, 2, 0), vec![
+    dependency_provider.add_dependencies("menu", (1, 2, 0), vec![
         ("dropdown", Range::higher_than((2, 0, 0))),
     ]);
-    solver.add_dependencies("menu", (1, 3, 0), vec![
+    dependency_provider.add_dependencies("menu", (1, 3, 0), vec![
         ("dropdown", Range::higher_than((2, 0, 0))),
     ]);
-    solver.add_dependencies("menu", (1, 4, 0), vec![
+    dependency_provider.add_dependencies("menu", (1, 4, 0), vec![
         ("dropdown", Range::higher_than((2, 0, 0))),
     ]);
-    solver.add_dependencies("menu", (1, 5, 0), vec![
+    dependency_provider.add_dependencies("menu", (1, 5, 0), vec![
         ("dropdown", Range::higher_than((2, 0, 0))),
     ]);
 
     // Dependencies of the dropdown lib.
-    solver.add_dependencies("dropdown", (1, 8, 0), vec![
+    dependency_provider.add_dependencies("dropdown", (1, 8, 0), vec![
         ("intl", Range::exact((3, 0, 0))),
     ]);
-    solver.add_dependencies("dropdown", (2, 0, 0), vec![
+    dependency_provider.add_dependencies("dropdown", (2, 0, 0), vec![
         ("icons", Range::exact((2, 0, 0))),
     ]);
-    solver.add_dependencies("dropdown", (2, 1, 0), vec![
+    dependency_provider.add_dependencies("dropdown", (2, 1, 0), vec![
         ("icons", Range::exact((2, 0, 0))),
     ]);
-    solver.add_dependencies("dropdown", (2, 2, 0), vec![
+    dependency_provider.add_dependencies("dropdown", (2, 2, 0), vec![
         ("icons", Range::exact((2, 0, 0))),
     ]);
-    solver.add_dependencies("dropdown", (2, 3, 0), vec![
+    dependency_provider.add_dependencies("dropdown", (2, 3, 0), vec![
         ("icons", Range::exact((2, 0, 0))),
     ]);
 
-    // Icons has no dependency.
-    solver.add_dependencies("icons", (1, 0, 0), vec![]);
-    solver.add_dependencies("icons", (2, 0, 0), vec![]);
+    // Icons have no dependencies.
+    dependency_provider.add_dependencies("icons", (1, 0, 0), vec![]);
+    dependency_provider.add_dependencies("icons", (2, 0, 0), vec![]);
 
-    // Intl has no dpendency.
-    solver.add_dependencies("intl", (3, 0, 0), vec![]);
-    solver.add_dependencies("intl", (4, 0, 0), vec![]);
-    solver.add_dependencies("intl", (5, 0, 0), vec![]);
+    // Intl have no dependencies.
+    dependency_provider.add_dependencies("intl", (3, 0, 0), vec![]);
+    dependency_provider.add_dependencies("intl", (4, 0, 0), vec![]);
+    dependency_provider.add_dependencies("intl", (5, 0, 0), vec![]);
 
-    // Run the solver.
-    match solver.run("root", (1, 0, 0)) {
+    // Run the algorithm.
+    match resolve(&dependency_provider, "root", (1, 0, 0)) {
         Ok(sol) => println!("{:?}", sol),
         Err(PubGrubError::NoSolution(mut derivation_tree)) => {
             derivation_tree.collapse_noversion();

--- a/examples/doc_interface_semantic.rs
+++ b/examples/doc_interface_semantic.rs
@@ -1,7 +1,7 @@
 use pubgrub::error::PubGrubError;
 use pubgrub::range::Range;
 use pubgrub::report::{DefaultStringReporter, Reporter};
-use pubgrub::solver::{OfflineSolver, Solver};
+use pubgrub::solver::{resolve, OfflineDependencyProvider};
 use pubgrub::version::SemanticVersion;
 
 // `root` depends on `menu` and `icons 1.0.0`
@@ -12,54 +12,54 @@ use pubgrub::version::SemanticVersion;
 // `icons` has no dependency
 #[rustfmt::skip]
 fn main() {
-    let mut solver = OfflineSolver::<&str, SemanticVersion>::new();
+    let mut dependency_provider = OfflineDependencyProvider::<&str, SemanticVersion>::new();
     // Direct dependencies: menu and icons.
-    solver.add_dependencies("root", (1, 0, 0), vec![
+    dependency_provider.add_dependencies("root", (1, 0, 0), vec![
         ("menu", Range::any()),
         ("icons", Range::exact((1, 0, 0))),
     ]);
 
     // Dependencies of the menu lib.
-    solver.add_dependencies("menu", (1, 0, 0), vec![
+    dependency_provider.add_dependencies("menu", (1, 0, 0), vec![
         ("dropdown", Range::strictly_lower_than((2, 0, 0))),
     ]);
-    solver.add_dependencies("menu", (1, 1, 0), vec![
+    dependency_provider.add_dependencies("menu", (1, 1, 0), vec![
         ("dropdown", Range::higher_than((2, 0, 0))),
     ]);
-    solver.add_dependencies("menu", (1, 2, 0), vec![
+    dependency_provider.add_dependencies("menu", (1, 2, 0), vec![
         ("dropdown", Range::higher_than((2, 0, 0))),
     ]);
-    solver.add_dependencies("menu", (1, 3, 0), vec![
+    dependency_provider.add_dependencies("menu", (1, 3, 0), vec![
         ("dropdown", Range::higher_than((2, 0, 0))),
     ]);
-    solver.add_dependencies("menu", (1, 4, 0), vec![
+    dependency_provider.add_dependencies("menu", (1, 4, 0), vec![
         ("dropdown", Range::higher_than((2, 0, 0))),
     ]);
-    solver.add_dependencies("menu", (1, 5, 0), vec![
+    dependency_provider.add_dependencies("menu", (1, 5, 0), vec![
         ("dropdown", Range::higher_than((2, 0, 0))),
     ]);
 
     // Dependencies of the dropdown lib.
-    solver.add_dependencies("dropdown", (1, 8, 0), vec![]);
-    solver.add_dependencies("dropdown", (2, 0, 0), vec![
+    dependency_provider.add_dependencies("dropdown", (1, 8, 0), vec![]);
+    dependency_provider.add_dependencies("dropdown", (2, 0, 0), vec![
         ("icons", Range::exact((2, 0, 0))),
     ]);
-    solver.add_dependencies("dropdown", (2, 1, 0), vec![
+    dependency_provider.add_dependencies("dropdown", (2, 1, 0), vec![
         ("icons", Range::exact((2, 0, 0))),
     ]);
-    solver.add_dependencies("dropdown", (2, 2, 0), vec![
+    dependency_provider.add_dependencies("dropdown", (2, 2, 0), vec![
         ("icons", Range::exact((2, 0, 0))),
     ]);
-    solver.add_dependencies("dropdown", (2, 3, 0), vec![
+    dependency_provider.add_dependencies("dropdown", (2, 3, 0), vec![
         ("icons", Range::exact((2, 0, 0))),
     ]);
 
     // Icons has no dependency.
-    solver.add_dependencies("icons", (1, 0, 0), vec![]);
-    solver.add_dependencies("icons", (2, 0, 0), vec![]);
+    dependency_provider.add_dependencies("icons", (1, 0, 0), vec![]);
+    dependency_provider.add_dependencies("icons", (2, 0, 0), vec![]);
 
-    // Run the solver.
-    match solver.run("root", (1, 0, 0)) {
+    // Run the algorithm.
+    match resolve(&dependency_provider, "root", (1, 0, 0)) {
         Ok(sol) => println!("{:?}", sol),
         Err(PubGrubError::NoSolution(mut derivation_tree)) => {
             derivation_tree.collapse_noversion();

--- a/examples/linear_error_reporting.rs
+++ b/examples/linear_error_reporting.rs
@@ -1,15 +1,15 @@
 use pubgrub::error::PubGrubError;
 use pubgrub::range::Range;
 use pubgrub::report::{DefaultStringReporter, Reporter};
-use pubgrub::solver::{OfflineSolver, Solver};
+use pubgrub::solver::{resolve, OfflineDependencyProvider};
 use pubgrub::version::SemanticVersion;
 
 // https://github.com/dart-lang/pub/blob/master/doc/solver.md#linear-error-reporting
 fn main() {
-    let mut solver = OfflineSolver::<&str, SemanticVersion>::new();
+    let mut dependency_provider = OfflineDependencyProvider::<&str, SemanticVersion>::new();
     #[rustfmt::skip]
     // root 1.0.0 depends on foo ^1.0.0 and baz ^1.0.0
-    solver.add_dependencies(
+        dependency_provider.add_dependencies(
         "root", (1, 0, 0),
         vec![
             ("foo", Range::between((1, 0, 0), (2, 0, 0))),
@@ -18,22 +18,22 @@ fn main() {
     );
     #[rustfmt::skip]
     // foo 1.0.0 depends on bar ^2.0.0
-    solver.add_dependencies(
+        dependency_provider.add_dependencies(
         "foo", (1, 0, 0),
         vec![("bar", Range::between((2, 0, 0), (3, 0, 0)))],
     );
     #[rustfmt::skip]
     // bar 2.0.0 depends on baz ^3.0.0
-    solver.add_dependencies(
+        dependency_provider.add_dependencies(
         "bar", (2, 0, 0),
         vec![("baz", Range::between((3, 0, 0), (4, 0, 0)))],
     );
     // baz 1.0.0 and 3.0.0 have no dependencies
-    solver.add_dependencies("baz", (1, 0, 0), vec![]);
-    solver.add_dependencies("baz", (3, 0, 0), vec![]);
+    dependency_provider.add_dependencies("baz", (1, 0, 0), vec![]);
+    dependency_provider.add_dependencies("baz", (3, 0, 0), vec![]);
 
-    // Run the solver.
-    match solver.run("root", (1, 0, 0)) {
+    // Run the algorithm.
+    match resolve(&dependency_provider, "root", (1, 0, 0)) {
         Ok(sol) => println!("{:?}", sol),
         Err(PubGrubError::NoSolution(mut derivation_tree)) => {
             derivation_tree.collapse_noversion();

--- a/src/error.rs
+++ b/src/error.rs
@@ -17,17 +17,17 @@ pub enum PubGrubError<P: Package, V: Version> {
     #[error("No solution")]
     NoSolution(DerivationTree<P, V>),
 
-    /// Error arising when the implementer of `Solver`
+    /// Error arising when the implementer of [DependencyProvider](crate::solver::DependencyProvider)
     /// returned an error in the method `list_available_versions`.
     #[error("Retrieving available versions of package {package} failed)")]
     ErrorRetrievingVersions {
         /// Package for which we want the list of versions.
         package: P,
-        /// Error raised by the implementer of `Solver`.
+        /// Error raised by the implementer of [DependencyProvider](crate::solver::DependencyProvider).
         source: Box<dyn std::error::Error>,
     },
 
-    /// Error arising when the implementer of `Solver`
+    /// Error arising when the implementer of [DependencyProvider](crate::solver::DependencyProvider)
     /// returned an error in the method `get_dependencies`.
     #[error("Retrieving dependencies of {package} {version} failed)")]
     ErrorRetrievingDependencies {
@@ -35,7 +35,7 @@ pub enum PubGrubError<P: Package, V: Version> {
         package: P,
         /// Version of the package for which we want the dependencies.
         version: V,
-        /// Error raised by the implementer of `Solver`.
+        /// Error raised by the implementer of [DependencyProvider](crate::solver::DependencyProvider).
         source: Box<dyn std::error::Error>,
     },
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,7 +27,7 @@
 //! and `bump(&self) -> Self` which returns the next smallest version
 //! strictly higher than the current one.
 //! For convenience, this library already provides two implementations of `Version`.
-//! The first one is `NumberVersion`, basically a newtype for `usize`.
+//! The first one is `NumberVersion`, basically a newtype for `u32`.
 //! The second one is `SemanticVersion` that implements semantic versioning rules.
 //!
 //! # Basic example
@@ -103,11 +103,11 @@
 //! of a given package at a given version.
 //! Return `None` if dependencies are unknown.
 //!
-//! On a real scenario, these two methods may involve reading the file system
-//! or doing network request, so you may want to hold a cache in your [DependencyProvider](solver::DependencyProvider) impl.
-//! You could use the [OfflineDependencyProvider](solver::OfflineDependencyProvider) type provided by the crate as guidance,
-//! but you are free to use whatever approach
-//! makes sense in your situation.
+//! In a real scenario, these two methods may involve reading the file system
+//! or doing network request, so you may want to hold a cache in your [DependencyProvider](solver::DependencyProvider) implementation.
+//! How exactly this could be achieved is shown in `CachingDependencyProvider` (see `examples/caching_dependency_provider.rs`).
+//! You could also use the [OfflineDependencyProvider](solver::OfflineDependencyProvider) type provided by the crate as guidance,
+//! but you are free to use whatever approach makes sense in your situation.
 //!
 //! # Solution and error reporting
 //!

--- a/src/report.rs
+++ b/src/report.rs
@@ -19,7 +19,7 @@ pub trait Reporter<P: Package, V: Version> {
     type Output;
 
     /// Generate a report from the derivation tree
-    /// describing the solver failure.
+    /// describing the resolution failure.
     fn report(derivation_tree: &DerivationTree<P, V>) -> Self::Output;
 }
 
@@ -70,7 +70,7 @@ impl<P: Package, V: Version> DerivationTree<P, V> {
     /// with the other one they are matched with
     /// in a derived incompatibility.
     /// This cleans up quite nicely the generated report.
-    /// You might want to do this if you know that the solver
+    /// You might want to do this if you know that the [DependencyProvider](crate::solver::DependencyProvider)
     /// was not run in some kind of offline mode that may not
     /// have access to all versions existing.
     pub fn collapse_noversion(&mut self) {

--- a/tests/examples.rs
+++ b/tests/examples.rs
@@ -1,45 +1,45 @@
 use std::collections::HashMap;
 
 use pubgrub::range::Range;
-use pubgrub::solver::{OfflineSolver, Solver};
+use pubgrub::solver::{resolve, OfflineDependencyProvider};
 use pubgrub::version::SemanticVersion;
 
 #[test]
 /// https://github.com/dart-lang/pub/blob/master/doc/solver.md#no-conflicts
 fn no_conflict() {
-    let mut solver = OfflineSolver::<&str, SemanticVersion>::new();
+    let mut dependency_provider = OfflineDependencyProvider::<&str, SemanticVersion>::new();
     #[rustfmt::skip]
-    solver.add_dependencies(
+        dependency_provider.add_dependencies(
         "root", (1, 0, 0),
         vec![("foo", Range::between((1, 0, 0), (2, 0, 0)))],
     );
     #[rustfmt::skip]
-    solver.add_dependencies(
+        dependency_provider.add_dependencies(
         "foo", (1, 0, 0),
         vec![("bar", Range::between((1, 0, 0), (2, 0, 0)))],
     );
-    solver.add_dependencies("bar", (1, 0, 0), vec![]);
-    solver.add_dependencies("bar", (2, 0, 0), vec![]);
+    dependency_provider.add_dependencies("bar", (1, 0, 0), vec![]);
+    dependency_provider.add_dependencies("bar", (2, 0, 0), vec![]);
 
-    // Run the solver.
-    let solver_solution = solver.run("root", (1, 0, 0)).unwrap();
+    // Run the algorithm.
+    let computed_solution = resolve(&dependency_provider, "root", (1, 0, 0)).unwrap();
 
     // Solution.
-    let mut solution = HashMap::new();
-    solution.insert("root", (1, 0, 0).into());
-    solution.insert("foo", (1, 0, 0).into());
-    solution.insert("bar", (1, 0, 0).into());
+    let mut expected_solution = HashMap::new();
+    expected_solution.insert("root", (1, 0, 0).into());
+    expected_solution.insert("foo", (1, 0, 0).into());
+    expected_solution.insert("bar", (1, 0, 0).into());
 
-    // Comparing the true solution with the one computed by the solver.
-    assert_eq!(solution, solver_solution);
+    // Comparing the true solution with the one computed by the algorithm.
+    assert_eq!(expected_solution, computed_solution);
 }
 
 #[test]
 /// https://github.com/dart-lang/pub/blob/master/doc/solver.md#avoiding-conflict-during-decision-making
 fn avoiding_conflict_during_decision_making() {
-    let mut solver = OfflineSolver::<&str, SemanticVersion>::new();
+    let mut dependency_provider = OfflineDependencyProvider::<&str, SemanticVersion>::new();
     #[rustfmt::skip]
-    solver.add_dependencies(
+        dependency_provider.add_dependencies(
         "root", (1, 0, 0),
         vec![
             ("foo", Range::between((1, 0, 0), (2, 0, 0))),
@@ -47,68 +47,68 @@ fn avoiding_conflict_during_decision_making() {
         ],
     );
     #[rustfmt::skip]
-    solver.add_dependencies(
+        dependency_provider.add_dependencies(
         "foo", (1, 1, 0),
         vec![("bar", Range::between((2, 0, 0), (3, 0, 0)))],
     );
-    solver.add_dependencies("foo", (1, 0, 0), vec![]);
-    solver.add_dependencies("bar", (1, 0, 0), vec![]);
-    solver.add_dependencies("bar", (1, 1, 0), vec![]);
-    solver.add_dependencies("bar", (2, 0, 0), vec![]);
+    dependency_provider.add_dependencies("foo", (1, 0, 0), vec![]);
+    dependency_provider.add_dependencies("bar", (1, 0, 0), vec![]);
+    dependency_provider.add_dependencies("bar", (1, 1, 0), vec![]);
+    dependency_provider.add_dependencies("bar", (2, 0, 0), vec![]);
 
-    // Run the solver.
-    let solver_solution = solver.run("root", (1, 0, 0)).unwrap();
+    // Run the algorithm.
+    let computed_solution = resolve(&dependency_provider, "root", (1, 0, 0)).unwrap();
 
     // Solution.
-    let mut solution = HashMap::new();
-    solution.insert("root", (1, 0, 0).into());
-    solution.insert("foo", (1, 0, 0).into());
-    solution.insert("bar", (1, 1, 0).into());
+    let mut expected_solution = HashMap::new();
+    expected_solution.insert("root", (1, 0, 0).into());
+    expected_solution.insert("foo", (1, 0, 0).into());
+    expected_solution.insert("bar", (1, 1, 0).into());
 
-    // Comparing the true solution with the one computed by the solver.
-    assert_eq!(solution, solver_solution);
+    // Comparing the true solution with the one computed by the algorithm.
+    assert_eq!(expected_solution, computed_solution);
 }
 
 #[test]
 /// https://github.com/dart-lang/pub/blob/master/doc/solver.md#performing-conflict-resolution
 fn conflict_resolution() {
-    let mut solver = OfflineSolver::<&str, SemanticVersion>::new();
+    let mut dependency_provider = OfflineDependencyProvider::<&str, SemanticVersion>::new();
     #[rustfmt::skip]
-    solver.add_dependencies(
+        dependency_provider.add_dependencies(
         "root", (1, 0, 0),
         vec![("foo", Range::higher_than((1, 0, 0)))],
     );
     #[rustfmt::skip]
-    solver.add_dependencies(
+        dependency_provider.add_dependencies(
         "foo", (2, 0, 0),
         vec![("bar", Range::between((1, 0, 0), (2, 0, 0)))],
     );
-    solver.add_dependencies("foo", (1, 0, 0), vec![]);
+    dependency_provider.add_dependencies("foo", (1, 0, 0), vec![]);
     #[rustfmt::skip]
-    solver.add_dependencies(
+        dependency_provider.add_dependencies(
         "bar", (1, 0, 0),
         vec![("foo", Range::between((1, 0, 0), (2, 0, 0)))],
     );
 
-    // Run the solver.
-    let solver_solution = solver.run("root", (1, 0, 0)).unwrap();
+    // Run the algorithm.
+    let computed_solution = resolve(&dependency_provider, "root", (1, 0, 0)).unwrap();
 
     // Solution.
-    let mut solution = HashMap::new();
-    solution.insert("root", (1, 0, 0).into());
-    solution.insert("foo", (1, 0, 0).into());
+    let mut expected_solution = HashMap::new();
+    expected_solution.insert("root", (1, 0, 0).into());
+    expected_solution.insert("foo", (1, 0, 0).into());
 
-    // Comparing the true solution with the one computed by the solver.
-    assert_eq!(solution, solver_solution);
+    // Comparing the true solution with the one computed by the algorithm.
+    assert_eq!(expected_solution, computed_solution);
 }
 
 #[test]
 /// https://github.com/dart-lang/pub/blob/master/doc/solver.md#conflict-resolution-with-a-partial-satisfier
 fn conflict_with_partial_satisfier() {
-    let mut solver = OfflineSolver::<&str, SemanticVersion>::new();
+    let mut dependency_provider = OfflineDependencyProvider::<&str, SemanticVersion>::new();
     #[rustfmt::skip]
     // root 1.0.0 depends on foo ^1.0.0 and target ^2.0.0
-    solver.add_dependencies(
+        dependency_provider.add_dependencies(
         "root", (1, 0, 0),
         vec![
             ("foo", Range::between((1, 0, 0), (2, 0, 0))),
@@ -117,45 +117,45 @@ fn conflict_with_partial_satisfier() {
     );
     #[rustfmt::skip]
     // foo 1.1.0 depends on left ^1.0.0 and right ^1.0.0
-    solver.add_dependencies(
+        dependency_provider.add_dependencies(
         "foo", (1, 1, 0),
         vec![
             ("left", Range::between((1, 0, 0), (2, 0, 0))),
             ("right", Range::between((1, 0, 0), (2, 0, 0))),
         ],
     );
-    solver.add_dependencies("foo", (1, 0, 0), vec![]);
+    dependency_provider.add_dependencies("foo", (1, 0, 0), vec![]);
     #[rustfmt::skip]
     // left 1.0.0 depends on shared >=1.0.0
-    solver.add_dependencies(
+        dependency_provider.add_dependencies(
         "left", (1, 0, 0),
         vec![("shared", Range::higher_than((1, 0, 0)))],
     );
     #[rustfmt::skip]
     // right 1.0.0 depends on shared <2.0.0
-    solver.add_dependencies(
+        dependency_provider.add_dependencies(
         "right", (1, 0, 0),
         vec![("shared", Range::strictly_lower_than((2, 0, 0)))],
     );
-    solver.add_dependencies("shared", (2, 0, 0), vec![]);
+    dependency_provider.add_dependencies("shared", (2, 0, 0), vec![]);
     #[rustfmt::skip]
     // shared 1.0.0 depends on target ^1.0.0
-    solver.add_dependencies(
+        dependency_provider.add_dependencies(
         "shared", (1, 0, 0),
         vec![("target", Range::between((1, 0, 0), (2, 0, 0)))],
     );
-    solver.add_dependencies("target", (2, 0, 0), vec![]);
-    solver.add_dependencies("target", (1, 0, 0), vec![]);
+    dependency_provider.add_dependencies("target", (2, 0, 0), vec![]);
+    dependency_provider.add_dependencies("target", (1, 0, 0), vec![]);
 
-    // Run the solver.
-    let solver_solution = solver.run("root", (1, 0, 0)).unwrap();
+    // Run the algorithm.
+    let computed_solution = resolve(&dependency_provider, "root", (1, 0, 0)).unwrap();
 
     // Solution.
-    let mut solution = HashMap::new();
-    solution.insert("root", (1, 0, 0).into());
-    solution.insert("foo", (1, 0, 0).into());
-    solution.insert("target", (2, 0, 0).into());
+    let mut expected_solution = HashMap::new();
+    expected_solution.insert("root", (1, 0, 0).into());
+    expected_solution.insert("foo", (1, 0, 0).into());
+    expected_solution.insert("target", (2, 0, 0).into());
 
-    // Comparing the true solution with the one computed by the solver.
-    assert_eq!(solution, solver_solution);
+    // Comparing the true solution with the one computed by the algorithm.
+    assert_eq!(expected_solution, computed_solution);
 }


### PR DESCRIPTION
To prevent run() function being overridden in Solver impls
it was extracted from the Solver trait.
run() was renamed to resolve(), and Solver became DependencyProvider
as dependency fetching was separated from the algorithm execution.

Closes https://github.com/mpizenberg/pubgrub-rs/issues/11. 