### PR TITLE
ci: enforce project conventions

### DIFF
--- a/.commitlintrc.yml
+++ b/.commitlintrc.yml
@@ -1,0 +1,5 @@
+extends:
+  - '@commitlint/config-angular'
+
+rules:
+  body-max-line-length: [2, 'always', 72]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,3 +82,16 @@ jobs:
         env:
           RUSTDOCFLAGS: -D warnings
         run: cargo +nightly doc --no-deps --document-private-items
+
+  check_commit_conventions:
+    name: Check commit conventions
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Check commit conventions
+        uses: wagoid/commitlint-github-action@v2
+        with:
+          configFile: .commitlintrc.yml
+          failOnWarnings: true


### PR DESCRIPTION
Check that commit messages follow [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) specification.

It's still possible to make a mistake when accepting future PRs and changing a title during squash merge, but I don't know how to prevent that.
There is such thing as precommit hooks, but could they be set up for the Github? Needs investigating.