### PR TITLE
test: switch to criterion

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,3 +24,9 @@ serde = { version = "1.0", features = ["derive"], optional = true }
 proptest = "0.10.1"
 ron="0.6"
 varisat="0.2.2"
+criterion = "0.3"
+
+[[bench]]
+name = "large_case"
+harness = false
+required-features = ["serde"]

--- a/benches/large_case.rs
+++ b/benches/large_case.rs
@@ -1,22 +1,38 @@
 // SPDX-License-Identifier: MPL-2.0
+use std::time::Duration;
 
-#![feature(test)]
-extern crate test;
-use test::Bencher;
+extern crate criterion;
+use self::criterion::*;
 
-use pubgrub::solver::{resolve, OfflineDependencyProvider};
+use pubgrub::solver::{resolve, DependencyProvider, OfflineDependencyProvider};
 use pubgrub::version::NumberVersion;
 
-#[cfg(feature = "serde")]
-#[bench]
-/// This is an entirely synthetic benchmark. It may not be realistic.
-fn large_case(b: &mut Bencher) {
-    let s = std::fs::read_to_string("test-examples/large_case_u16_NumberVersion.ron").unwrap();
-    let dependency_provider: OfflineDependencyProvider<u16, NumberVersion> =
-        ron::de::from_str(&s).unwrap();
+fn bench_nested(c: &mut Criterion) {
+    let mut group = c.benchmark_group("large_cases");
+    group.measurement_time(Duration::from_secs(20));
 
-    // bench
-    b.iter(|| {
-        let _ = resolve(&dependency_provider, 0, 0);
-    });
+    for case in std::fs::read_dir("test-examples").unwrap() {
+        let case = case.unwrap().path();
+
+        group.bench_function(
+            format!("{}", case.file_name().unwrap().to_string_lossy()),
+            |b| {
+                let s = std::fs::read_to_string(&case).unwrap();
+                let dependency_provider: OfflineDependencyProvider<u16, NumberVersion> =
+                    ron::de::from_str(&s).unwrap();
+                let all_versions = dependency_provider.list_available_versions(&0).unwrap();
+
+                b.iter(|| {
+                    for &n in &all_versions {
+                        let _ = resolve(&dependency_provider, 0, n);
+                    }
+                });
+            },
+        );
+    }
+
+    group.finish();
 }
+
+criterion_group!(benches, bench_nested);
+criterion_main!(benches);


### PR DESCRIPTION
This switches our benchmark(s) to use criterion. Newer versions of criterion works better with slower tests, so it works out pretty well.

This automatically adds a benchmark for each file in `test-examples/`, removing the duplicated code pointed out in https://github.com/pubgrub-rs/pubgrub/pull/34#issuecomment-708426561. This also allows decoupling between the code and the  ron files. For example if in #43 we decide not to store all the ron files in tree, this will run the benchmarks on only what is in the file system.