### PR TITLE
refactor: use arena to have type safe ids

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ include = ["Cargo.toml", "LICENSE", "README.md", "src/**", "tests/**", "examples
 [dependencies]
 thiserror = "1.0"
 rustc-hash = "1.1.0"
+id-arena="2.2.1"
 serde = { version = "1.0", features = ["derive"], optional = true }
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,6 @@ include = ["Cargo.toml", "LICENSE", "README.md", "src/**", "tests/**", "examples
 [dependencies]
 thiserror = "1.0"
 rustc-hash = "1.1.0"
-id-arena="2.2.1"
 serde = { version = "1.0", features = ["derive"], optional = true }
 
 [dev-dependencies]

--- a/src/internal/arena.rs
+++ b/src/internal/arena.rs
@@ -1,0 +1,87 @@
+use std::{
+    fmt,
+    hash::{Hash, Hasher},
+    marker::PhantomData,
+    ops::Index,
+};
+
+/// The index of a value allocated in an arena that holds `T`s.
+pub struct Id<T> {
+    raw: u32,
+    _ty: PhantomData<fn() -> T>,
+}
+
+impl<T> Clone for Id<T> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
+impl<T> Copy for Id<T> {}
+
+impl<T> PartialEq for Id<T> {
+    fn eq(&self, other: &Id<T>) -> bool {
+        self.raw == other.raw
+    }
+}
+
+impl<T> Eq for Id<T> {}
+
+impl<T> Hash for Id<T> {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.raw.hash(state)
+    }
+}
+
+impl<T> fmt::Debug for Id<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut type_name = std::any::type_name::<T>();
+        if let Some(id) = type_name.rfind(':') {
+            type_name = &type_name[id + 1..]
+        }
+        write!(f, "Id::<{}>({})", type_name, self.raw)
+    }
+}
+
+impl<T> Id<T> {
+    pub fn into_raw(self) -> usize {
+        self.raw as usize
+    }
+}
+
+/// Yet another index-based arena.
+#[derive(Clone, PartialEq, Eq)]
+pub struct Arena<T> {
+    data: Vec<T>,
+}
+
+impl<T: fmt::Debug> fmt::Debug for Arena<T> {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        fmt.debug_struct("Arena")
+            .field("len", &self.data.len())
+            .field("data", &self.data)
+            .finish()
+    }
+}
+
+impl<T> Arena<T> {
+    pub fn new() -> Arena<T> {
+        Arena { data: Vec::new() }
+    }
+
+    pub fn alloc(&mut self, value: T) -> Id<T> {
+        let raw = self.data.len() as u32;
+        self.data.push(value);
+        Id {
+            raw,
+            _ty: PhantomData,
+        }
+    }
+}
+
+impl<T> Index<Id<T>> for Arena<T> {
+    type Output = T;
+    fn index(&self, id: Id<T>) -> &T {
+        &self.data[id.raw as usize]
+    }
+}

--- a/src/internal/arena.rs
+++ b/src/internal/arena.rs
@@ -6,6 +6,12 @@ use std::{
 };
 
 /// The index of a value allocated in an arena that holds `T`s.
