### PR TITLE
perf: choose package with fewest versions matching (30x speedup)

### DIFF
--- a/benches/large_case.rs
+++ b/benches/large_case.rs
@@ -8,8 +8,6 @@ use pubgrub::version::NumberVersion;
 #[cfg(feature = "serde")]
 #[bench]
 /// This is an entirely synthetic benchmark. It may not be realistic.
-/// It is too slow to be useful in the long term. But hopefully that can be fixed by making [resolve](crate::solver::resolve) faster.
-/// It has not bean minimized. There are many [add_dependencies](crate::solver::DependencyProvider::add_dependencies) that have no impact on the runtime or output.
 fn large_case(b: &mut Bencher) {
     let s = std::fs::read_to_string("test-examples/large_case_u16_NumberVersion.ron").unwrap();
     let dependency_provider: OfflineDependencyProvider<u16, NumberVersion> =

--- a/src/internal/incompatibility.rs
+++ b/src/internal/incompatibility.rs
@@ -262,7 +262,7 @@ impl<P: Package, V: Version> Incompatibility<P, V> {
             false
         } else {
             let (package, term) = self.package_terms.iter().next().unwrap();
-            (package == root_package) && term.accept_version(&root_version)
+            (package == root_package) && term.contains(&root_version)
         }
     }
 

--- a/src/internal/partial_solution.rs
+++ b/src/internal/partial_solution.rs
@@ -100,13 +100,10 @@ impl<P: Package, V: Version> PartialSolution<P, V> {
     /// This should be a package with a positive derivation but no decision yet.
     /// If multiple choices are possible, use a heuristic.
     ///
-    /// We and Pub chooses the package with the fewest versions
-    /// matching the outstanding constraint.
+    /// Current heuristic employed by this and Pub's implementations is to choose
+    /// the package with the fewest versions matching the outstanding constraint.
     /// This tends to find conflicts earlier if any exist,
     /// since these packages will run out of versions to try more quickly.
-    /// But there's likely room for improvement in these heuristics.
-    ///
-    /// TODO: improve? (do not introduce any side effect if trying to improve)
     pub fn pick_package(
         &self,
         dependency_provider: &impl DependencyProvider<P, V>,

--- a/src/solver.rs
+++ b/src/solver.rs
@@ -93,7 +93,7 @@ pub fn resolve<P: Package, V: Version>(
         state.unit_propagation(next)?;
 
         // Pick the next package.
-        let (p, term) = match state.partial_solution.pick_package() {
+        let (p, term) = match state.partial_solution.pick_package(dependency_provider)? {
             None => {
                 return state
                     .partial_solution

--- a/src/term.rs
+++ b/src/term.rs
@@ -63,7 +63,7 @@ impl<V: Version> Term<V> {
     }
 
     /// Evaluate a term regarding a given choice of version.
-    pub(crate) fn accept_version(&self, v: &V) -> bool {
+    pub(crate) fn contains(&self, v: &V) -> bool {
         match self {
             Self::Positive(range) => range.contains(v),
             Self::Negative(range) => !(range.contains(v)),


### PR DESCRIPTION
This adds the heuristic that is described in the comment. This is the heuristic asked for in #20, but there may be even better ones to try. Unfortunately, it is hard to tell with the existing benchmark as even this makes the benchmark fly. For me the benchmark 0.175 sec -> 0.006 sec!