### PR TITLE
Proptest index

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -43,6 +43,11 @@ pub enum PubGrubError<P: Package, V: Version> {
         source: Box<dyn std::error::Error>,
     },
 
+    /// Error arising when the implementer of [DependencyProvider](crate::solver::DependencyProvider)
+    /// returned an error in the method `callback`.
+    #[error("callback failed)")]
+    ErrorCallback(Box<dyn std::error::Error>),
+
     /// Something unexpected happened.
     #[error("{0}")]
     Failure(String),

--- a/src/error.rs
+++ b/src/error.rs
@@ -19,7 +19,7 @@ pub enum PubGrubError<P: Package, V: Version> {
     /// [DependencyProvider](crate::solver::DependencyProvider)
     /// returned an error in the method
     /// [list_available_versions](crate::solver::DependencyProvider::list_available_versions).
-    #[error("Retrieving available versions of package {package} failed)")]
+    #[error("Retrieving available versions of package {package} failed")]
     ErrorRetrievingVersions {
         /// Package for which we want the list of versions.
         package: P,
@@ -32,7 +32,7 @@ pub enum PubGrubError<P: Package, V: Version> {
     /// [DependencyProvider](crate::solver::DependencyProvider)
     /// returned an error in the method
     /// [get_dependencies](crate::solver::DependencyProvider::get_dependencies).
-    #[error("Retrieving dependencies of {package} {version} failed)")]
+    #[error("Retrieving dependencies of {package} {version} failed")]
     ErrorRetrievingDependencies {
         /// Package whose dependencies we want.
         package: P,
@@ -44,9 +44,9 @@ pub enum PubGrubError<P: Package, V: Version> {
     },
 
     /// Error arising when the implementer of [DependencyProvider](crate::solver::DependencyProvider)
-    /// returned an error in the method [callback](crate::solver::DependencyProvider::callback).
-    #[error("callback failed)")]
-    ErrorCallback(Box<dyn std::error::Error>),
+    /// returned an error in the method [should_cancel](crate::solver::DependencyProvider::should_cancel).
+    #[error("We should cancel")]
+    ErrorShouldCancel(Box<dyn std::error::Error>),
 
     /// Something unexpected happened.
     #[error("{0}")]

--- a/src/error.rs
+++ b/src/error.rs
@@ -44,7 +44,7 @@ pub enum PubGrubError<P: Package, V: Version> {
     },
 
     /// Error arising when the implementer of [DependencyProvider](crate::solver::DependencyProvider)
-    /// returned an error in the method `callback`.
+    /// returned an error in the method [callback](crate::solver::DependencyProvider::callback).
     #[error("callback failed)")]
     ErrorCallback(Box<dyn std::error::Error>),
 

--- a/src/solver.rs
+++ b/src/solver.rs
@@ -92,6 +92,7 @@ pub fn resolve<P: Package, V: Version>(
         dependency_provider
             .callback()
             .map_err(|err| PubGrubError::ErrorCallback(err))?;
+
         state.unit_propagation(next)?;
 
         // Pick the next package.

--- a/src/solver.rs
+++ b/src/solver.rs
@@ -226,6 +226,11 @@ impl<P: Package, V: Version + Hash> OfflineDependencyProvider<P, V> {
             .or_default() = package_deps;
     }
 
+    /// Lists packages that have bean saved.
+    pub fn packages(&self) -> impl Iterator<Item=&P> {
+        self.dependencies.keys()
+    }
+
     /// Lists versions of saved packages.
     /// Returns [None] if no information is available regarding that package.
     fn versions(&self, package: &P) -> Option<Set<V>> {

--- a/src/solver.rs
+++ b/src/solver.rs
@@ -90,8 +90,8 @@ pub fn resolve<P: Package, V: Version>(
     let mut next = package;
     loop {
         dependency_provider
-            .callback()
-            .map_err(|err| PubGrubError::ErrorCallback(err))?;
+            .should_cancel()
+            .map_err(|err| PubGrubError::ErrorShouldCancel(err))?;
 
         state.unit_propagation(next)?;
 
@@ -192,7 +192,7 @@ pub trait DependencyProvider<P: Package, V: Version> {
     /// This is helpful if you want to add some form of early termination like a timeout,
     /// or you want to add some form of user feedback if things are taking a while.
     /// If not provided the resolver will run as long as needed.
-    fn callback(&self) -> Result<(), Box<dyn Error>> {
+    fn should_cancel(&self) -> Result<(), Box<dyn Error>> {
         Ok(())
     }
 }

--- a/tests/proptest.rs
+++ b/tests/proptest.rs
@@ -1,6 +1,4 @@
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+// SPDX-License-Identifier: MPL-2.0
 
 use std::{collections::BTreeSet as Set, error::Error};
 

--- a/tests/proptest.rs
+++ b/tests/proptest.rs
@@ -66,7 +66,7 @@ impl<P: Package, V: Version, DP: DependencyProvider<P, V>> DependencyProvider<P,
         self.dp.get_dependencies(p, v)
     }
 
-    fn callback(&self) -> Result<(), Box<dyn Error>> {
+    fn should_cancel(&self) -> Result<(), Box<dyn Error>> {
         assert!(self.start_time.elapsed().as_secs() < 60);
         let calls = self.call_count.get();
         assert!(calls < self.max_calls);
@@ -77,7 +77,7 @@ impl<P: Package, V: Version, DP: DependencyProvider<P, V>> DependencyProvider<P,
 
 #[test]
 #[should_panic]
-fn callback_can_panic() {
+fn should_cancel_can_panic() {
     let mut dependency_provider = OfflineDependencyProvider::<_, NumberVersion>::new();
     dependency_provider.add_dependencies(0, 0, vec![(666, Range::any())]);
 

--- a/tests/proptest.rs
+++ b/tests/proptest.rs
@@ -18,10 +18,10 @@ use proptest::string::string_regex;
 /// The same as DP but takes versions from the opposite end:
 /// if DP returns versions from newest to oldest, this returns them from oldest to newest.
 #[derive(Clone)]
-struct ReversedDependencyProvider<DP>(DP);
+struct ReverseDependencyProvider<DP>(DP);
 
 impl<P: Package, V: Version, DP: DependencyProvider<P, V>> DependencyProvider<P, V>
-    for ReversedDependencyProvider<DP>
+    for ReverseDependencyProvider<DP>
 {
     fn list_available_versions(&self, p: &P) -> Result<Vec<V>, Box<dyn Error>> {
         self.0.list_available_versions(p).map(|mut v| {
@@ -324,10 +324,10 @@ proptest! {
     fn prop_reversed_version_errors_the_same(
         (dependency_provider, cases) in registry_strategy(0u16..665, 666)
     )  {
-        let reversed_provider = ReversedDependencyProvider(dependency_provider.clone());
+        let reverse_provider = ReverseDependencyProvider(dependency_provider.clone());
         for (name, ver) in cases {
             let l = resolve(&TimeoutDependencyProvider::new(dependency_provider.clone(), 50_000), name, ver);
-            let r = resolve(&TimeoutDependencyProvider::new(reversed_provider.clone(), 50_000), name, ver);
+            let r = resolve(&TimeoutDependencyProvider::new(reverse_provider.clone(), 50_000), name, ver);
             match (&l, &r) {
                 (Ok(_), Ok(_)) => (),
                 (Err(_), Err(_)) => (),

--- a/tests/proptest.rs
+++ b/tests/proptest.rs
@@ -1,0 +1,138 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+use pubgrub::range::Range;
+use pubgrub::version::NumberVersion;
+
+use proptest::collection::{btree_map, vec};
+use proptest::prelude::*;
+use proptest::sample::Index;
+use proptest::string::string_regex;
+
+/// This generates a random registry index.
+/// Unlike vec((Name, Ver, vec((Name, VerRq), ..), ..)
+/// This strategy has a high probability of having valid dependencies
+pub fn registry_strategy(
+    max_crates: usize,
+    max_versions: usize,
+    shrinkage: usize,
+) -> impl Strategy<
+    Value = Vec<(
+        String,
+        NumberVersion,
+        Vec<(String, pubgrub::range::Range<NumberVersion>)>,
+    )>,
+> {
+    let name = string_regex("[A-Za-z][A-Za-z0-9_-]{0,5}")
+        .unwrap()
+        .prop_filter("reseved names", |n| {
+            // root is the name of the thing being compiled
+            // so it would be confusing to have it in the index
+            // bad is a name reserved for a dep that won't work
+            n != "root" && n != "bad"
+        });
+
+    // If this is false than the crate will depend on the nonexistent "bad"
+    // instead of the complex set we generated for it.
+    let allow_deps = prop::bool::weighted(0.99);
+
+    let a_version = ..(max_versions as u32);
+
+    let list_of_versions = btree_map(a_version, allow_deps, 1..=max_versions)
+        .prop_map(move |ver| ver.into_iter().collect::<Vec<_>>());
+
+    let list_of_crates_with_versions = btree_map(name, list_of_versions, 1..=max_crates);
+
+    // each version of each crate can depend on each crate smaller then it.
+    // In theory shrinkage should be 2, but in practice we get better trees with a larger value.
+    let max_deps = max_versions * (max_crates * (max_crates - 1)) / shrinkage;
+
+    let raw_version_range = (any::<Index>(), any::<Index>());
+    let raw_dependency = (any::<Index>(), any::<Index>(), raw_version_range);
+
+    fn order_index(a: Index, b: Index, size: usize) -> (usize, usize) {
+        use std::cmp::{max, min};
+        let (a, b) = (a.index(size), b.index(size));
+        (min(a, b), max(a, b))
+    }
+
+    let list_of_raw_dependency = vec(raw_dependency, ..=max_deps);
+
+    // By default a package depends only on other packages that have a smaller name,
+    // this helps make sure that all things in the resulting index are DAGs.
+    // If this is true then the DAG is maintained with grater instead.
+    let reverse_alphabetical = any::<bool>().no_shrink();
+
+    (
+        list_of_crates_with_versions,
+        list_of_raw_dependency,
+        reverse_alphabetical,
+    )
+        .prop_map(
+            move |(crate_vers_by_name, raw_dependencies, reverse_alphabetical)| {
+                let list_of_pkgid: Vec<((String, NumberVersion), bool)> = crate_vers_by_name
+                    .iter()
+                    .flat_map(|(name, vers)| {
+                        vers.iter()
+                            .map(move |x| ((name.clone(), NumberVersion::from(x.0)), x.1))
+                    })
+                    .collect();
+                let len_all_pkgid = list_of_pkgid.len();
+                let mut dependency_by_pkgid: Vec<Vec<(String, Range<NumberVersion>)>> =
+                    vec![vec![]; len_all_pkgid];
+                for (a, b, (c, d)) in raw_dependencies {
+                    let (a, b) = order_index(a, b, len_all_pkgid);
+                    let (a, b) = if reverse_alphabetical { (b, a) } else { (a, b) };
+                    let ((dep_name, _), _) = &list_of_pkgid[a];
+                    if &(list_of_pkgid[b].0).0 == dep_name {
+                        continue;
+                    }
+                    let s = &crate_vers_by_name[dep_name];
+                    let s_last_index = s.len() - 1;
+                    let (c, d) = order_index(c, d, s.len());
+
+                    dependency_by_pkgid[b].push((
+                        dep_name.to_owned(),
+                        if c == 0 && d == s_last_index {
+                            Range::any()
+                        } else if c == 0 {
+                            Range::strictly_lower_than(s[d].0 + 1)
+                        } else if d == s_last_index {
+                            Range::higher_than(s[c].0)
+                        } else if c == d {
+                            Range::exact(s[c].0)
+                        } else {
+                            Range::between(s[c].0, s[d].0 + 1)
+                        },
+                    ))
+                }
+
+                let mut out: Vec<_> = list_of_pkgid
+                    .into_iter()
+                    .zip(dependency_by_pkgid.into_iter())
+                    .map(|(((name, ver), allow_deps), deps)| {
+                        (
+                            name,
+                            ver,
+                            if !allow_deps {
+                                vec![("bad".to_owned(), Range::any())]
+                            } else {
+                                let mut deps = deps;
+                                deps.sort_by_key(|(ref d, _)| d.clone());
+                                deps.dedup_by_key(|(ref d, _)| d.clone());
+                                deps
+                            },
+                        )
+                    })
+                    .collect();
+
+                if reverse_alphabetical {
+                    // make sure the complicated cases are at the end
+                    out.reverse();
+                }
+
+                out
+            },
+        )
+}

--- a/tests/proptest.rs
+++ b/tests/proptest.rs
@@ -218,6 +218,14 @@ fn meta_test_deep_trees_from_strategy() {
 
 proptest! {
     #![proptest_config(ProptestConfig {
+    max_shrink_iters:
+        if std::env::var("CI").is_ok() {
+            // This attempts to make sure that CI will fail fast,
+            0
+        } else {
+            // but that local builds will give a small clear test case.
+            2048 // u32::MAX
+        },
         result_cache: prop::test_runner::basic_result_cache,
         .. ProptestConfig::default()
     })]


### PR DESCRIPTION
This is mostly porting proptests from Cargo. It is mostly ready for a first PR. 

Things that have been intentionally left for a follow up:
- The good tooling around reporting the part of the `dependency_provider` that was used.
- The validation that a `Ok(_)` output has all its dependencies satisfied.
- The  validation that a `Err(_)` output happens when an SAT solver also can't find a solution.

This is going to be unpleasant unless we:
- ~~Impl a time out. So inputs that leave us in an infinite loop (or effectively infinite) just come out as a panic.~~ CC [discussion on zulip](https://rust-lang.zulipchat.com/#narrow/stream/260232-t-cargo.2FPubGrub/topic/How.20to.20add.20a.20timeout.3F)
- ~~Some way to make sure the slow job of shrinking does not happen on CI. (not hard but I need to do it.)~~

Just wanted to share for others to take a look.