+///
+/// The Clone, Copy and other traits are defined manually because
+/// deriving them adds some additional constraints on the `T` generic type
+/// that we actually don't need since it is phantom.
+///
+/// https://github.com/rust-lang/rust/issues/26925
 pub struct Id<T> {
     raw: u32,
     _ty: PhantomData<fn() -> T>,

--- a/src/internal/arena.rs
+++ b/src/internal/arena.rs
@@ -11,7 +11,7 @@ use std::{
 /// deriving them adds some additional constraints on the `T` generic type
 /// that we actually don't need since it is phantom.
 ///
-/// https://github.com/rust-lang/rust/issues/26925
+/// <https://github.com/rust-lang/rust/issues/26925>
 pub struct Id<T> {
     raw: u32,
     _ty: PhantomData<fn() -> T>,

--- a/src/internal/arena.rs
+++ b/src/internal/arena.rs
@@ -56,6 +56,11 @@ impl<T> Id<T> {
 }
 
 /// Yet another index-based arena.
+///
+/// An arena is a kind of simple grow-only allocator, backed by a `Vec`
+/// where all items have the same lifetime, making it easier
+/// to have references between those items.
+/// They are all dropped at once when the arena is dropped.
 #[derive(Clone, PartialEq, Eq)]
 pub struct Arena<T> {
     data: Vec<T>,

--- a/src/internal/arena.rs
+++ b/src/internal/arena.rs
@@ -2,7 +2,7 @@ use std::{
     fmt,
     hash::{Hash, Hasher},
     marker::PhantomData,
-    ops::Index,
+    ops::{Index, RangeFrom},
 };
 
 /// The index of a value allocated in an arena that holds `T`s.
@@ -88,11 +88,26 @@ impl<T> Arena<T> {
             _ty: PhantomData,
         }
     }
+
+    pub fn next_id(&self) -> Id<T> {
+        let raw = self.data.len() as u32;
+        Id {
+            raw,
+            _ty: PhantomData,
+        }
+    }
 }
 
 impl<T> Index<Id<T>> for Arena<T> {
     type Output = T;
     fn index(&self, id: Id<T>) -> &T {
         &self.data[id.raw as usize]
+    }
+}
+
+impl<T> Index<RangeFrom<Id<T>>> for Arena<T> {
+    type Output = [T];
+    fn index(&self, id: RangeFrom<Id<T>>) -> &[T] {
+        &self.data[(id.start.raw as usize)..]
     }
 }

--- a/src/internal/assignment.rs
+++ b/src/internal/assignment.rs
@@ -3,8 +3,8 @@
 //! Assignments are the building blocks of a PubGrub partial solution.
 //! (partial solution = the current state of the solution we are building in the algorithm).
 
-use id_arena::{Arena, Id};
-
+use crate::internal::arena::Arena;
+use crate::internal::incompatibility::IncompId;
 use crate::internal::incompatibility::Incompatibility;
 use crate::package::Package;
 use crate::term::Term;
@@ -27,7 +27,7 @@ pub enum Assignment<P: Package, V: Version> {
         /// The package corresponding to the derivation.
         package: P,
         /// Incompatibility cause of the derivation.
-        cause: Id<Incompatibility<P, V>>,
+        cause: IncompId<P, V>,
     },
 }
 

--- a/src/internal/assignment.rs
+++ b/src/internal/assignment.rs
@@ -3,6 +3,8 @@
 //! Assignments are the building blocks of a PubGrub partial solution.
 //! (partial solution = the current state of the solution we are building in the algorithm).
 
+use id_arena::{Arena, Id};
+
 use crate::internal::incompatibility::Incompatibility;
 use crate::package::Package;
 use crate::term::Term;
@@ -25,7 +27,7 @@ pub enum Assignment<P: Package, V: Version> {
         /// The package corresponding to the derivation.
         package: P,
         /// Incompatibility cause of the derivation.
-        cause: Incompatibility<P, V>,
+        cause: Id<Incompatibility<P, V>>,
     },
 }
 
