### PR TITLE
Use an enum in memory

### DIFF
--- a/src/internal/incompatibility.rs
+++ b/src/internal/incompatibility.rs
@@ -238,11 +238,11 @@ impl<P: Package, V: Version> Incompatibility<P, V> {
                     return Relation::Contradicted((package.clone(), incompat_term.clone()));
                 }
                 None | Some(term::Relation::Inconclusive) => {
-                    // If a package is not present, the intersection is the same as any.
-                    // And according to the rules of satisfactions, the relation would be inconclusive.
-                    // It could also be satisfied if the incompatibility term was also any.
-                    // But we systematically remove those from incompatibilities.
-                    // So we're safe on that front.
+                    // If a package is not present, the intersection is the same as [Term::any].
+                    // According to the rules of satisfactions, the relation would be inconclusive.
+                    // It could also be satisfied if the incompatibility term was also [Term::any],
+                    // but we systematically remove those from incompatibilities
+                    // so we're safe on that front.
                     if relation == Relation::Satisfied {
                         relation =
                             Relation::AlmostSatisfied((package.clone(), incompat_term.clone()));

--- a/src/internal/incompatibility.rs
+++ b/src/internal/incompatibility.rs
@@ -237,7 +237,12 @@ impl<P: Package, V: Version> Incompatibility<P, V> {
                 Some(term::Relation::Contradicted) => {
                     return Relation::Contradicted((package.clone(), incompat_term.clone()));
                 }
-                _ => {
+                None | Some(term::Relation::Inconclusive) => {
+                    // If a package is not present, the intersection is the same as any.
+                    // And according to the rules of satisfactions, the relation would be inconclusive.
+                    // It could also be satisfied if the incompatibility term was also any.
+                    // But we systematically remove those from incompatibilities.
+                    // So we're safe on that front.
                     if relation == Relation::Satisfied {
                         relation =
                             Relation::AlmostSatisfied((package.clone(), incompat_term.clone()));

--- a/src/internal/memory.rs
+++ b/src/internal/memory.rs
@@ -137,7 +137,7 @@ impl<V: Version> PackageAssignments<V> {
     /// Mutates itself to store the intersection result.
     fn assignment_intersection(&mut self) -> &Term<V> {
         match self {
-            PackageAssignments::Decision((_, term)) => &*term,
+            PackageAssignments::Decision((_, term)) => term,
             PackageAssignments::Derivations {
                 intersected,
                 not_intersected_yet,
@@ -146,7 +146,7 @@ impl<V: Version> PackageAssignments<V> {
                     *intersected = intersected.intersection(&derivation);
                 }
                 not_intersected_yet.clear();
-                &*intersected
+                intersected
             }
         }
     }

--- a/src/internal/memory.rs
+++ b/src/internal/memory.rs
@@ -76,6 +76,7 @@ impl<P: Package, V: Version> Memory<P, V> {
         use std::collections::hash_map::Entry;
         match self.assignments.entry(package) {
             Entry::Occupied(mut o) => match o.get_mut() {
+                // Check that add_derivation is never called in the wrong context.
                 PackageAssignments::Decision(_) => debug_assert!(false),
                 PackageAssignments::Derivations {
                     intersected: _,

--- a/src/internal/memory.rs
+++ b/src/internal/memory.rs
@@ -38,11 +38,10 @@ impl<P: Package, V: Version> Memory<P, V> {
     }
 
     /// Retrieve intersection of terms in memory related to package.
-    pub fn term_intersection_for_package(&mut self, package: &P) -> Term<V> {
-        match self.assignments.get_mut(package) {
-            None => Term::any(),
-            Some(pa) => pa.assignment_intersection().clone(),
-        }
+    pub fn term_intersection_for_package(&mut self, package: &P) -> Option<&Term<V>> {
+        self.assignments
+            .get_mut(package)
+            .map(|pa| pa.assignment_intersection())
     }
 
     /// Building step of a Memory from a given assignment.
@@ -161,10 +160,10 @@ impl<V: Version> PackageAssignments<V> {
     /// selected version (no "decision")
     /// and if it contains at least one positive derivation term
     /// in the partial solution.
-    fn potential_package_filter<'a, 'b, P: Package>(
+    fn potential_package_filter<'a, P: Package>(
         &'a mut self,
-        package: &'b P,
-    ) -> Option<(&'b P, &'a Term<V>)> {
+        package: &'a P,
+    ) -> Option<(&'a P, &'a Term<V>)> {
         match self {
             PackageAssignments::Decision(_) => None,
             PackageAssignments::Derivations {

--- a/src/internal/memory.rs
+++ b/src/internal/memory.rs
@@ -21,10 +21,12 @@ pub struct Memory<P: Package, V: Version> {
 /// A package memory contains the potential decision and derivations
 /// that have already been made for a given package.
 #[derive(Clone)]
-struct PackageAssignments<V: Version> {
-    decision: Option<(V, Term<V>)>,
-    derivations_intersected: Term<V>,
-    derivations_not_intersected_yet: Vec<Term<V>>,
+enum PackageAssignments<V: Version> {
+    Decision((V, Term<V>)),
+    Derivations {
+        intersected: Term<V>,
+        not_intersected_yet: Vec<Term<V>>,
+    },
 }
 
 impl<P: Package, V: Version> Memory<P, V> {
@@ -39,7 +41,7 @@ impl<P: Package, V: Version> Memory<P, V> {
     pub fn term_intersection_for_package(&mut self, package: &P) -> Term<V> {
         match self.assignments.get_mut(package) {
             None => Term::any(),
-            Some(pa) => pa.assignment_intersection(),
+            Some(pa) => pa.assignment_intersection().clone(),
         }
     }
 
@@ -53,27 +55,50 @@ impl<P: Package, V: Version> Memory<P, V> {
 
     /// Add a decision to a Memory.
     fn add_decision(&mut self, package: P, version: V) {
-        let pa = self
-            .assignments
-            .entry(package)
-            .or_insert_with(PackageAssignments::new);
-        pa.decision = Some((version.clone(), Term::exact(version)));
-    }
-
-    /// Remove a decision from a Memory.
-    pub fn remove_decision(&mut self, package: &P) {
-        if let Some(pa) = self.assignments.get_mut(package) {
-            pa.decision = None;
+        if cfg!(debug_assertions) {
+            match self.assignments.get(&package) {
+                Some(PackageAssignments::Decision(v)) => assert_eq!(v.0, version),
+                Some(PackageAssignments::Derivations {
+                    intersected,
+                    not_intersected_yet,
+                }) => {
+                    debug_assert!(intersected.contains(&version));
+                    for term in not_intersected_yet {
+                        debug_assert!(term.contains(&version));
+                    }
+                }
+                _ => {}
+            }
         }
+
+        self.assignments.insert(
+            package,
+            PackageAssignments::Decision((version.clone(), Term::exact(version))),
+        );
     }
 
     /// Add a derivation to a Memory.
     fn add_derivation(&mut self, package: P, term: Term<V>) {
-        let pa = self
-            .assignments
-            .entry(package)
-            .or_insert_with(PackageAssignments::new);
-        pa.derivations_not_intersected_yet.push(term);
+        let pa =
+            self.assignments
+                .entry(package)
+                .or_insert_with(|| PackageAssignments::Derivations {
+                    intersected: Term::any(),
+                    not_intersected_yet: Vec::with_capacity(1),
+                });
+        match pa {
+            PackageAssignments::Decision((version, _)) => {
+                if cfg!(debug_assertions) {
+                    debug_assert!(term.contains(&version))
+                }
+            }
+            PackageAssignments::Derivations {
+                intersected: _,
+                not_intersected_yet,
+            } => {
+                not_intersected_yet.push(term);
+            }
+        }
     }
 
     /// Extract all packages that may potentially be picked next
@@ -92,11 +117,20 @@ impl<P: Package, V: Version> Memory<P, V> {
     /// a corresponding decision that satisfies that assignment,
     /// it's a total solution and version solving has succeeded.
     pub fn extract_solution(&self) -> Option<SelectedDependencies<P, V>> {
-        if self.assignments.values().all(|pa| pa.is_valid()) {
+        if self.assignments.iter().all(|(_, pa)| match pa {
+            PackageAssignments::Decision(_) => true,
+            PackageAssignments::Derivations {
+                intersected,
+                not_intersected_yet,
+            } => intersected.is_negative() && not_intersected_yet.iter().all(|t| t.is_negative()),
+        }) {
             Some(
                 self.assignments
                     .iter()
-                    .filter_map(|(p, pa)| pa.decision.as_ref().map(|v| (p.clone(), v.0.clone())))
+                    .filter_map(|(p, pa)| match pa {
+                        PackageAssignments::Decision((v, _)) => Some((p.clone(), v.clone())),
+                        PackageAssignments::Derivations { .. } => None,
+                    })
                     .collect(),
             )
         } else {
@@ -106,49 +140,21 @@ impl<P: Package, V: Version> Memory<P, V> {
 }
 
 impl<V: Version> PackageAssignments<V> {
-    /// Empty package assignment
-    fn new() -> Self {
-        Self {
-            decision: None,
-            derivations_intersected: Term::any(),
-            derivations_not_intersected_yet: Vec::new(),
-        }
-    }
-
-    /// If a partial solution has, for every positive derivation,
-    /// a corresponding decision that satisfies that assignment,
-    /// it's a total solution and version solving has succeeded.
-    fn is_valid(&self) -> bool {
-        match self.decision {
-            None => {
-                self.derivations_intersected.is_negative()
-                    && self
-                        .derivations_not_intersected_yet
-                        .iter()
-                        .all(|t| t.is_negative())
-            }
-            Some(_) => true,
-        }
-    }
-
     /// Returns intersection of all assignments (decision included).
     /// Mutates itself to store the intersection result.
-    fn assignment_intersection(&mut self) -> Term<V> {
-        self.derivation_intersection();
-        match &self.decision {
-            None => self.derivations_intersected.clone(),
-            Some((_, decision_term)) => decision_term.intersection(&self.derivations_intersected),
+    fn assignment_intersection(&mut self) -> &Term<V> {
+        match self {
+            PackageAssignments::Decision((_, term)) => &*term,
+            PackageAssignments::Derivations {
+                intersected,
+                not_intersected_yet,
+            } => {
+                for derivation in not_intersected_yet.drain(..) {
+                    *intersected = intersected.intersection(&derivation);
+                }
+                &*intersected
+            }
         }
-    }
-
-    /// Returns intersection of all derivation terms.
-    /// Mutates itself to store the intersection result.
-    fn derivation_intersection(&mut self) -> &Term<V> {
-        for derivation in self.derivations_not_intersected_yet.iter() {
-            self.derivations_intersected = self.derivations_intersected.intersection(derivation);
-        }
-        self.derivations_not_intersected_yet.clear();
-        &self.derivations_intersected
     }
 
     /// A package is a potential pick if there isn't an already
@@ -159,16 +165,19 @@ impl<V: Version> PackageAssignments<V> {
         &'a mut self,
         package: &'b P,
     ) -> Option<(&'b P, &'a Term<V>)> {
-        if self.decision == None
-            && (self.derivations_intersected.is_positive()
-                || self
-                    .derivations_not_intersected_yet
-                    .iter()
-                    .any(|t| t.is_positive()))
-        {
-            Some((package, self.derivation_intersection()))
-        } else {
-            None
+        match self {
+            PackageAssignments::Decision(_) => None,
+            PackageAssignments::Derivations {
+                intersected,
+                not_intersected_yet,
+            } => {
+                if intersected.is_positive() || not_intersected_yet.iter().any(|t| t.is_positive())
+                {
+                    Some((package, self.assignment_intersection()))
+                } else {
+                    None
+                }
+            }
         }
     }
 }

--- a/src/internal/partial_solution.rs
+++ b/src/internal/partial_solution.rs
@@ -172,7 +172,7 @@ impl<P: Package, V: Version> PartialSolution<P, V> {
 
     /// Check if the terms in the partial solution satisfy the incompatibility.
     pub fn relation(&mut self, incompat: &Incompatibility<P, V>) -> Relation<P, V> {
-        incompat.relation(|package| self.memory.term_intersection_for_package(package))
+        incompat.relation(|package| self.memory.term_intersection_for_package(package).cloned())
     }
 
     /// Find satisfier and previous satisfier decision level.

--- a/src/internal/partial_solution.rs
+++ b/src/internal/partial_solution.rs
@@ -181,21 +181,21 @@ impl<P: Package, V: Version> PartialSolution<P, V> {
         version: V,
         new_incompatibilities: &[Incompatibility<P, V>],
     ) {
-        let satisfied = |incompat: &Incompatibility<P, V>| {
+        let not_satisfied = |incompat: &Incompatibility<P, V>| {
             incompat.relation(|p| {
                 if p == &package {
                     Some(Term::exact(version.clone()))
                 } else {
                     self.memory.term_intersection_for_package(p).cloned()
                 }
-            }) == Relation::Satisfied
+            }) != Relation::Satisfied
         };
-        // Preventive check that none of the dependencies (new_incompatibilities)
+
+        // Check none of the dependencies (new_incompatibilities)
         // would create a conflict (be satisfied).
-        if new_incompatibilities.iter().any(satisfied) {
-            return;
+        if new_incompatibilities.iter().all(not_satisfied) {
+            self.add_decision(package, version);
         }
-        self.add_decision(package, version);
     }
 
     /// Check if the terms in the partial solution satisfy the incompatibility.

--- a/src/internal/partial_solution.rs
+++ b/src/internal/partial_solution.rs
@@ -170,36 +170,6 @@ impl<P: Package, V: Version> PartialSolution<P, V> {
             .cloned()
     }
 
-    /// We can add the version to the partial solution as a decision
-    /// if it doesn't produce any conflict with the new incompatibilities.
-    /// In practice I think it can only produce a conflict if one of the dependencies
-    /// (which are used to make the new incompatibilities)
-    /// is already in the partial solution with an incompatible version.
-    pub fn add_version(
-        &mut self,
-        package: P,
-        version: V,
-        new_incompatibilities: &[Incompatibility<P, V>],
-    ) {
-        self.add_decision(package, version);
-        if self.satisfies_any_of(new_incompatibilities) {
-            self.remove_last_decision();
-        }
-    }
-
-    /// Can ONLY be called if the last assignment added was a decision.
-    fn remove_last_decision(&mut self) {
-        self.decision_level -= DecisionLevel(1);
-        let last_assignment = self.history.pop().unwrap().assignment;
-        self.memory.remove_decision(last_assignment.package());
-    }
-
-    fn satisfies_any_of(&mut self, incompatibilities: &[Incompatibility<P, V>]) -> bool {
-        incompatibilities
-            .iter()
-            .any(|incompat| self.relation(incompat) == Relation::Satisfied)
-    }
-
     /// Check if the terms in the partial solution satisfy the incompatibility.
     pub fn relation(&mut self, incompat: &Incompatibility<P, V>) -> Relation<P, V> {
         incompat.relation(|package| self.memory.term_intersection_for_package(package))

--- a/src/solver.rs
+++ b/src/solver.rs
@@ -182,8 +182,12 @@ pub fn resolve<P: Package, V: Version>(
                     "Root package depends on itself at a different version?".into(),
                 ));
             }
+            state.partial_solution.add_version(p, v, &dep_incompats);
+        } else {
+            // `dep_incompats` are already in `incompatibilities` so we know there are not satisfied
+            // terms and can add the decision directly.
+            state.partial_solution.add_decision(p, v);
         }
-        state.partial_solution.add_decision(p, v);
     }
 }
 

--- a/src/solver.rs
+++ b/src/solver.rs
@@ -126,62 +126,64 @@ pub fn resolve<P: Package, V: Version>(
             Some(x) => x,
         };
 
-        // Retrieve that package dependencies.
-        let dependencies = match dependency_provider
-            .get_dependencies(&p, &v)
-            .map_err(|err| PubGrubError::ErrorRetrievingDependencies {
-                package: p.clone(),
-                version: v.clone(),
-                source: err,
-            })? {
-            Dependencies::Unknown => {
-                state.add_incompatibility(|id| {
-                    Incompatibility::unavailable_dependencies(id, p.clone(), v.clone())
-                });
-                continue;
-            }
-            Dependencies::Known(x) => {
-                if x.contains_key(&p) {
-                    return Err(PubGrubError::SelfDependency {
-                        package: p.clone(),
-                        version: v.clone(),
-                    });
-                }
-                if let Some((dependent, _)) = x.iter().find(|(_, r)| r == &&Range::none()) {
-                    return Err(PubGrubError::DependencyOnTheEmptySet {
-                        package: p.clone(),
-                        version: v.clone(),
-                        dependent: dependent.clone(),
-                    });
-                }
-                x
-            }
-        };
-
-        // Add that package and version if the dependencies are not problematic.
-        let start_id = state.incompatibility_store.len();
-        let dep_incompats =
-            Incompatibility::from_dependencies(start_id, p.clone(), v.clone(), &dependencies);
         if added_dependencies
             .entry(p.clone())
             .or_default()
             .insert(v.clone())
         {
+            // Retrieve that package dependencies.
+            let dependencies =
+                match dependency_provider
+                    .get_dependencies(&p, &v)
+                    .map_err(|err| PubGrubError::ErrorRetrievingDependencies {
+                        package: p.clone(),
+                        version: v.clone(),
+                        source: err,
+                    })? {
+                    Dependencies::Unknown => {
+                        state.add_incompatibility(|id| {
+                            Incompatibility::unavailable_dependencies(id, p.clone(), v.clone())
+                        });
+                        continue;
+                    }
+                    Dependencies::Known(x) => {
+                        if x.contains_key(&p) {
+                            return Err(PubGrubError::SelfDependency {
+                                package: p.clone(),
+                                version: v.clone(),
+                            });
+                        }
+                        if let Some((dependent, _)) = x.iter().find(|(_, r)| r == &&Range::none()) {
+                            return Err(PubGrubError::DependencyOnTheEmptySet {
+                                package: p.clone(),
+                                version: v.clone(),
+                                dependent: dependent.clone(),
+                            });
+                        }
+                        x
+                    }
+                };
+
+            // Add that package and version if the dependencies are not problematic.
+            let start_id = state.incompatibility_store.len();
+            let dep_incompats =
+                Incompatibility::from_dependencies(start_id, p.clone(), v.clone(), &dependencies);
+
             for incompat in dep_incompats.iter() {
                 state.add_incompatibility(|_| incompat.clone());
             }
+            if dep_incompats
+                .iter()
+                .any(|incompat| state.is_terminal(incompat))
+            {
+                // For a dependency incompatibility to be terminal,
+                // it can only mean that root depend on not root?
+                return Err(PubGrubError::Failure(
+                    "Root package depends on itself at a different version?".into(),
+                ));
+            }
         }
-        if dep_incompats
-            .iter()
-            .any(|incompat| state.is_terminal(incompat))
-        {
-            // For a dependency incompatibility to be terminal,
-            // it can only mean that root depend on not root?
-            return Err(PubGrubError::Failure(
-                "Root package depends on itself at a different version?".into(),
-            ));
-        }
-        state.partial_solution.add_version(p, v, &dep_incompats);
+        state.partial_solution.add_decision(p, v);
     }
 }
 

--- a/src/term.rs
+++ b/src/term.rs
@@ -45,11 +45,6 @@ impl<V: Version> Term<V> {
         }
     }
 
-    /// Simply check if a term is negative.
-    pub(crate) fn is_negative(&self) -> bool {
-        !self.is_positive()
-    }
-
     /// Negate a term.
     /// Evaluation of a negated term always returns
     /// the opposite of the evaluation of the original one.


### PR DESCRIPTION
This is an impl of #56.

The main questionable decision is: `remove_last_decision` was handled by removing `add_version` and using `add_decision` directly.  I think the next call to `unit_propagation` will clean up if one of the dependency is satisfied. But I don't know how important that fast path was.