### PR TITLE
refactor: add minor code clean-up

### DIFF
--- a/src/internal/partial_solution.rs
+++ b/src/internal/partial_solution.rs
@@ -179,7 +179,7 @@ impl<P: Package, V: Version> PartialSolution<P, V> {
         incompat: &Incompatibility<P, V>,
         store: &Arena<Incompatibility<P, V>>,
     ) -> (&Assignment<P, V>, DecisionLevel, DecisionLevel) {
-        let satisfier_map = Self::find_satisfier(incompat, self.history.as_slice(), store);
+        let satisfier_map = Self::find_satisfier(incompat, &self.history, store);
         assert_eq!(
             satisfier_map.len(),
             incompat.len(),

--- a/src/internal/small_vec.rs
+++ b/src/internal/small_vec.rs
@@ -1,4 +1,5 @@
-use std::{fmt, ops::Deref};
+use std::fmt;
+use std::ops::Deref;
 
 #[derive(Clone)]
 pub enum SmallVec<T> {

--- a/src/internal/small_vec.rs
+++ b/src/internal/small_vec.rs
@@ -1,4 +1,4 @@
-use std::fmt;
+use std::{fmt, ops::Deref};
 
 #[derive(Clone)]
 pub enum SmallVec<T> {
@@ -38,7 +38,7 @@ impl<T> SmallVec<T> {
         }
     }
 
-    pub fn iter(&self) -> impl Iterator<Item = &T> {
+    pub fn iter(&self) -> std::slice::Iter<'_, T> {
         self.as_slice().iter()
     }
 }
@@ -49,10 +49,28 @@ impl<T> Default for SmallVec<T> {
     }
 }
 
-impl<T: PartialEq> Eq for SmallVec<T> {}
+impl<T> Deref for SmallVec<T> {
+    type Target = [T];
 
-impl<T: PartialEq> PartialEq<SmallVec<T>> for SmallVec<T> {
-    fn eq(&self, other: &SmallVec<T>) -> bool {
+    fn deref(&self) -> &Self::Target {
+        self.as_slice()
+    }
+}
+
+impl<'a, T> IntoIterator for &'a SmallVec<T> {
+    type Item = &'a T;
+
+    type IntoIter = std::slice::Iter<'a, T>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter()
+    }
+}
+
+impl<T: Eq> Eq for SmallVec<T> {}
+
+impl<T: PartialEq> PartialEq for SmallVec<T> {
+    fn eq(&self, other: &Self) -> bool {
         self.as_slice() == other.as_slice()
     }
 }

--- a/src/range.rs
+++ b/src/range.rs
@@ -284,10 +284,11 @@ impl<V: Version> fmt::Display for Range<V> {
     }
 }
 
-fn interval_to_string<V: Version>((start, end): &Interval<V>) -> String {
-    end.as_ref()
-        .map(|end| format!("[ {}, {} [", start, end))
-        .unwrap_or_else(|| format!("[ {}, ∞ [", start))
+fn interval_to_string<V: Version>((start, maybe_end): &Interval<V>) -> String {
+    match maybe_end {
+        Some(end) => format!("[ {}, {} [", start, end),
+        None => format!("[ {}, ∞ [", start),
+    }
 }
 
 // TESTS #######################################################################

--- a/src/range.rs
+++ b/src/range.rs
@@ -125,11 +125,11 @@ impl<V: Version> Range<V> {
     fn negate_segments(start: V, segments: &[Interval<V>]) -> Range<V> {
         let mut complement_segments = SmallVec::empty();
         let mut start = Some(start);
-        for (v1, some_v2) in segments {
+        for (v1, maybe_v2) in segments {
             // start.unwrap() is fine because `segments` is not exposed,
             // and our usage guaranties that only the last segment may contain a None.
             complement_segments.push((start.unwrap(), Some(v1.to_owned())));
-            start = some_v2.to_owned();
+            start = maybe_v2.to_owned();
         }
         if let Some(last) = start {
             complement_segments.push((last, None));
@@ -241,8 +241,8 @@ impl<V: Version> Range<V> {
 impl<V: Version> Range<V> {
     /// Check if a range contains a given version.
     pub fn contains(&self, version: &V) -> bool {
-        for (v1, some_v2) in &self.segments {
-            match some_v2 {
+        for (v1, maybe_v2) in &self.segments {
+            match maybe_v2 {
                 None => return v1 <= version,
                 Some(v2) => {
                     if version < v1 {

--- a/src/report.rs
+++ b/src/report.rs
@@ -3,10 +3,8 @@
 //! Build a report as clear as possible as to why
 //! dependency solving failed.
 
-use std::{
-    fmt,
-    ops::{Deref, DerefMut},
-};
+use std::fmt;
+use std::ops::{Deref, DerefMut};
 
 use crate::package::Package;
 use crate::range::Range;

--- a/src/term.rs
+++ b/src/term.rs
@@ -149,7 +149,7 @@ impl<'a, V: 'a + Version> Term<V> {
     /// Check if a set of terms satisfies or contradicts a given term.
     /// Otherwise the relation is inconclusive.
     pub(crate) fn relation_with(&self, other_terms_intersection: &Term<V>) -> Relation {
-        let full_intersection = self.intersection(other_terms_intersection.as_ref());
+        let full_intersection = self.intersection(other_terms_intersection);
         if &full_intersection == other_terms_intersection {
             Relation::Satisfied
         } else if full_intersection == Self::empty() {

--- a/tests/sat_dependency_provider.rs
+++ b/tests/sat_dependency_provider.rs
@@ -34,8 +34,8 @@ fn sat_at_most_one(solver: &mut impl varisat::ExtendFormula, vars: &[varisat::Va
     // https://www.it.uu.se/research/group/astra/ModRef10/papers/Alan%20M.%20Frisch%20and%20Paul%20A.%20Giannoros.%20SAT%20Encodings%20of%20the%20At-Most-k%20Constraint%20-%20ModRef%202010.pdf
     let bits: Vec<varisat::Var> = solver.new_var_iter(log_bits(vars.len())).collect();
     for (i, p) in vars.iter().enumerate() {
-        for b in 0..bits.len() {
-            solver.add_clause(&[p.negative(), bits[b].lit(((1 << b) & i) > 0)]);
+        for (j, &bit) in bits.iter().enumerate() {
+            solver.add_clause(&[p.negative(), bit.lit(((1 << j) & i) > 0)]);
         }
     }
 }
@@ -79,7 +79,7 @@ impl<P: Package, V: Version> SatResolve<P, V> {
                 Dependencies::Unknown => panic!(),
                 Dependencies::Known(d) => d,
             };
-            for (p1, range) in deps.iter() {
+            for (p1, range) in &deps {
                 let empty_vec = vec![];
                 let mut matches: Vec<varisat::Lit> = all_versions_by_p
                     .get(&p1)


### PR DESCRIPTION
Highlights:

- Add `Deref` and `IntoIterator` impls for `SmallVec` references for convenience
- Shorten code where deref coercion can be applied
- Replace `&*` with explicit `.deref()` calls for readability