### PR TITLE
Use smallvec for unit propagation buffer

### DIFF
--- a/src/internal/core.rs
+++ b/src/internal/core.rs
@@ -93,7 +93,7 @@ impl<P: Package, V: Version> State<P, V> {
     /// Unit propagation is the core mechanism of the solving algorithm.
     /// CF <https://github.com/dart-lang/pub/blob/master/doc/solver.md#unit-propagation>
     pub fn unit_propagation(&mut self, package: P) -> Result<(), PubGrubError<P, V>> {
-        self.unit_propagation_buffer = SmallVec::Empty;
+        self.unit_propagation_buffer.clear();
         self.unit_propagation_buffer.push(package);
         while let Some(current_package) = self.unit_propagation_buffer.pop() {
             // Iterate over incompatibilities in reverse order
@@ -123,7 +123,7 @@ impl<P: Package, V: Version> State<P, V> {
             }
             if let Some(incompat_id) = conflict_id {
                 let (package_almost, root_cause) = self.conflict_resolution(incompat_id)?;
-                self.unit_propagation_buffer = SmallVec::Empty;
+                self.unit_propagation_buffer.clear();
                 self.unit_propagation_buffer.push(package_almost.clone());
                 // Add to the partial solution with incompat as cause.
                 self.partial_solution.add_derivation(

--- a/src/internal/small_vec.rs
+++ b/src/internal/small_vec.rs
@@ -39,6 +39,21 @@ impl<T> SmallVec<T> {
         }
     }
 
+    pub fn pop(&mut self) -> Option<T> {
+        match std::mem::take(self) {
+            Self::Empty => None,
+            Self::One([v1]) => {
+                *self = Self::Empty;
+                Some(v1)
+            }
+            Self::Two([v1, v2]) => {
+                *self = Self::One([v1]);
+                Some(v2)
+            }
+            Self::Flexible(mut v) => v.pop(),
+        }
+    }
+
     pub fn iter(&self) -> std::slice::Iter<'_, T> {
         self.as_slice().iter()
     }

--- a/src/internal/small_vec.rs
+++ b/src/internal/small_vec.rs
@@ -58,6 +58,13 @@ impl<T> SmallVec<T> {
         }
     }
 
+    pub fn clear(&mut self) {
+        if let Self::Flexible(mut v) = std::mem::take(self) {
+            v.clear();
+            *self = Self::Flexible(v);
+        } // else: self already eq Empty from the take
+    }
+
     pub fn iter(&self) -> std::slice::Iter<'_, T> {
         self.as_slice().iter()
     }

--- a/src/internal/small_vec.rs
+++ b/src/internal/small_vec.rs
@@ -50,7 +50,11 @@ impl<T> SmallVec<T> {
                 *self = Self::One([v1]);
                 Some(v2)
             }
-            Self::Flexible(mut v) => v.pop(),
+            Self::Flexible(mut v) => {
+                let out = v.pop();
+                *self = Self::Flexible(v);
+                out
+            }
         }
     }
 
@@ -114,5 +118,33 @@ impl<'de, T: serde::Deserialize<'de>> serde::Deserialize<'de> for SmallVec<T> {
             v.push(item);
         }
         Ok(v)
+    }
+}
+
+// TESTS #######################################################################
+
+#[cfg(test)]
+pub mod tests {
+    use super::*;
+    use proptest::prelude::*;
+
+    proptest! {
+        #[test]
+        fn push_and_pop(comands: Vec<Option<u8>>) {
+            let mut v = vec![];
+            let mut sv = SmallVec::Empty;
+            for comand in comands {
+                match comand {
+                    Some(i) => {
+                        v.push(i);
+                        sv.push(i);
+                    }
+                    None => {
+                        assert_eq!(v.pop(), sv.pop());
+                    }
+                }
+                assert_eq!(v.as_slice(), sv.as_slice());
+            }
+        }
     }
 }


### PR DESCRIPTION
It occurred to me while reading your last PR that the unit propagation buffer follows most of the time a succession of push/pop, making it rather small during most operations. So I tried using `SmallVec` for it and I seem to be getting roughly 10% perf improvements on the elm and synthetic benchmarks. Let me know if you get the same.

The one thing that's a bit annoying me is that I didn't handle the case when `pop` should make the small vec not a `Vec` anymore. I didn't do it both because I was lazy, and because I thought it would prevent the optimization of having that vec only allocated once (but I didn't check).