### PR TITLE
perf: optimize term::relation_with()

### DIFF
--- a/src/internal/incompatibility.rs
+++ b/src/internal/incompatibility.rs
@@ -9,9 +9,9 @@ use std::fmt;
 use crate::internal::arena::{Arena, Id};
 use crate::internal::small_map::SmallMap;
 use crate::package::Package;
-use crate::range::Range;
+use crate::range::{self, Range};
 use crate::report::{DefaultStringReporter, DerivationTree, Derived, External};
-use crate::term::{self, Term};
+use crate::term::Term;
 use crate::version::Version;
 
 /// An incompatibility is a set of terms for different packages
@@ -177,11 +177,11 @@ impl<P: Package, V: Version> Incompatibility<P, V> {
         let mut relation = Relation::Satisfied;
         for (package, incompat_term) in self.package_terms.iter() {
             match terms(package).map(|term| incompat_term.relation_with(&term)) {
-                Some(term::Relation::Satisfied) => {}
-                Some(term::Relation::Contradicted) => {
+                Some(range::Relation::Satisfied) => {}
+                Some(range::Relation::Contradicted) => {
                     return Relation::Contradicted((package.clone(), incompat_term.clone()));
                 }
-                None | Some(term::Relation::Inconclusive) => {
+                None | Some(range::Relation::Inconclusive) => {
                     // If a package is not present, the intersection is the same as [Term::any].
                     // According to the rules of satisfactions, the relation would be inconclusive.
                     // It could also be satisfied if the incompatibility term was also [Term::any],

--- a/src/internal/small_vec.rs
+++ b/src/internal/small_vec.rs
@@ -38,7 +38,7 @@ impl<T> SmallVec<T> {
         }
     }
 
-    pub fn iter(&self) -> impl Iterator<Item = &T> {
+    pub fn iter(&self) -> impl DoubleEndedIterator<Item = &T> {
         self.as_slice().iter()
     }
 }


### PR DESCRIPTION
In #27 it was measured that we spend a lot of our runtime in `intersection`s in `relation_with`. For that use case we do not need the exact list of what versions are in the `intersection` just a trinary state. So this adds a function to `Range` to compute that directly.

Criterion thinks this is a ~20% improvement in runtime of the benchmarks from #34.
This is mostly because of skipping the cache miss and allocation of making a new `Range`. But also because we can short circuit when we see a `Relation::Inconclusive`.

This still needs wordsmithing.