### PR TITLE
ci: allow exclamation mark after commit message type

### DIFF
--- a/.commitlintrc.yml
+++ b/.commitlintrc.yml
@@ -1,5 +1,23 @@
 extends:
-  - '@commitlint/config-angular'
+  - '@commitlint/config-conventional'
 
 rules:
-  body-max-line-length: [2, 'always', 72]
+  footer-max-line-length: [ 2, 'always', 72 ]
+  header-max-length: [ 2, 'always', 72 ]
+  body-max-line-length: [ 2, 'always', 72 ]
+  type-enum: [
+      2,
+      'always',
+    [
+        'build',
+        'ci',
+        'docs',
+        'feat',
+        'fix',
+        'perf',
+        'refactor',
+        'revert',
+        'style',
+        'test',
+    ]
+  ]


### PR DESCRIPTION
Extracted out of #46 since there are more PRs depended on this fix.