### PR TITLE
refactor: make Kind a lot smaller

### DIFF
--- a/src/internal/incompatibility.rs
+++ b/src/internal/incompatibility.rs
@@ -52,19 +52,16 @@ enum Kind<P: Package, V: Version> {
     DerivedFrom(IncompId<P, V>, IncompId<P, V>),
 }
 
-/// A type alias for a pair of [Package] and a corresponding [Term].
-pub type PackageTerm<P, V> = (P, Term<V>);
-
 /// A Relation describes how a set of terms can be compared to an incompatibility.
 /// Typically, the set of terms comes from the partial solution.
 #[derive(Eq, PartialEq)]
-pub enum Relation<P: Package, V: Version> {
+pub enum Relation<P: Package> {
     /// We say that a set of terms S satisfies an incompatibility I
     /// if S satisfies every term in I.
     Satisfied,
     /// We say that S contradicts I
     /// if S contradicts at least one term in I.
-    Contradicted(PackageTerm<P, V>),
+    Contradicted(P),
     /// If S satisfies all but one of I's terms and is inconclusive for the remaining term,
     /// we say S "almost satisfies" I and we call the remaining term the "unsatisfied term".
     AlmostSatisfied(P),
@@ -173,13 +170,13 @@ impl<P: Package, V: Version> Incompatibility<P, V> {
     }
 
     /// CF definition of Relation enum.
-    pub fn relation(&self, mut terms: impl FnMut(&P) -> Option<Term<V>>) -> Relation<P, V> {
+    pub fn relation(&self, mut terms: impl FnMut(&P) -> Option<Term<V>>) -> Relation<P> {
         let mut relation = Relation::Satisfied;
         for (package, incompat_term) in self.package_terms.iter() {
             match terms(package).map(|term| incompat_term.relation_with(&term)) {
                 Some(term::Relation::Satisfied) => {}
                 Some(term::Relation::Contradicted) => {
-                    return Relation::Contradicted((package.clone(), incompat_term.clone()));
+                    return Relation::Contradicted(package.clone());
                 }
                 None | Some(term::Relation::Inconclusive) => {
                     // If a package is not present, the intersection is the same as [Term::any].

--- a/src/internal/partial_solution.rs
+++ b/src/internal/partial_solution.rs
@@ -169,7 +169,7 @@ impl<P: Package, V: Version> PartialSolution<P, V> {
     }
 
     /// Check if the terms in the partial solution satisfy the incompatibility.
-    pub fn relation(&mut self, incompat: &Incompatibility<P, V>) -> Relation<P, V> {
+    pub fn relation(&mut self, incompat: &Incompatibility<P, V>) -> Relation<P> {
         incompat.relation(|package| self.memory.term_intersection_for_package(package).cloned())
     }
 

--- a/src/internal/small_map.rs
+++ b/src/internal/small_map.rs
@@ -1,5 +1,5 @@
 use crate::type_aliases::Map;
-use std::hash::Hash;
+use std::{hash::Hash, ops::Index};
 
 #[derive(Debug, Clone)]
 pub enum SmallMap<K, V> {
@@ -143,6 +143,13 @@ impl<K, V> SmallMap<K, V> {
             Self::Two(_) => 2,
             Self::Flexible(data) => data.len(),
         }
+    }
+}
+
+impl<K: PartialEq + Eq + Hash, V> Index<&K> for SmallMap<K, V> {
+    type Output = V;
+    fn index(&self, key: &K) -> &V {
+        &self.get(key).unwrap()
     }
 }
 

--- a/src/term.rs
+++ b/src/term.rs
@@ -71,6 +71,14 @@ impl<V: Version> Term<V> {
             _ => panic!("Negative term cannot unwrap positive range"),
         }
     }
+
+    /// Unwrap the range contains in the term.
+    pub(crate) fn as_range(&self) -> &Range<V> {
+        match self {
+            Self::Positive(range) => range,
+            Self::Negative(range) => range,
+        }
+    }
 }
 
 /// Set operations with terms.


### PR DESCRIPTION
This is two changes that make `Kind` a lot smaller. That intern makes `Incompatibility` significantly smaller. And as the `incompatibility_store` is a large portion of memory usage, this reduces the total memory usage significantly.

The trick is that data that is going into the `package_terms` does not need to be kept in the `Kind`.

Using dhat-rs I am seeing the elm file go from:
```
dhat: Total:     352,307,668 bytes in 412,858 blocks
dhat: At t-gmax: 118,080 bytes in 58 blocks
```
to:
```
dhat: Total:     252,962,988 bytes in 412,852 blocks
dhat: At t-gmax: 79,168 bytes in 58 blocks
```
So a ~30% reduction.
Unfortunately that did not come with a speedup, but what can you do.