### PR TITLE
fix(semver): bump_minor and bump_major

### DIFF
--- a/src/version.rs
+++ b/src/version.rs
@@ -96,12 +96,12 @@ impl SemanticVersion {
 
     /// Bump the minor number of a version.
     pub fn bump_minor(self) -> Self {
-        Self::new(self.major, self.minor + 1, self.patch)
+        Self::new(self.major, self.minor + 1, 0)
     }
 
     /// Bump the major number of a version.
     pub fn bump_major(self) -> Self {
-        Self::new(self.major + 1, self.minor, self.patch)
+        Self::new(self.major + 1, 0, 0)
     }
 }
 


### PR DESCRIPTION
Just realized now that I'm back to working on an elm dependency provider that the minor and major bumps were not correct for `SemanticVersion`