### PR TITLE
feat: use SPDX licence identifier

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: MPL-2.0
+
 [package]
 name = "pubgrub"
 version = "0.1.0"

--- a/benches/large_case.rs
+++ b/benches/large_case.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MPL-2.0
+
 #![feature(test)]
 extern crate test;
 use test::Bencher;
@@ -12,7 +14,8 @@ use pubgrub::version::NumberVersion;
 /// It has not bean minimized. There are meny `add_dependencies` that have no impact on the runtime or output.
 fn large_case(b: &mut Bencher) {
     let s = std::fs::read_to_string("test-examples/large_case_u16_NumberVersion.ron").unwrap();
-    let dependency_provider: OfflineDependencyProvider<u16, NumberVersion> = ron::de::from_str(&s).unwrap();
+    let dependency_provider: OfflineDependencyProvider<u16, NumberVersion> =
+        ron::de::from_str(&s).unwrap();
 
     // bench
     b.iter(|| {

--- a/examples/branching_error_reporting.rs
+++ b/examples/branching_error_reporting.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MPL-2.0
+
 use pubgrub::error::PubGrubError;
 use pubgrub::range::Range;
 use pubgrub::report::{DefaultStringReporter, Reporter};

--- a/examples/caching_dependency_provider.rs
+++ b/examples/caching_dependency_provider.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MPL-2.0
+
 use pubgrub::package::Package;
 use pubgrub::range::Range;
 use pubgrub::solver::{resolve, DependencyProvider, OfflineDependencyProvider};

--- a/examples/doc_interface.rs
+++ b/examples/doc_interface.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MPL-2.0
+
 use pubgrub::range::Range;
 use pubgrub::solver::{resolve, OfflineDependencyProvider};
 use pubgrub::version::NumberVersion;

--- a/examples/doc_interface_error.rs
+++ b/examples/doc_interface_error.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MPL-2.0
+
 use pubgrub::error::PubGrubError;
 use pubgrub::range::Range;
 use pubgrub::report::{DefaultStringReporter, Reporter};

--- a/examples/doc_interface_semantic.rs
+++ b/examples/doc_interface_semantic.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MPL-2.0
+
 use pubgrub::error::PubGrubError;
 use pubgrub::range::Range;
 use pubgrub::report::{DefaultStringReporter, Reporter};

--- a/examples/linear_error_reporting.rs
+++ b/examples/linear_error_reporting.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MPL-2.0
+
 use pubgrub::error::PubGrubError;
 use pubgrub::range::Range;
 use pubgrub::report::{DefaultStringReporter, Reporter};

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,6 +1,4 @@
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+// SPDX-License-Identifier: MPL-2.0
 
 //! Handling pubgrub errors.
 

--- a/src/internal/assignment.rs
+++ b/src/internal/assignment.rs
@@ -1,6 +1,4 @@
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+// SPDX-License-Identifier: MPL-2.0
 
 //! Assignments are the building blocks of a PubGrub partial solution.
 //! (partial solution = the current state of the solution we are building in the algorithm).

--- a/src/internal/core.rs
+++ b/src/internal/core.rs
@@ -1,6 +1,4 @@
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+// SPDX-License-Identifier: MPL-2.0
 
 //! Core model and functions
 //! to write a functional PubGrub algorithm.

--- a/src/internal/incompatibility.rs
+++ b/src/internal/incompatibility.rs
@@ -1,6 +1,4 @@
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+// SPDX-License-Identifier: MPL-2.0
 
 //! An incompatibility is a set of terms for different packages
 //! that should never be satisfied all together.

--- a/src/internal/memory.rs
+++ b/src/internal/memory.rs
@@ -1,6 +1,4 @@
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+// SPDX-License-Identifier: MPL-2.0
 
 //! A Memory acts like a structured partial solution
 //! where terms are regrouped by package in a [Map](crate::Map).

--- a/src/internal/mod.rs
+++ b/src/internal/mod.rs
@@ -1,6 +1,4 @@
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+// SPDX-License-Identifier: MPL-2.0
 
 //! Non exposed modules.
 

--- a/src/internal/partial_solution.rs
+++ b/src/internal/partial_solution.rs
@@ -1,6 +1,4 @@
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+// SPDX-License-Identifier: MPL-2.0
 
 //! The partial solution is the current state
 //! of the solution being built by the algorithm.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,4 @@
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+// SPDX-License-Identifier: MPL-2.0
 
 //! PubGrub version solving algorithm.
 //!

--- a/src/package.rs
+++ b/src/package.rs
@@ -1,6 +1,4 @@
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+// SPDX-License-Identifier: MPL-2.0
 
 //! Trait for identifying packages.
 //! Automatically implemented for traits implementing Clone + Eq + Hash + Debug + Display.

--- a/src/range.rs
+++ b/src/range.rs
@@ -1,6 +1,4 @@
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+// SPDX-License-Identifier: MPL-2.0
 
 //! Ranges are constraints defining sets of versions.
 //!

--- a/src/report.rs
+++ b/src/report.rs
@@ -1,6 +1,4 @@
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+// SPDX-License-Identifier: MPL-2.0
 
 //! Build a report as clear as possible as to why
 //! dependency solving failed.

--- a/src/solver.rs
+++ b/src/solver.rs
@@ -1,6 +1,4 @@
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+// SPDX-License-Identifier: MPL-2.0
 
 //! PubGrub version solving algorithm.
 //!

--- a/src/term.rs
+++ b/src/term.rs
@@ -1,6 +1,4 @@
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+// SPDX-License-Identifier: MPL-2.0
 
 //! A term is the fundamental unit of operation of the PubGrub algorithm.
 //! It is a positive or negative expression regarding a set of versions.

--- a/src/type_aliases.rs
+++ b/src/type_aliases.rs
@@ -1,6 +1,4 @@
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+// SPDX-License-Identifier: MPL-2.0
 
 //! Publicly exported type aliases.
 

--- a/src/version.rs
+++ b/src/version.rs
@@ -1,6 +1,4 @@
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+// SPDX-License-Identifier: MPL-2.0
 
 //! Traits and implementations to create and compare versions.
 

--- a/tests/examples.rs
+++ b/tests/examples.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MPL-2.0
+
 use pubgrub::range::Range;
 use pubgrub::solver::{resolve, OfflineDependencyProvider};
 use pubgrub::type_aliases::Map;

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1,6 +1,4 @@
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+// SPDX-License-Identifier: MPL-2.0
 
 use pubgrub::range::Range;
 use pubgrub::solver::{resolve, OfflineDependencyProvider};


### PR DESCRIPTION
Replaces standard Mozilla header and adds an identifier to files that were missing one.

Closes #24 