### PR TITLE
perf: remove not_intersected_yet

### DIFF
--- a/src/internal/partial_solution.rs
+++ b/src/internal/partial_solution.rs
@@ -96,7 +96,7 @@ impl<P: Package, V: Version> PartialSolution<P, V> {
     }
 
     /// Compute, cache and retrieve the intersection of all terms for this package.
-    pub fn term_intersection_for_package(&mut self, package: &P) -> Option<&Term<V>> {
+    pub fn term_intersection_for_package(&self, package: &P) -> Option<&Term<V>> {
         self.memory.term_intersection_for_package(package)
     }
 
@@ -130,7 +130,7 @@ impl<P: Package, V: Version> PartialSolution<P, V> {
 
     /// Extract potential packages for the next iteration of unit propagation.
     /// Return `None` if there is no suitable package anymore, which stops the algorithm.
-    pub fn potential_packages(&mut self) -> Option<impl Iterator<Item = (&P, &Range<V>)>> {
+    pub fn potential_packages(&self) -> Option<impl Iterator<Item = (&P, &Range<V>)>> {
         let mut iter = self.memory.potential_packages().peekable();
         if iter.peek().is_some() {
             Some(iter)
@@ -151,12 +151,13 @@ impl<P: Package, V: Version> PartialSolution<P, V> {
         new_incompatibilities: std::ops::Range<IncompId<P, V>>,
         store: &Arena<Incompatibility<P, V>>,
     ) {
+        let exact = &Term::exact(version.clone());
         let not_satisfied = |incompat: &Incompatibility<P, V>| {
             incompat.relation(|p| {
                 if p == &package {
-                    Some(Term::exact(version.clone()))
+                    Some(exact)
                 } else {
-                    self.memory.term_intersection_for_package(p).cloned()
+                    self.memory.term_intersection_for_package(p)
                 }
             }) != Relation::Satisfied
         };
@@ -169,8 +170,8 @@ impl<P: Package, V: Version> PartialSolution<P, V> {
     }
 
     /// Check if the terms in the partial solution satisfy the incompatibility.
-    pub fn relation(&mut self, incompat: &Incompatibility<P, V>) -> Relation<P> {
-        incompat.relation(|package| self.memory.term_intersection_for_package(package).cloned())
+    pub fn relation(&self, incompat: &Incompatibility<P, V>) -> Relation<P> {
+        incompat.relation(|package| self.memory.term_intersection_for_package(package))
     }
 
     /// Find satisfier and previous satisfier decision level.


### PR DESCRIPTION
This includes #84, the only new part is the last commit. It is intended to be merged after it.

For a Range an intersection is almost as fast as a clone. By removing the not_intersected_yet optimization we do more intersections and less clones and allocations. This simplifies the code for `term_intersection_for_package` witch is in the hotest part of the of `unit_propagation`.

I was trying this because of how much it simplified the code. It would be worth doing even if it was perf neutral, but I am consistently seeing small perf improvements!

```
Benchmarking large_cases/elm-packages_str_SemanticVersion.ron: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 20.0s. You may wish to increase target time to 28.2s, or reduce sample count to 70.
large_cases/elm-packages_str_SemanticVersion.ron
                        time:   [279.06 ms 279.37 ms 279.67 ms]
                        change: [-6.6904% -6.5466% -6.4031%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high mild
large_cases/large_case_u16_NumberVersion.ron
                        time:   [10.604 ms 10.634 ms 10.670 ms]
                        change: [-10.819% -10.537% -10.273%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 4 outliers among 100 measurements (4.00%)
  4 (4.00%) high severe
Benchmarking large_cases/zuse_str_SemanticVersion.ron: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 20.0s. You may wish to increase target time to 38.2s, or reduce sample count to 50.
large_cases/zuse_str_SemanticVersion.ron
                        time:   [380.02 ms 380.46 ms 380.92 ms]
                        change: [-8.5621% -8.3803% -8.2179%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 8 outliers among 100 measurements (8.00%)
  1 (1.00%) low mild
  5 (5.00%) high mild
  2 (2.00%) high severe
```