### PR TITLE
refactor!: pluralize NoVersion incompatibilities

### DIFF
--- a/examples/branching_error_reporting.rs
+++ b/examples/branching_error_reporting.rs
@@ -56,7 +56,7 @@ fn main() {
     match resolve(&dependency_provider, "root", (1, 0, 0)) {
         Ok(sol) => println!("{:?}", sol),
         Err(PubGrubError::NoSolution(mut derivation_tree)) => {
-            derivation_tree.collapse_noversion();
+            derivation_tree.collapse_no_versions();
             eprintln!("{}", DefaultStringReporter::report(&derivation_tree));
             std::process::exit(1);
         }

--- a/examples/doc_interface_error.rs
+++ b/examples/doc_interface_error.rs
@@ -73,7 +73,7 @@ fn main() {
     match resolve(&dependency_provider, "root", (1, 0, 0)) {
         Ok(sol) => println!("{:?}", sol),
         Err(PubGrubError::NoSolution(mut derivation_tree)) => {
-            derivation_tree.collapse_noversion();
+            derivation_tree.collapse_no_versions();
             eprintln!("{}", DefaultStringReporter::report(&derivation_tree));
         }
         Err(err) => panic!("{:?}", err),

--- a/examples/doc_interface_semantic.rs
+++ b/examples/doc_interface_semantic.rs
@@ -64,7 +64,7 @@ fn main() {
     match resolve(&dependency_provider, "root", (1, 0, 0)) {
         Ok(sol) => println!("{:?}", sol),
         Err(PubGrubError::NoSolution(mut derivation_tree)) => {
-            derivation_tree.collapse_noversion();
+            derivation_tree.collapse_no_versions();
             eprintln!("{}", DefaultStringReporter::report(&derivation_tree));
         }
         Err(err) => panic!("{:?}", err),

--- a/examples/linear_error_reporting.rs
+++ b/examples/linear_error_reporting.rs
@@ -38,7 +38,7 @@ fn main() {
     match resolve(&dependency_provider, "root", (1, 0, 0)) {
         Ok(sol) => println!("{:?}", sol),
         Err(PubGrubError::NoSolution(mut derivation_tree)) => {
-            derivation_tree.collapse_noversion();
+            derivation_tree.collapse_no_versions();
             eprintln!("{}", DefaultStringReporter::report(&derivation_tree));
             std::process::exit(1);
         }

--- a/src/internal/incompatibility.rs
+++ b/src/internal/incompatibility.rs
@@ -40,7 +40,7 @@ pub struct Incompatibility<P: Package, V: Version> {
 #[derive(Debug, Clone)]
 enum Kind<P: Package, V: Version> {
     NotRoot(P, V),
-    NoVersion(P, Range<V>),
+    NoVersions(P, Range<V>),
     UnavailableDependencies(P, Range<V>),
     FromDependencyOf(P, Range<V>, P, Range<V>),
     DerivedFrom(usize, usize),
@@ -83,7 +83,7 @@ impl<P: Package, V: Version> Incompatibility<P, V> {
 
     /// Create an incompatibility to remember
     /// that a given range does not contain any version.
-    pub fn no_version(id: usize, package: P, term: Term<V>) -> Self {
+    pub fn no_versions(id: usize, package: P, term: Term<V>) -> Self {
         let range = match &term {
             Term::Positive(r) => r.clone(),
             Term::Negative(_) => panic!("No version should have a positive term"),
@@ -93,7 +93,7 @@ impl<P: Package, V: Version> Incompatibility<P, V> {
         Self {
             id,
             package_terms,
-            kind: Kind::NoVersion(package, range),
+            kind: Kind::NoVersions(package, range),
         }
     }
 
@@ -301,8 +301,8 @@ impl<P: Package, V: Version> Incompatibility<P, V> {
             Kind::NotRoot(package, version) => {
                 DerivationTree::External(External::NotRoot(package.clone(), version.clone()))
             }
-            Kind::NoVersion(package, range) => {
-                DerivationTree::External(External::NoVersion(package.clone(), range.clone()))
+            Kind::NoVersions(package, range) => {
+                DerivationTree::External(External::NoVersions(package.clone(), range.clone()))
             }
             Kind::UnavailableDependencies(package, range) => DerivationTree::External(
                 External::UnavailableDependencies(package.clone(), range.clone()),

--- a/src/internal/incompatibility.rs
+++ b/src/internal/incompatibility.rs
@@ -39,10 +39,15 @@ pub struct Incompatibility<P: Package, V: Version> {
 
 #[derive(Debug, Clone)]
 enum Kind<P: Package, V: Version> {
+    /// Initial incompatibility aiming at picking the root package for the first decision.
     NotRoot(P, V),
+    /// No versions from range satisfy given constraints.
     NoVersions(P, Range<V>),
+    /// Dependencies of the package are unavailable for versions in that range.
     UnavailableDependencies(P, Range<V>),
+    /// Incompatibility coming from the dependencies of a given package.
     FromDependencyOf(P, Range<V>, P, Range<V>),
+    /// Derived from two causes. Stores cause ids.
     DerivedFrom(usize, usize),
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -181,7 +181,7 @@
 //! Notice that we also used
 //! [collapse_noversion()](crate::report::DerivationTree::collapse_noversion) above.
 //! This method simplifies the derivation tree to get rid of the
-//! [NoVersion](crate::report::External::NoVersion)
+//! [NoVersions](crate::report::External::NoVersions)
 //! external incompatibilities in the derivation tree.
 //! So instead of seeing things like this in the report:
 //! ```txt

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -172,14 +172,14 @@
 //! match resolve(&dependency_provider, root_package, root_version) {
 //!     Ok(solution) => println!("{:?}", solution),
 //!     Err(PubGrubError::NoSolution(mut derivation_tree)) => {
-//!         derivation_tree.collapse_noversion();
+//!         derivation_tree.collapse_no_versions();
 //!         eprintln!("{}", DefaultStringReporter::report(&derivation_tree));
 //!     }
 //!     Err(err) => panic!("{:?}", err),
 //! };
 //! ```
 //! Notice that we also used
-//! [collapse_noversion()](crate::report::DerivationTree::collapse_noversion) above.
+//! [collapse_no_versions()](crate::report::DerivationTree::collapse_no_versions) above.
 //! This method simplifies the derivation tree to get rid of the
 //! [NoVersions](crate::report::External::NoVersions)
 //! external incompatibilities in the derivation tree.

--- a/src/report.rs
+++ b/src/report.rs
@@ -35,8 +35,7 @@ pub enum DerivationTree<P: Package, V: Version> {
 /// they have their own reason.
 #[derive(Debug, Clone)]
 pub enum External<P: Package, V: Version> {
-    /// Initial incompatibility aiming at picking the root package
-    /// for the first decision.
+    /// Initial incompatibility aiming at picking the root package for the first decision.
     NotRoot(P, V),
     /// No versions from range satisfy given constraints.
     NoVersions(P, Range<V>),

--- a/src/report.rs
+++ b/src/report.rs
@@ -72,35 +72,35 @@ impl<P: Package, V: Version> DerivationTree<P, V> {
     /// [DependencyProvider](crate::solver::DependencyProvider)
     /// was not run in some kind of offline mode that may not
     /// have access to all versions existing.
-    pub fn collapse_noversion(&mut self) {
+    pub fn collapse_no_versions(&mut self) {
         match self {
             DerivationTree::External(_) => {}
             DerivationTree::Derived(derived) => {
                 match (&mut *derived.cause1, &mut *derived.cause2) {
                     (DerivationTree::External(External::NoVersions(p, r)), ref mut cause2) => {
-                        cause2.collapse_noversion();
+                        cause2.collapse_no_versions();
                         *self = cause2
                             .clone()
-                            .merge_noversion(p.to_owned(), r.to_owned())
+                            .merge_no_versions(p.to_owned(), r.to_owned())
                             .unwrap_or_else(|| self.to_owned());
                     }
                     (ref mut cause1, DerivationTree::External(External::NoVersions(p, r))) => {
-                        cause1.collapse_noversion();
+                        cause1.collapse_no_versions();
                         *self = cause1
                             .clone()
-                            .merge_noversion(p.to_owned(), r.to_owned())
+                            .merge_no_versions(p.to_owned(), r.to_owned())
                             .unwrap_or_else(|| self.to_owned());
                     }
                     _ => {
-                        derived.cause1.collapse_noversion();
-                        derived.cause2.collapse_noversion();
+                        derived.cause1.collapse_no_versions();
+                        derived.cause2.collapse_no_versions();
                     }
                 }
             }
         }
     }
 
-    fn merge_noversion(self, package: P, range: Range<V>) -> Option<Self> {
+    fn merge_no_versions(self, package: P, range: Range<V>) -> Option<Self> {
         match self {
             // TODO: take care of the Derived case.
             // Once done, we can remove the Option.

--- a/src/solver.rs
+++ b/src/solver.rs
@@ -119,7 +119,7 @@ pub fn resolve<P: Package, V: Version>(
         let v = match PartialSolution::<P, V>::pick_version(&available_versions[..], &term) {
             None => {
                 state.add_incompatibility(|id| {
-                    Incompatibility::no_version(id, p.clone(), term.clone())
+                    Incompatibility::no_versions(id, p.clone(), term.clone())
                 });
                 continue;
             }


### PR DESCRIPTION
Just a small thing that bothered me.

I've also noticed that we mostly duplicate incompatibility::Kind with report::External, so maybe we should see if we could combine them.