@@ -41,10 +43,10 @@ impl<P: Package, V: Version> Assignment<P, V> {
     /// Retrieve the current assignment as a [Term].
     /// If this is decision, it returns a positive term with that exact version.
     /// Otherwise, if this is a derivation, just returns its term.
-    pub fn as_term(&self) -> Term<V> {
+    pub fn as_term(&self, store: &Arena<Incompatibility<P, V>>) -> Term<V> {
         match &self {
             Self::Decision { version, .. } => Term::exact(version.clone()),
-            Self::Derivation { package, cause } => cause.get(&package).unwrap().negate(),
+            Self::Derivation { package, cause } => store[*cause].get(&package).unwrap().negate(),
         }
     }
 }

--- a/src/internal/core.rs
+++ b/src/internal/core.rs
@@ -117,47 +117,47 @@ impl<P: Package, V: Version> State<P, V> {
         &mut self,
         incompatibility: IncompId<P, V>,
     ) -> Result<(P, IncompId<P, V>), PubGrubError<P, V>> {
-        let mut current_incompat = incompatibility;
+        let mut current_incompat_id = incompatibility;
         let mut current_incompat_changed = false;
         loop {
-            if self.incompatibility_store[current_incompat]
+            if self.incompatibility_store[current_incompat_id]
                 .is_terminal(&self.root_package, &self.root_version)
             {
                 return Err(PubGrubError::NoSolution(
-                    self.build_derivation_tree(current_incompat),
+                    self.build_derivation_tree(current_incompat_id),
                 ));
             } else {
                 let (satisfier, satisfier_level, previous_satisfier_level) = self
                     .partial_solution
                     .find_satisfier_and_previous_satisfier_level(
-                        &self.incompatibility_store[current_incompat],
+                        &self.incompatibility_store[current_incompat_id],
                         &self.incompatibility_store,
                     );
                 match satisfier {
                     Decision { package, .. } => {
                         self.backtrack(
-                            current_incompat,
+                            current_incompat_id,
                             current_incompat_changed,
                             previous_satisfier_level,
                         );
-                        return Ok((package, current_incompat));
+                        return Ok((package, current_incompat_id));
                     }
                     Derivation { cause, package } => {
                         if previous_satisfier_level != satisfier_level {
                             self.backtrack(
-                                current_incompat,
+                                current_incompat_id,
                                 current_incompat_changed,
                                 previous_satisfier_level,
                             );
-                            return Ok((package, current_incompat));
+                            return Ok((package, current_incompat_id));
                         } else {
                             let prior_cause = Incompatibility::prior_cause(
-                                current_incompat,
+                                current_incompat_id,
                                 cause,
                                 &package,
                                 &self.incompatibility_store,
                             );
-                            current_incompat = self.incompatibility_store.alloc(prior_cause);
+                            current_incompat_id = self.incompatibility_store.alloc(prior_cause);
                             current_incompat_changed = true;
                         }
                     }

--- a/src/internal/core.rs
+++ b/src/internal/core.rs
@@ -13,6 +13,8 @@ use crate::package::Package;
 use crate::report::DerivationTree;
 use crate::version::Version;
 
+use id_arena::{Arena, Id};
+
 /// Current state of the PubGrub algorithm.
 #[derive(Clone)]
 pub struct State<P: Package, V: Version> {
@@ -20,18 +22,14 @@ pub struct State<P: Package, V: Version> {
     root_version: V,
 
     /// TODO: remove pub.
-    pub incompatibilities: Rc<Vec<Incompatibility<P, V>>>,
+    pub incompatibilities: Rc<Vec<Id<Incompatibility<P, V>>>>,
 
     /// Partial solution.
     /// TODO: remove pub.
     pub partial_solution: PartialSolution<P, V>,
 
     /// The store is the reference storage for all incompatibilities.
-    /// The id field in one incompatibility refers
-    /// to the position in the [incompatibility_store](State::incompatibility_store) vec,
-    /// NOT the position in the [incompatibilities](State::incompatibilities) vec.
-    /// TODO: remove pub.
-    pub incompatibility_store: Vec<Incompatibility<P, V>>,
+    pub incompatibility_store: Arena<Incompatibility<P, V>>,
 
     /// This is a stack of work to be done in `unit_propagation`.
     /// It can definitely be a local variable to that method, but
@@ -42,25 +40,28 @@ pub struct State<P: Package, V: Version> {
 impl<P: Package, V: Version> State<P, V> {
     /// Initialization of PubGrub state.
     pub fn init(root_package: P, root_version: V) -> Self {
-        let not_root_incompat =
-            Incompatibility::not_root(0, root_package.clone(), root_version.clone());
+        let mut incompatibility_store = Arena::with_capacity(2);
+        let not_root_id = incompatibility_store.alloc(Incompatibility::not_root(
+            root_package.clone(),
+            root_version.clone(),
+        ));
         Self {
             root_package,
             root_version,
-            incompatibilities: Rc::new(vec![not_root_incompat.clone()]),
+            incompatibilities: Rc::new(vec![not_root_id]),
             partial_solution: PartialSolution::empty(),
-            incompatibility_store: vec![not_root_incompat],
+            incompatibility_store,
             unit_propagation_buffer: vec![],
         }
     }
 
     /// Add an incompatibility to the state.
-    pub fn add_incompatibility<F: Fn(usize) -> Incompatibility<P, V>>(&mut self, gen_incompat: F) {
-        let incompat = gen_incompat(self.incompatibility_store.len());
-        self.incompatibility_store.push(incompat.clone());
-        incompat.merge_into(Rc::make_mut(&mut self.incompatibilities));
+    pub fn add_incompatibility(&mut self, incompat: Incompatibility<P, V>) {
+        Incompatibility::merge_into(
+            self.incompatibility_store.alloc(incompat),
+            Rc::make_mut(&mut self.incompatibilities),
+        );
     }
-
     /// Check if an incompatibility is terminal.
     pub fn is_terminal(&self, incompatibility: &Incompatibility<P, V>) -> bool {
         incompatibility.is_terminal(&self.root_package, &self.root_version)
@@ -74,27 +75,36 @@ impl<P: Package, V: Version> State<P, V> {
         while let Some(current_package) = self.unit_propagation_buffer.pop() {
             // Iterate over incompatibilities in reverse order
             // to evaluate first the newest incompatibilities.
-            for incompat in Rc::clone(&self.incompatibilities).iter().rev() {
+            for &incompat_id in Rc::clone(&self.incompatibilities).iter().rev() {
                 // We only care about that incompatibility if it contains the current package.
-                if incompat.get(&current_package) == None {
+                if self.incompatibility_store[incompat_id].get(&current_package) == None {
                     continue;
                 }
-                match self.partial_solution.relation(&incompat) {
+                match self
+                    .partial_solution
+                    .relation(&self.incompatibility_store[incompat_id])
+                {
                     // If the partial solution satisfies the incompatibility
                     // we must perform conflict resolution.
                     Relation::Satisfied => {
-                        let (package_almost, root_cause) = self.conflict_resolution(&incompat)?;
+                        let (package_almost, root_cause) = self.conflict_resolution(incompat_id)?;
                         self.unit_propagation_buffer.clear();
                         self.unit_propagation_buffer.push(package_almost.clone());
                         // Add to the partial solution with incompat as cause.
-                        self.partial_solution
-                            .add_derivation(package_almost, root_cause);
+                        self.partial_solution.add_derivation(
+                            package_almost,
+                            root_cause,
+                            &self.incompatibility_store,
+                        );
                     }
                     Relation::AlmostSatisfied(package_almost) => {
                         self.unit_propagation_buffer.push(package_almost.clone());
                         // Add (not term) to the partial solution with incompat as cause.
-                        self.partial_solution
-                            .add_derivation(package_almost, incompat.clone());
+                        self.partial_solution.add_derivation(
+                            package_almost,
+                            incompat_id,
+                            &self.incompatibility_store,
+                        );
                     }
                     _ => {}
                 }
@@ -108,23 +118,28 @@ impl<P: Package, V: Version> State<P, V> {
     /// CF <https://github.com/dart-lang/pub/blob/master/doc/solver.md#unit-propagation>
     fn conflict_resolution(
         &mut self,
-        incompatibility: &Incompatibility<P, V>,
-    ) -> Result<(P, Incompatibility<P, V>), PubGrubError<P, V>> {
-        let mut current_incompat = incompatibility.clone();
+        incompatibility: Id<Incompatibility<P, V>>,
+    ) -> Result<(P, Id<Incompatibility<P, V>>), PubGrubError<P, V>> {
+        let mut current_incompat = incompatibility;
         let mut current_incompat_changed = false;
         loop {
-            if current_incompat.is_terminal(&self.root_package, &self.root_version) {
+            if self.incompatibility_store[current_incompat]
+                .is_terminal(&self.root_package, &self.root_version)
+            {
                 return Err(PubGrubError::NoSolution(
-                    self.build_derivation_tree(&current_incompat),
+                    self.build_derivation_tree(current_incompat),
                 ));
             } else {
                 let (satisfier, satisfier_level, previous_satisfier_level) = self
                     .partial_solution
-                    .find_satisfier_and_previous_satisfier_level(&current_incompat);
+                    .find_satisfier_and_previous_satisfier_level(
+                        &self.incompatibility_store[current_incompat],
+                        &self.incompatibility_store,
+                    );
                 match satisfier {
                     Decision { package, .. } => {
                         self.backtrack(
-                            current_incompat.clone(),
+                            current_incompat,
                             current_incompat_changed,
                             previous_satisfier_level,
                         );
@@ -133,21 +148,19 @@ impl<P: Package, V: Version> State<P, V> {
                     Derivation { cause, package } => {
                         if previous_satisfier_level != satisfier_level {
                             self.backtrack(
-                                current_incompat.clone(),
+                                current_incompat,
                                 current_incompat_changed,
                                 previous_satisfier_level,
                             );
                             return Ok((package, current_incompat));
                         } else {
-                            let id = self.incompatibility_store.len();
                             let prior_cause = Incompatibility::prior_cause(
-                                id,
-                                &current_incompat,
-                                &cause,
+                                current_incompat,
+                                cause,
                                 &package,
+                                &self.incompatibility_store,
                             );
-                            self.incompatibility_store.push(prior_cause.clone());
-                            current_incompat = prior_cause;
+                            current_incompat = self.incompatibility_store.alloc(prior_cause);
                             current_incompat_changed = true;
                         }
                     }
@@ -159,36 +172,39 @@ impl<P: Package, V: Version> State<P, V> {
     /// Backtracking.
     fn backtrack(
         &mut self,
-        incompat: Incompatibility<P, V>,
+        incompat: Id<Incompatibility<P, V>>,
         incompat_changed: bool,
         decision_level: DecisionLevel,
     ) {
-        self.partial_solution.backtrack(decision_level);
+        self.partial_solution
+            .backtrack(decision_level, &self.incompatibility_store);
         if incompat_changed {
-            incompat.merge_into(Rc::make_mut(&mut self.incompatibilities));
+            Incompatibility::merge_into(incompat, Rc::make_mut(&mut self.incompatibilities));
         }
     }
 
     // Error reporting #########################################################
 
-    fn build_derivation_tree(&self, incompat: &Incompatibility<P, V>) -> DerivationTree<P, V> {
+    fn build_derivation_tree(&self, incompat: Id<Incompatibility<P, V>>) -> DerivationTree<P, V> {
         let shared_ids = self.find_shared_ids(incompat);
-        incompat.build_derivation_tree(&shared_ids, self.incompatibility_store.as_slice())
+        Incompatibility::build_derivation_tree(incompat, &shared_ids, &self.incompatibility_store)
     }
 
-    fn find_shared_ids(&self, incompat: &Incompatibility<P, V>) -> Set<usize> {
+    fn find_shared_ids(
+        &self,
+        incompat: Id<Incompatibility<P, V>>,
+    ) -> Set<Id<Incompatibility<P, V>>> {
         let mut all_ids = Set::new();
         let mut shared_ids = Set::new();
-        let mut stack = Vec::new();
-        stack.push(incompat);
+        let mut stack = vec![incompat];
         while let Some(i) = stack.pop() {
-            if let Some((id1, id2)) = i.causes() {
-                if all_ids.contains(&i.id) {
-                    shared_ids.insert(i.id);
+            if let Some((id1, id2)) = self.incompatibility_store[i].causes() {
+                if all_ids.contains(&i) {
+                    shared_ids.insert(i);
                 } else {
-                    all_ids.insert(i.id);
-                    stack.push(&self.incompatibility_store[id1]);
-                    stack.push(&self.incompatibility_store[id2]);
+                    all_ids.insert(i);
+                    stack.push(id1);
+                    stack.push(id2);
                 }
             }
         }

--- a/src/internal/core.rs
+++ b/src/internal/core.rs
@@ -75,14 +75,12 @@ impl<P: Package, V: Version> State<P, V> {
             // Iterate over incompatibilities in reverse order
             // to evaluate first the newest incompatibilities.
             for &incompat_id in Rc::clone(&self.incompatibilities).iter().rev() {
+                let current_incompat = &self.incompatibility_store[incompat_id];
                 // We only care about that incompatibility if it contains the current package.
-                if self.incompatibility_store[incompat_id].get(&current_package) == None {
+                if current_incompat.get(&current_package).is_none() {
                     continue;
                 }
-                match self
-                    .partial_solution
-                    .relation(&self.incompatibility_store[incompat_id])
-                {
+                match self.partial_solution.relation(current_incompat) {
                     // If the partial solution satisfies the incompatibility
                     // we must perform conflict resolution.
                     Relation::Satisfied => {

--- a/src/internal/incompatibility.rs
+++ b/src/internal/incompatibility.rs
@@ -14,6 +14,7 @@ use crate::report::{DefaultStringReporter, DerivationTree, Derived, External};
 use crate::solver::DependencyConstraints;
 use crate::term::{self, Term};
 use crate::version::Version;
+
 /// An incompatibility is a set of terms for different packages
 /// that should never be satisfied all together.
 /// An incompatibility usually originates from a package dependency.
@@ -35,6 +36,7 @@ pub struct Incompatibility<P: Package, V: Version> {
     kind: Kind<P, V>,
 }
 
+/// Type alias of unique identifiers for incompatibilities.
 pub type IncompId<P, V> = Id<Incompatibility<P, V>>;
 
 #[derive(Debug, Clone)]

--- a/src/internal/incompatibility.rs
+++ b/src/internal/incompatibility.rs
@@ -11,7 +11,6 @@ use crate::internal::small_map::SmallMap;
 use crate::package::Package;
 use crate::range::Range;
 use crate::report::{DefaultStringReporter, DerivationTree, Derived, External};
-use crate::solver::DependencyConstraints;
 use crate::term::{self, Term};
 use crate::version::Version;
 
@@ -109,19 +108,8 @@ impl<P: Package, V: Version> Incompatibility<P, V> {
         }
     }
 
-    /// Generate a list of incompatibilities from direct dependencies of a package.
-    pub fn from_dependencies(
-        package: P,
-        version: V,
-        deps: &DependencyConstraints<P, V>,
-    ) -> Vec<Self> {
-        deps.iter()
-            .map(|dep| Self::from_dependency(package.clone(), version.clone(), dep))
-            .collect()
-    }
-
     /// Build an incompatibility from a given dependency.
-    fn from_dependency(package: P, version: V, dep: (&P, &Range<V>)) -> Self {
+    pub fn from_dependency(package: P, version: V, dep: (&P, &Range<V>)) -> Self {
         let range1 = Range::exact(version);
         let (p2, range2) = dep;
         Self {

--- a/src/internal/incompatibility.rs
+++ b/src/internal/incompatibility.rs
@@ -169,12 +169,12 @@ impl<P: Package, V: Version> Incompatibility<P, V> {
         let kind = Kind::DerivedFrom(incompat, satisfier_cause);
         let mut package_terms = incompatibility_store[incompat].package_terms.clone();
         let t1 = package_terms.remove(package).unwrap();
-        let statisfier_cause_terms = &incompatibility_store[satisfier_cause].package_terms;
+        let satisfier_cause_terms = &incompatibility_store[satisfier_cause].package_terms;
         package_terms.merge(
-            statisfier_cause_terms.iter().filter(|(p, _)| p != &package),
+            satisfier_cause_terms.iter().filter(|(p, _)| p != &package),
             |t1, t2| Some(t1.intersection(t2)),
         );
-        let term = t1.union(statisfier_cause_terms.get(package).unwrap());
+        let term = t1.union(satisfier_cause_terms.get(package).unwrap());
         if term != Term::any() {
             package_terms.insert(package.clone(), term);
         }

--- a/src/internal/incompatibility.rs
+++ b/src/internal/incompatibility.rs
@@ -169,19 +169,12 @@ impl<P: Package, V: Version> Incompatibility<P, V> {
         let kind = Kind::DerivedFrom(incompat, satisfier_cause);
         let mut package_terms = incompatibility_store[incompat].package_terms.clone();
         let t1 = package_terms.remove(package).unwrap();
+        let statisfier_cause_terms = &incompatibility_store[satisfier_cause].package_terms;
         package_terms.merge(
-            incompatibility_store[satisfier_cause]
-                .package_terms
-                .iter()
-                .filter(|(p, _)| p != &package),
+            statisfier_cause_terms.iter().filter(|(p, _)| p != &package),
             |t1, t2| Some(t1.intersection(t2)),
         );
-        let term = t1.union(
-            incompatibility_store[satisfier_cause]
-                .package_terms
-                .get(package)
-                .unwrap(),
-        );
+        let term = t1.union(statisfier_cause_terms.get(package).unwrap());
         if term != Term::any() {
             package_terms.insert(package.clone(), term);
         }

--- a/src/internal/memory.rs
+++ b/src/internal/memory.rs
@@ -3,16 +3,14 @@
 //! A Memory acts like a structured partial solution
 //! where terms are regrouped by package in a [Map](crate::type_aliases::Map).
 
-use id_arena::Arena;
-
+use crate::internal::arena::Arena;
 use crate::internal::assignment::Assignment::{self, Decision, Derivation};
+use crate::internal::incompatibility::Incompatibility;
 use crate::package::Package;
 use crate::range::Range;
 use crate::term::Term;
 use crate::type_aliases::{Map, SelectedDependencies};
 use crate::version::Version;
-
-use super::incompatibility::Incompatibility;
 
 /// A memory is the set of all assignments in the partial solution,
 /// organized by package instead of historically ordered.

--- a/src/internal/mod.rs
+++ b/src/internal/mod.rs
@@ -2,6 +2,7 @@
 
 //! Non exposed modules.
 
+pub mod arena;
 pub mod assignment;
 pub mod core;
 pub mod incompatibility;

--- a/src/internal/partial_solution.rs
+++ b/src/internal/partial_solution.rs
@@ -3,9 +3,9 @@
 //! The partial solution is the current state
 //! of the solution being built by the algorithm.
 
-use id_arena::{Arena, Id};
-
+use crate::internal::arena::Arena;
 use crate::internal::assignment::Assignment::{self, Decision, Derivation};
+use crate::internal::incompatibility::IncompId;
 use crate::internal::incompatibility::{Incompatibility, Relation};
 use crate::internal::memory::Memory;
 use crate::package::Package;
@@ -91,7 +91,7 @@ impl<P: Package, V: Version> PartialSolution<P, V> {
     pub fn add_derivation(
         &mut self,
         package: P,
-        cause: Id<Incompatibility<P, V>>,
+        cause: IncompId<P, V>,
         store: &Arena<Incompatibility<P, V>>,
     ) {
         self.add_assignment(Derivation { package, cause }, store);

--- a/src/internal/partial_solution.rs
+++ b/src/internal/partial_solution.rs
@@ -13,6 +13,7 @@ use crate::range::Range;
 use crate::term::Term;
 use crate::type_aliases::{Map, SelectedDependencies};
 use crate::version::Version;
+use std::ops::RangeFrom;
 
 #[derive(Debug, Copy, Clone, Ord, PartialOrd, Eq, PartialEq)]
 pub struct DecisionLevel(u32);
@@ -157,7 +158,7 @@ impl<P: Package, V: Version> PartialSolution<P, V> {
         &mut self,
         package: P,
         version: V,
-        new_incompatibilities: &[Incompatibility<P, V>],
+        new_incompatibilities: RangeFrom<IncompId<P, V>>,
         store: &Arena<Incompatibility<P, V>>,
     ) {
         let not_satisfied = |incompat: &Incompatibility<P, V>| {
@@ -172,7 +173,7 @@ impl<P: Package, V: Version> PartialSolution<P, V> {
 
         // Check none of the dependencies (new_incompatibilities)
         // would create a conflict (be satisfied).
-        if new_incompatibilities.iter().all(not_satisfied) {
+        if store[new_incompatibilities].iter().all(not_satisfied) {
             self.add_decision(package, version, store);
         }
     }

--- a/src/internal/partial_solution.rs
+++ b/src/internal/partial_solution.rs
@@ -13,7 +13,6 @@ use crate::range::Range;
 use crate::term::Term;
 use crate::type_aliases::{Map, SelectedDependencies};
 use crate::version::Version;
-use std::ops::RangeFrom;
 
 #[derive(Debug, Copy, Clone, Ord, PartialOrd, Eq, PartialEq)]
 pub struct DecisionLevel(u32);
@@ -158,7 +157,7 @@ impl<P: Package, V: Version> PartialSolution<P, V> {
         &mut self,
         package: P,
         version: V,
-        new_incompatibilities: RangeFrom<IncompId<P, V>>,
+        new_incompatibilities: std::ops::Range<IncompId<P, V>>,
         store: &Arena<Incompatibility<P, V>>,
     ) {
         let not_satisfied = |incompat: &Incompatibility<P, V>| {

--- a/src/solver.rs
+++ b/src/solver.rs
@@ -192,13 +192,18 @@ pub fn resolve<P: Package, V: Version>(
                     "Root package depends on itself at a different version?".into(),
                 ));
             }
-            state
-                .partial_solution
-                .add_version(p.clone(), v, &dep_incompats, &state.incompatibility_store);
+            state.partial_solution.add_version(
+                p.clone(),
+                v,
+                &dep_incompats,
+                &state.incompatibility_store,
+            );
         } else {
             // `dep_incompats` are already in `incompatibilities` so we know there are not satisfied
             // terms and can add the decision directly.
-            state.partial_solution.add_decision(next.clone(), v, &state.incompatibility_store);
+            state
+                .partial_solution
+                .add_decision(next.clone(), v, &state.incompatibility_store);
         }
     }
 }

--- a/src/solver.rs
+++ b/src/solver.rs
@@ -177,12 +177,9 @@ pub fn resolve<P: Package, V: Version>(
 
             // Add that package and version if the dependencies are not problematic.
             let dep_incompats =
-                Incompatibility::from_dependencies(p.clone(), v.clone(), &dependencies);
+                state.add_incompatibility_from_dependencies(p.clone(), v.clone(), &dependencies);
 
-            for incompat in dep_incompats.iter() {
-                state.add_incompatibility(incompat.clone());
-            }
-            if dep_incompats
+            if state.incompatibility_store[dep_incompats.clone()]
                 .iter()
                 .any(|incompat| state.is_terminal(incompat))
             {
@@ -195,7 +192,7 @@ pub fn resolve<P: Package, V: Version>(
             state.partial_solution.add_version(
                 p.clone(),
                 v,
-                &dep_incompats,
+                dep_incompats,
                 &state.incompatibility_store,
             );
         } else {


### PR DESCRIPTION
closes #21.

Conceptually, this moves the id's out of the `Incompatibility`. Then it changes `usize` to an `Id<Incompatibility<P, V>>` to make sure that we only use these Ids to index into the `incompatibility_store`.

In the first commit this is accomplished by using the `id-arena` crate. That crate has some complexity to make sure at run time that an `Id<T>` is only used with the correct `Arena<T>`. We only have the one `Arena` so don't need that check. And if we get more `Arena`'s I can only imagine getting one per type.  So the second commit wraps a `Vec` ourselves. For ~80 LOC I don't think the dependency pulls its weight.

There is an alternative approach based on the `typed-arena` crate, I tested that approach in the [no-ids branch](https://github.com/pubgrub-rs/pubgrub/tree/no-ids). That crate uses some unsafe to let us use `&Incompatibility<P, V>` as our `Id` type. This is very convenient in many ways, mostly that we don't need a `Id` and a `&incompatibility_store` to get at methods of the `Incompatibility`. But it does need a lifetime to make the compiler happy, and the `'arena` is just as inconvenient to carry around as the `&incompatibility_store`. So all told I don't think it pulls its weight, as compared to the version in this PR.

The exact perf impacts depend on which variation is being tested, and on top of which other optimizations. For example this PR (commit 33735521dcbe6fbf31a78bab28b3c18ca3ca0bf0) on top of Dev (commit f8432fd84a67bc901f96939cad85ea4e3a306517 + #47 + #46).

```
large_cases/elm-packages_str_SemanticVersion.ron                                                                            
                        time:   [295.60 ms 295.90 ms 296.22 ms]
                        change: [-11.279% -11.151% -11.028%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high mild
large_cases/large_case_u16_NumberVersion.ron                                                                             
                        time:   [16.566 ms 16.609 ms 16.654 ms]
                        change: [-8.4532% -8.1611% -7.8912%] (p = 0.00 < 0.05)
                        Performance has improved.
```
dhat-rs befor
```
dhat: Total:     20,513,896 bytes in 35,475 blocks
dhat: At t-gmax: 430,096 bytes in 108 blocks
```
dhat-rs after
```
dhat: Total:     9,220,412 bytes in 34,708 blocks
dhat: At t-gmax: 121,088 bytes in 100 blocks
```
