### PR TITLE
refactor!: define Dependencies type

### DIFF
--- a/examples/caching_dependency_provider.rs
+++ b/examples/caching_dependency_provider.rs
@@ -42,7 +42,7 @@ impl<P: Package, V: Version + Hash, DP: DependencyProvider<P, V>> DependencyProv
     ) -> Result<Dependencies<P, V>, Box<dyn Error>> {
         let mut cache = self.cached_dependencies.borrow_mut();
         match cache.get_dependencies(package, version) {
-            Ok(Dependencies::Unavailable) => {
+            Ok(Dependencies::Unknown) => {
                 let dependencies = self.remote_dependencies.get_dependencies(package, version);
                 match dependencies {
                     Ok(Dependencies::Known(dependencies)) => {
@@ -53,7 +53,7 @@ impl<P: Package, V: Version + Hash, DP: DependencyProvider<P, V>> DependencyProv
                         );
                         Ok(Dependencies::Known(dependencies))
                     }
-                    Ok(Dependencies::Unavailable) => Ok(Dependencies::Unavailable),
+                    Ok(Dependencies::Unknown) => Ok(Dependencies::Unknown),
                     error @ Err(_) => error,
                 }
             }

--- a/src/internal/core.rs
+++ b/src/internal/core.rs
@@ -61,7 +61,7 @@ impl<P: Package, V: Version> State<P, V> {
     }
 
     /// Unit propagation is the core mechanism of the solving algorithm.
-    /// CF https://github.com/dart-lang/pub/blob/master/doc/solver.md#unit-propagation
+    /// CF <https://github.com/dart-lang/pub/blob/master/doc/solver.md#unit-propagation>
     pub fn unit_propagation(&mut self, package: P) -> Result<(), PubGrubError<P, V>> {
         let mut current_package = package.clone();
         let mut changed = vec![package];
@@ -111,7 +111,7 @@ impl<P: Package, V: Version> State<P, V> {
     }
 
     /// Return the root cause and the backtracked model.
-    /// CF https://github.com/dart-lang/pub/blob/master/doc/solver.md#unit-propagation
+    /// CF <https://github.com/dart-lang/pub/blob/master/doc/solver.md#unit-propagation>
     fn conflict_resolution(
         &mut self,
         incompatibility: &Incompatibility<P, V>,

--- a/src/internal/incompatibility.rs
+++ b/src/internal/incompatibility.rs
@@ -9,7 +9,7 @@ use std::fmt;
 use crate::package::Package;
 use crate::range::Range;
 use crate::report::{DefaultStringReporter, DerivationTree, Derived, External};
-use crate::solver::AllowedVersions;
+use crate::solver::DependencyConstraints;
 use crate::term::{self, Term};
 use crate::type_aliases::Map;
 use crate::version::Version;
@@ -113,7 +113,7 @@ impl<P: Package, V: Version> Incompatibility<P, V> {
         start_id: usize,
         package: P,
         version: V,
-        deps: &AllowedVersions<P, V>,
+        deps: &DependencyConstraints<P, V>,
     ) -> Vec<Self> {
         deps.iter()
             .enumerate()

--- a/src/internal/incompatibility.rs
+++ b/src/internal/incompatibility.rs
@@ -9,6 +9,7 @@ use std::fmt;
 use crate::package::Package;
 use crate::range::Range;
 use crate::report::{DefaultStringReporter, DerivationTree, Derived, External};
+use crate::solver::AllowedVersions;
 use crate::term::{self, Term};
 use crate::type_aliases::Map;
 use crate::version::Version;
@@ -112,7 +113,7 @@ impl<P: Package, V: Version> Incompatibility<P, V> {
         start_id: usize,
         package: P,
         version: V,
-        deps: &Map<P, Range<V>>,
+        deps: &AllowedVersions<P, V>,
     ) -> Vec<Self> {
         deps.iter()
             .enumerate()

--- a/src/internal/memory.rs
+++ b/src/internal/memory.rs
@@ -6,7 +6,7 @@
 use crate::internal::assignment::Assignment::{self, Decision, Derivation};
 use crate::package::Package;
 use crate::term::Term;
-use crate::type_aliases::Map;
+use crate::type_aliases::{Map, SelectedDependencies};
 use crate::version::Version;
 
 /// A memory is the set of all assignments in the partial solution,
@@ -91,7 +91,7 @@ impl<P: Package, V: Version> Memory<P, V> {
     /// If a partial solution has, for every positive derivation,
     /// a corresponding decision that satisfies that assignment,
     /// it's a total solution and version solving has succeeded.
-    pub fn extract_solution(&self) -> Option<Map<P, V>> {
+    pub fn extract_solution(&self) -> Option<SelectedDependencies<P, V>> {
         if self.assignments.values().all(|pa| pa.is_valid()) {
             Some(
                 self.assignments

--- a/src/internal/partial_solution.rs
+++ b/src/internal/partial_solution.rs
@@ -6,7 +6,7 @@
 use crate::internal::memory::Memory;
 use crate::package::Package;
 use crate::term::Term;
-use crate::type_aliases::Map;
+use crate::type_aliases::{Map, SelectedDependencies};
 use crate::version::Version;
 use crate::{
     error::PubGrubError,
@@ -67,7 +67,7 @@ impl<P: Package, V: Version> PartialSolution<P, V> {
     /// If a partial solution has, for every positive derivation,
     /// a corresponding decision that satisfies that assignment,
     /// it's a total solution and version solving has succeeded.
-    pub fn extract_solution(&self) -> Option<Map<P, V>> {
+    pub fn extract_solution(&self) -> Option<SelectedDependencies<P, V>> {
         self.memory.extract_solution()
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,11 +75,9 @@
 //! and [SemanticVersion](version::SemanticVersion) for versions.
 //! This may be done quite easily by implementing the two following functions.
 //! ```
-//! # use pubgrub::solver::DependencyProvider;
+//! # use pubgrub::solver::{DependencyProvider, Dependencies};
 //! # use pubgrub::version::SemanticVersion;
 //! # use std::error::Error;
-//! # use pubgrub::range::Range;
-//! # use pubgrub::type_aliases::Map;
 //! #
 //! # struct MyDependencyProvider;
 //! #
@@ -95,7 +93,7 @@
 //!         &self,
 //!         package: &String,
 //!         version: &SemanticVersion,
-//!     ) -> Result<Option<Map<String, Range<SemanticVersion>>>, Box<dyn Error>> {
+//!     ) -> Result<Dependencies<String, SemanticVersion>, Box<dyn Error>> {
 //!         unimplemented!()
 //!     }
 //! }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -119,7 +119,8 @@
 //!
 //! When everything goes well, the algorithm finds and returns the complete
 //! set of direct and indirect dependencies satisfying all the constraints.
-//! The packages and versions selected are returned in a [Map<P, V>](type_aliases::Map).
+//! The packages and versions selected are returned as
+//! [SelectedDepedencies<P, V>](type_aliases::SelectedDependencies).
 //! But sometimes there is no solution because dependencies are incompatible.
 //! In such cases, [resolve(...)](solver::resolve) returns a
 //! [PubGrubError::NoSolution(derivation_tree)](error::PubGrubError::NoSolution),

--- a/src/solver.rs
+++ b/src/solver.rs
@@ -305,8 +305,7 @@ impl<P: Package, V: Version + Hash> OfflineDependencyProvider<P, V> {
     }
 
     /// Lists dependencies of a given package and version.
-    /// Returns [Dependencies::Unknown] if no information is available
-    /// regarding that package and version pair.
+    /// Returns [None] if no information is available regarding that package and version pair.
     fn dependencies(&self, package: &P, version: &V) -> Option<DependencyConstraints<P, V>> {
         self.dependencies
             .get(package)?

--- a/src/solver.rs
+++ b/src/solver.rs
@@ -76,7 +76,7 @@ use crate::internal::incompatibility::Incompatibility;
 use crate::internal::partial_solution::PartialSolution;
 use crate::package::Package;
 use crate::range::Range;
-use crate::type_aliases::Map;
+use crate::type_aliases::{Map, SelectedDependencies};
 use crate::version::Version;
 
 /// Main function of the library.
@@ -85,7 +85,7 @@ pub fn resolve<P: Package, V: Version>(
     dependency_provider: &impl DependencyProvider<P, V>,
     package: P,
     version: impl Into<V>,
-) -> Result<Map<P, V>, PubGrubError<P, V>> {
+) -> Result<SelectedDependencies<P, V>, PubGrubError<P, V>> {
     let mut state = State::init(package.clone(), version.into());
     let mut added_dependencies: Map<P, Set<V>> = Map::default();
     let mut next = package;

--- a/src/solver.rs
+++ b/src/solver.rs
@@ -135,7 +135,7 @@ pub fn resolve<P: Package, V: Version>(
                 version: v.clone(),
                 source: err,
             })? {
-            Dependencies::Unavailable => {
+            Dependencies::Unknown => {
                 state.add_incompatibility(|id| {
                     Incompatibility::unavailable_dependencies(id, p.clone(), v.clone())
                 });
@@ -176,15 +176,15 @@ pub fn resolve<P: Package, V: Version>(
 #[derive(Clone)]
 pub enum Dependencies<P: Package, V: Version> {
     /// Package dependencies are unavailable.
-    Unavailable,
+    Unknown,
     /// Container for all available package versions.
-    Known(AllowedVersions<P, V>),
+    Known(DependencyConstraints<P, V>),
 }
 
 /// Subtype of [Dependencies] which holds information about
 /// all possible versions a given package can accept.
 /// There is a difference in semantics between an empty [Map<P, Range<V>>](crate::type_aliases::Map)
-/// inside [AllowedVersions] and [Dependencies::Unavailable]:
+/// inside [DependencyConstraints] and [Dependencies::Unknown]:
 /// the former means the package has no dependencies and it is a known fact,
 /// while the latter means they could not be fetched by [DependencyProvider].
 #[derive(Debug, Clone)]
@@ -193,22 +193,22 @@ pub enum Dependencies<P: Package, V: Version> {
     derive(serde::Serialize, serde::Deserialize),
     serde(transparent)
 )]
-pub struct AllowedVersions<P: Package, V: Version>(Map<P, Range<V>>);
+pub struct DependencyConstraints<P: Package, V: Version>(Map<P, Range<V>>);
 
-impl<P: Package, V: Version> Default for AllowedVersions<P, V> {
+impl<P: Package, V: Version> Default for DependencyConstraints<P, V> {
     fn default() -> Self {
-        AllowedVersions(Map::default())
+        DependencyConstraints(Map::default())
     }
 }
 
-impl<P: Package, V: Version> AllowedVersions<P, V> {
+impl<P: Package, V: Version> DependencyConstraints<P, V> {
     /// An iterator over inner values of [Map<P, Range<V>>](crate::type_aliases::Map)
     pub fn iter(&self) -> impl Iterator<Item = (&P, &Range<V>)> {
         self.0.iter()
     }
 }
 
-impl<P: Package, V: Version> IntoIterator for AllowedVersions<P, V> {
+impl<P: Package, V: Version> IntoIterator for DependencyConstraints<P, V> {
     type Item = (P, Range<V>);
     type IntoIter = std::collections::hash_map::IntoIter<P, Range<V>>;
 
@@ -217,9 +217,9 @@ impl<P: Package, V: Version> IntoIterator for AllowedVersions<P, V> {
     }
 }
 
-impl<P: Package, V: Version> FromIterator<(P, Range<V>)> for AllowedVersions<P, V> {
+impl<P: Package, V: Version> FromIterator<(P, Range<V>)> for DependencyConstraints<P, V> {
     fn from_iter<T: IntoIterator<Item = (P, Range<V>)>>(iter: T) -> Self {
-        AllowedVersions(iter.into_iter().collect())
+        DependencyConstraints(iter.into_iter().collect())
     }
 }
 
@@ -232,7 +232,7 @@ pub trait DependencyProvider<P: Package, V: Version> {
     fn list_available_versions(&self, package: &P) -> Result<Vec<V>, Box<dyn Error>>;
 
     /// Retrieves the package dependencies.
-    /// Return [Dependencies::Unavailable] if its dependencies are unknown.
+    /// Return [Dependencies::Unknown] if its dependencies are unknown.
     fn get_dependencies(
         &self,
         package: &P,
@@ -254,7 +254,7 @@ pub trait DependencyProvider<P: Package, V: Version> {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(transparent))]
 pub struct OfflineDependencyProvider<P: Package, V: Version + Hash> {
-    dependencies: Map<P, Map<V, AllowedVersions<P, V>>>,
+    dependencies: Map<P, Map<V, DependencyConstraints<P, V>>>,
 }
 
 impl<P: Package, V: Version + Hash> OfflineDependencyProvider<P, V> {
@@ -305,9 +305,9 @@ impl<P: Package, V: Version + Hash> OfflineDependencyProvider<P, V> {
     }
 
     /// Lists dependencies of a given package and version.
-    /// Returns [Dependencies::Unavailable] if no information is available
+    /// Returns [Dependencies::Unknown] if no information is available
     /// regarding that package and version pair.
-    fn dependencies(&self, package: &P, version: &V) -> Option<AllowedVersions<P, V>> {
+    fn dependencies(&self, package: &P, version: &V) -> Option<DependencyConstraints<P, V>> {
         self.dependencies
             .get(package)?
             .get(version)
@@ -332,7 +332,7 @@ impl<P: Package, V: Version + Hash> DependencyProvider<P, V> for OfflineDependen
         version: &V,
     ) -> Result<Dependencies<P, V>, Box<dyn Error>> {
         Ok(match self.dependencies(package, version) {
-            None => Dependencies::Unavailable,
+            None => Dependencies::Unknown,
             Some(dependencies) => Dependencies::Known(dependencies),
         })
     }

--- a/src/type_aliases.rs
+++ b/src/type_aliases.rs
@@ -4,3 +4,7 @@
 
 /// Map implementation used by the library.
 pub type Map<K, V> = rustc_hash::FxHashMap<K, V>;
+
+/// Concrete dependencies picked by the library during [resolve](crate::solver::resolve)
+/// from [DependencyConstraints](crate::solver::DependencyConstraints)
+pub type SelectedDependencies<P, V> = Map<P, V>;

--- a/tests/proptest.rs
+++ b/tests/proptest.rs
@@ -370,7 +370,7 @@ proptest! {
                 .get_dependencies(package, version)
                 .unwrap()
             {
-                Dependencies::Unavailable => panic!(),
+                Dependencies::Unknown => panic!(),
                 Dependencies::Known(d) => d.into_iter().collect(),
             };
             if !dependencies.is_empty() {
@@ -432,7 +432,7 @@ proptest! {
                            || to_remove.get(&(n, v)).is_none() // or it is not one to be removed
                         {
                             let deps = match dependency_provider.get_dependencies(&n, &v).unwrap() {
-                                Dependencies::Unavailable => panic!(),
+                                Dependencies::Unknown => panic!(),
                                 Dependencies::Known(deps) => deps,
                             };
                             smaller_dependency_provider.add_dependencies(n, v, deps)
@@ -454,7 +454,7 @@ proptest! {
                         if to_remove.get(&(n, v)).is_none() // it is not one to be removed
                         {
                             let deps = match dependency_provider.get_dependencies(&n, &v).unwrap() {
-                                Dependencies::Unavailable => panic!(),
+                                Dependencies::Unknown => panic!(),
                                 Dependencies::Known(deps) => deps,
                             };
                             smaller_dependency_provider.add_dependencies(n, v, deps)

--- a/tests/sat_dependency_provider.rs
+++ b/tests/sat_dependency_provider.rs
@@ -77,7 +77,7 @@ impl<P: Package, V: Version + Hash> SatResolve<P, V> {
         // active packages need each of there `deps` to be satisfied
         for (p, v, var) in &all_versions {
             let deps = match dp.get_dependencies(p, v).unwrap() {
-                Dependencies::Unavailable => panic!(),
+                Dependencies::Unknown => panic!(),
                 Dependencies::Known(d) => d,
             };
             for (p1, range) in deps.iter() {

--- a/tests/sat_dependency_provider.rs
+++ b/tests/sat_dependency_provider.rs
@@ -2,7 +2,7 @@
 
 use pubgrub::package::Package;
 use pubgrub::solver::{Dependencies, DependencyProvider, OfflineDependencyProvider};
-use pubgrub::type_aliases::Map;
+use pubgrub::type_aliases::{Map, SelectedDependencies};
 use pubgrub::version::Version;
 use std::hash::Hash;
 use varisat::ExtendFormula;
@@ -127,7 +127,7 @@ impl<P: Package, V: Version + Hash> SatResolve<P, V> {
         }
     }
 
-    pub fn sat_is_valid_solution(&mut self, pids: &Map<P, V>) -> bool {
+    pub fn sat_is_valid_solution(&mut self, pids: &SelectedDependencies<P, V>) -> bool {
         let mut assumption = vec![];
 
         for (p, vs) in &self.all_versions_by_p {

--- a/tests/sat_dependency_provider.rs
+++ b/tests/sat_dependency_provider.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
 use pubgrub::package::Package;
-use pubgrub::solver::{DependencyProvider, OfflineDependencyProvider};
+use pubgrub::solver::{Dependencies, DependencyProvider, OfflineDependencyProvider};
 use pubgrub::type_aliases::Map;
 use pubgrub::version::Version;
 use std::hash::Hash;
@@ -76,7 +76,11 @@ impl<P: Package, V: Version + Hash> SatResolve<P, V> {
 
         // active packages need each of there `deps` to be satisfied
         for (p, v, var) in &all_versions {
-            for (p1, range) in dp.get_dependencies(p, v).unwrap().unwrap() {
+            let deps = match dp.get_dependencies(p, v).unwrap() {
+                Dependencies::Unavailable => panic!(),
+                Dependencies::Known(d) => d,
+            };
+            for (p1, range) in deps.iter() {
                 let empty_vec = vec![];
                 let mut matches: Vec<varisat::Lit> = all_versions_by_p
                     .get(&p1)


### PR DESCRIPTION
This is a work I started doing while working on Clippy suggestions. I've extracted it into a separate PR since this affects the public API and is rather large on its own.

What I've done here was to extract a separate `Dependencies` type that is now returned from `DependencyProvider`.
Before:
```
fn get_dependencies(...) -> Result<Option<Map<P, Range<V>>>, Box<dyn Error>>
```
After:
```
fn get_dependencies(...) -> Result<Dependencies<P, V>, Box<dyn Error>>
```

Doing this was suggested by [type_complexity](https://rust-lang.github.io/rust-clippy/master/index.html#type_complexity) lint, which my first reaction was to just disable. After thinking more about it though, it actually did make sense for me to
- Define our own enum here instead of `Option`. This encodes our intent in the type system and clarifies that the difference between `None` and an `empty Map`. It was mentioned in the docs, but I think it could be more easy glanced over while actually coding.
- Clarify what this `Map` should contain using a newtype ~`AllowedVersions`~ `DependencyConstraints` with its own documentation.

That's the substance, other changes just piled on to make the tests pass.

I see this as an ergonomics improvement and can't wait to hear your thoughts about it!