### PR TITLE
refactor: do less work in backtrack

### DIFF
--- a/src/internal/memory.rs
+++ b/src/internal/memory.rs
@@ -38,6 +38,11 @@ impl<P: Package, V: Version> Memory<P, V> {
         }
     }
 
+    /// Clears the memory.
+    pub fn clear(&mut self) {
+        self.assignments.clear();
+    }
+
     /// Retrieve intersection of terms in memory related to package.
     pub fn term_intersection_for_package(&mut self, package: &P) -> Option<&Term<V>> {
         self.assignments


### PR DESCRIPTION
Using `dhat-rs` I saw that most of the bytes we allocate over a run are in `PartialSolution::from_assignments`. This cleans up some things so we can reuse the main `Memory.assignments` and `history` allocations. `dhat-rs` is happy, we are allocating less memory. `criterion` is unimpressed, no change to runtime on my computers.

I do have thoughts for other ways to store history/memory that have a better Big-O on backtrack, but this is a PR for a small refactor, not for a big redesign.