### PR TITLE
refactor: inline find_satisfier_helper and try to simplify

### DIFF
--- a/src/internal/core.rs
+++ b/src/internal/core.rs
@@ -157,7 +157,7 @@ impl<P: Package, V: Version> State<P, V> {
                         &self.incompatibility_store[current_incompat_id],
                         &self.incompatibility_store,
                     );
-                match satisfier {
+                match satisfier.clone() {
                     Decision { package, .. } => {
                         self.backtrack(
                             current_incompat_id,

--- a/src/internal/incompatibility.rs
+++ b/src/internal/incompatibility.rs
@@ -221,6 +221,11 @@ impl<P: Package, V: Version> Incompatibility<P, V> {
         self.package_terms.iter()
     }
 
+    // The number of packages.
+    pub fn len(&self) -> usize {
+        self.package_terms.len()
+    }
+
     // Reporting ###############################################################
 
     /// Retrieve parent causes if of type DerivedFrom.

--- a/src/internal/memory.rs
+++ b/src/internal/memory.rs
@@ -68,7 +68,7 @@ impl<P: Package, V: Version> Memory<P, V> {
     }
 
     /// Add a decision to a Memory.
-    fn add_decision(&mut self, package: P, version: V) {
+    pub fn add_decision(&mut self, package: P, version: V) {
         // Check that add_decision is never used in the wrong context.
         if cfg!(debug_assertions) {
             match self.assignments.get_mut(&package) {
@@ -87,7 +87,7 @@ impl<P: Package, V: Version> Memory<P, V> {
     }
 
     /// Add a derivation to a Memory.
-    fn add_derivation(&mut self, package: P, term: Term<V>) {
+    pub fn add_derivation(&mut self, package: P, term: Term<V>) {
         use std::collections::hash_map::Entry;
         match self.assignments.entry(package) {
             Entry::Occupied(mut o) => match o.get_mut() {

--- a/src/internal/partial_solution.rs
+++ b/src/internal/partial_solution.rs
@@ -203,6 +203,9 @@ impl<P: Package, V: Version> PartialSolution<P, V> {
 
     /// A satisfier is the earliest assignment in partial solution such that the incompatibility
     /// is satisfied by the partial solution up to and including that assignment.
+    ///
+    /// Returns a map indicating for each package term, when that was first satisfied in history.
+    /// If we effectively found a satisfier, the returned map must be the same size that incompat.
     fn find_satisfier<'a>(
         incompat: &Incompatibility<P, V>,
         history: &'a [DatedAssignment<P, V>],

--- a/src/solver.rs
+++ b/src/solver.rs
@@ -198,9 +198,7 @@ pub fn resolve<P: Package, V: Version>(
         } else {
             // `dep_incompats` are already in `incompatibilities` so we know there are not satisfied
             // terms and can add the decision directly.
-            state
-                .partial_solution
-                .add_decision(next.clone(), v, &state.incompatibility_store);
+            state.partial_solution.add_decision(next.clone(), v);
         }
     }
 }

--- a/src/version.rs
+++ b/src/version.rs
@@ -81,9 +81,9 @@ impl From<(u32, u32, u32)> for SemanticVersion {
 }
 
 // Convert a version into a tuple (major, minor, patch).
-impl Into<(u32, u32, u32)> for SemanticVersion {
-    fn into(self) -> (u32, u32, u32) {
-        (self.major, self.minor, self.patch)
+impl From<SemanticVersion> for (u32, u32, u32) {
+    fn from(v: SemanticVersion) -> Self {
+        (v.major, v.minor, v.patch)
     }
 }
 
@@ -238,9 +238,9 @@ impl From<u32> for NumberVersion {
 }
 
 // Convert a version into an usize.
-impl Into<u32> for NumberVersion {
-    fn into(self) -> u32 {
-        self.0
+impl From<NumberVersion> for u32 {
+    fn from(version: NumberVersion) -> Self {
+        version.0
     }
 }
 


### PR DESCRIPTION
This PR is intended to refactor the find_satisfier code to make sure I understood it. There are bigger redesigns to data structures (`history`) that should be considered, but I did not want to try them until I was sure I understand this part. I am seeing consistent perf improvements, but that is not intended. The "unrelated" refactor to add_assignment, is salvaged from an attempt at one of the possible redesigns.