### PR TITLE
fix: don't panic on Range::none() dependencies

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -43,6 +43,21 @@ pub enum PubGrubError<P: Package, V: Version> {
         source: Box<dyn std::error::Error>,
     },
 
+    /// Error arising when the implementer of
+    /// [DependencyProvider](crate::solver::DependencyProvider)
+    /// returned a dependency on an empty range.
+    /// This technically means that the package can not be selected,
+    /// but is clearly some kind of mistake.
+    #[error("Retrieving dependency {dependent} of {package} {version} is the empty set")]
+    ForbiddenEmptyDependency {
+        /// Package whose dependencies we want.
+        package: P,
+        /// Version of the package for which we want the dependencies.
+        version: V,
+        /// The dependent package that requires us to pick from the empty set.
+        dependent: P,
+    },
+
     /// Error arising when the implementer of [DependencyProvider](crate::solver::DependencyProvider)
     /// returned an error in the method [should_cancel](crate::solver::DependencyProvider::should_cancel).
     #[error("We should cancel")]

--- a/src/error.rs
+++ b/src/error.rs
@@ -48,7 +48,7 @@ pub enum PubGrubError<P: Package, V: Version> {
     /// returned a dependency on an empty range.
     /// This technically means that the package can not be selected,
     /// but is clearly some kind of mistake.
-    #[error("Retrieving dependency {dependent} of {package} {version} is the empty set")]
+    #[error("Package {dependent} required by {package} {version} depends on the empty set")]
     ForbiddenEmptyDependency {
         /// Package whose dependencies we want.
         package: P,

--- a/src/error.rs
+++ b/src/error.rs
@@ -49,7 +49,7 @@ pub enum PubGrubError<P: Package, V: Version> {
     /// This technically means that the package can not be selected,
     /// but is clearly some kind of mistake.
     #[error("Package {dependent} required by {package} {version} depends on the empty set")]
-    ForbiddenEmptyDependency {
+    DependencyOnTheEmptySet {
         /// Package whose dependencies we want.
         package: P,
         /// Version of the package for which we want the dependencies.
@@ -64,7 +64,7 @@ pub enum PubGrubError<P: Package, V: Version> {
     /// This technically means that the package directly depends on itself,
     /// and is clearly some kind of mistake.
     #[error("{package} {version} depends on itself")]
-    ForbiddenSelfDependency {
+    SelfDependency {
         /// Package whose dependencies we want.
         package: P,
         /// Version of the package for which we want the dependencies.

--- a/src/error.rs
+++ b/src/error.rs
@@ -58,6 +58,19 @@ pub enum PubGrubError<P: Package, V: Version> {
         dependent: P,
     },
 
+    /// Error arising when the implementer of
+    /// [DependencyProvider](crate::solver::DependencyProvider)
+    /// returned a dependency on the requested package.
+    /// This technically means that the package directly depends on itself,
+    /// and is clearly some kind of mistake.
+    #[error("{package} {version} depends on itself")]
+    ForbiddenSelfDependency {
+        /// Package whose dependencies we want.
+        package: P,
+        /// Version of the package for which we want the dependencies.
+        version: V,
+    },
+
     /// Error arising when the implementer of [DependencyProvider](crate::solver::DependencyProvider)
     /// returned an error in the method [should_cancel](crate::solver::DependencyProvider::should_cancel).
     #[error("We should cancel")]

--- a/src/solver.rs
+++ b/src/solver.rs
@@ -140,7 +140,16 @@ pub fn resolve<P: Package, V: Version>(
                 });
                 continue;
             }
-            Dependencies::Known(x) => x,
+            Dependencies::Known(x) => {
+                if let Some((dependent, _)) = x.iter().find(|(_, r)| r == &&Range::none()) {
+                    return Err(PubGrubError::ForbiddenEmptyDependency {
+                        package: p.clone(),
+                        version: v.clone(),
+                        dependent: dependent.clone(),
+                    });
+                }
+                x
+            }
         };
 
         // Add that package and version if the dependencies are not problematic.

--- a/src/solver.rs
+++ b/src/solver.rs
@@ -142,13 +142,13 @@ pub fn resolve<P: Package, V: Version>(
             }
             Dependencies::Known(x) => {
                 if x.contains_key(&p) {
-                    return Err(PubGrubError::ForbiddenSelfDependency {
+                    return Err(PubGrubError::SelfDependency {
                         package: p.clone(),
                         version: v.clone(),
                     });
                 }
                 if let Some((dependent, _)) = x.iter().find(|(_, r)| r == &&Range::none()) {
-                    return Err(PubGrubError::ForbiddenEmptyDependency {
+                    return Err(PubGrubError::DependencyOnTheEmptySet {
                         package: p.clone(),
                         version: v.clone(),
                         dependent: dependent.clone(),

--- a/src/solver.rs
+++ b/src/solver.rs
@@ -141,6 +141,12 @@ pub fn resolve<P: Package, V: Version>(
                 continue;
             }
             Dependencies::Known(x) => {
+                if x.contains_key(&p) {
+                    return Err(PubGrubError::ForbiddenSelfDependency {
+                        package: p.clone(),
+                        version: v.clone(),
+                    });
+                }
                 if let Some((dependent, _)) = x.iter().find(|(_, r)| r == &&Range::none()) {
                     return Err(PubGrubError::ForbiddenEmptyDependency {
                         package: p.clone(),

--- a/tests/proptest.rs
+++ b/tests/proptest.rs
@@ -326,8 +326,8 @@ proptest! {
                     (Ok(l), Ok(r)) => assert_eq!(l, r),
                     (Err(PubGrubError::NoSolution(derivation_l)), Err(PubGrubError::NoSolution(derivation_r))) => {
                         prop_assert_eq!(
-                            DefaultStringReporter::report(&derivation_l).to_string(),
-                            DefaultStringReporter::report(&derivation_r).to_string()
+                            DefaultStringReporter::report(&derivation_l),
+                            DefaultStringReporter::report(&derivation_r)
                         )},
                     _ => panic!("not the same result")
                 }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: MPL-2.0
 
+use pubgrub::error::PubGrubError;
 use pubgrub::range::Range;
 use pubgrub::solver::{resolve, OfflineDependencyProvider};
 use pubgrub::version::NumberVersion;
@@ -24,4 +25,20 @@ fn same_result_on_repeated_runs() {
             _ => panic!("not the same result"),
         }
     }
+}
+
+#[test]
+fn should_always_find_a_satisfier() {
+    let mut dependency_provider = OfflineDependencyProvider::<_, NumberVersion>::new();
+    dependency_provider.add_dependencies("a", 0, vec![("b", Range::none())]);
+    assert!(matches!(
+        resolve(&dependency_provider, "a", 0),
+        Err(PubGrubError::ForbiddenEmptyDependency { .. })
+    ));
+
+    dependency_provider.add_dependencies("c", 0, vec![("a", Range::any())]);
+    assert!(matches!(
+        resolve(&dependency_provider, "c", 0),
+        Err(PubGrubError::ForbiddenEmptyDependency { .. })
+    ));
 }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -42,3 +42,13 @@ fn should_always_find_a_satisfier() {
         Err(PubGrubError::ForbiddenEmptyDependency { .. })
     ));
 }
+
+#[test]
+fn cannot_depend_on_self() {
+    let mut dependency_provider = OfflineDependencyProvider::<_, NumberVersion>::new();
+    dependency_provider.add_dependencies("a", 0, vec![("a", Range::any())]);
+    assert!(matches!(
+        resolve(&dependency_provider, "a", 0),
+        Err(PubGrubError::ForbiddenSelfDependency { .. })
+    ));
+}

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -33,13 +33,13 @@ fn should_always_find_a_satisfier() {
     dependency_provider.add_dependencies("a", 0, vec![("b", Range::none())]);
     assert!(matches!(
         resolve(&dependency_provider, "a", 0),
-        Err(PubGrubError::ForbiddenEmptyDependency { .. })
+        Err(PubGrubError::DependencyOnTheEmptySet { .. })
     ));
 
     dependency_provider.add_dependencies("c", 0, vec![("a", Range::any())]);
     assert!(matches!(
         resolve(&dependency_provider, "c", 0),
-        Err(PubGrubError::ForbiddenEmptyDependency { .. })
+        Err(PubGrubError::DependencyOnTheEmptySet { .. })
     ));
 }
 
@@ -49,6 +49,6 @@ fn cannot_depend_on_self() {
     dependency_provider.add_dependencies("a", 0, vec![("a", Range::any())]);
     assert!(matches!(
         resolve(&dependency_provider, "a", 0),
-        Err(PubGrubError::ForbiddenSelfDependency { .. })
+        Err(PubGrubError::SelfDependency { .. })
     ));
 }


### PR DESCRIPTION
This fixes #36. By filtering out the meaningless `Term` `Negative(Range::none)` in the specific case when it is generated from a dependency on `Range::none()`.