### PR TITLE
Remove contradicted incompatibilities

### DIFF
--- a/src/internal/arena.rs
+++ b/src/internal/arena.rs
@@ -91,6 +91,10 @@ impl<T> Arena<T> {
         Arena { data: Vec::new() }
     }
 
+    pub fn len(&self) -> usize {
+        self.data.len()
+    }
+
     pub fn alloc(&mut self, value: T) -> Id<T> {
         let raw = self.data.len();
         self.data.push(value);

--- a/src/internal/arena.rs
+++ b/src/internal/arena.rs
@@ -1,4 +1,5 @@
 use std::{
+    cmp::Ordering,
     fmt,
     hash::{Hash, Hasher},
     marker::PhantomData,
@@ -32,6 +33,18 @@ impl<T> PartialEq for Id<T> {
 }
 
 impl<T> Eq for Id<T> {}
+
+impl<T> PartialOrd for Id<T> {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl<T> Ord for Id<T> {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.raw.cmp(&other.raw)
+    }
+}
 
 impl<T> Hash for Id<T> {
     fn hash<H: Hasher>(&self, state: &mut H) {

--- a/src/internal/core.rs
+++ b/src/internal/core.rs
@@ -214,6 +214,14 @@ impl<P: Package, V: Version> State<P, V> {
         incompat_changed: bool,
         decision_level: DecisionLevel,
     ) {
+        println!(
+            "Contradicted incompat count: {}",
+            self.contradicted_incompatibilities.len()
+        );
+        println!(
+            "Saved incompat count:        {}",
+            self.incompatibility_store.len()
+        );
         self.partial_solution
             .backtrack(decision_level, &self.incompatibility_store);
         self.contradicted_incompatibilities.clear();

--- a/src/internal/memory.rs
+++ b/src/internal/memory.rs
@@ -107,6 +107,12 @@ impl<P: Package, V: Version> Memory<P, V> {
     /// and if it contains at least one positive derivation term
     /// in the partial solution.
     pub fn potential_packages(&self) -> impl Iterator<Item = (&P, &Range<V>)> {
+        // let count = self
+        //     .assignments
+        //     .iter()
+        //     .filter_map(|(p, pa)| pa.potential_package_filter(p))
+        //     .count();
+        // println!("Potential packages count: {}", count);
         self.assignments
             .iter()
             .filter_map(|(p, pa)| pa.potential_package_filter(p))

--- a/src/internal/partial_solution.rs
+++ b/src/internal/partial_solution.rs
@@ -63,7 +63,7 @@ impl<P: Package, V: Version> PartialSolution<P, V> {
 
     /// Add a decision to the partial solution.
     pub fn add_decision(&mut self, package: P, version: V) {
-        println!("Add decision: {} @ {}", &package, &version);
+        // println!("Add decision: {} @ {}", &package, &version);
         self.decision_level = self.decision_level + DecisionLevel(1);
         self.memory.add_decision(package.clone(), version.clone());
         self.history.push(DatedAssignment {

--- a/src/internal/partial_solution.rs
+++ b/src/internal/partial_solution.rs
@@ -63,6 +63,7 @@ impl<P: Package, V: Version> PartialSolution<P, V> {
 
     /// Add a decision to the partial solution.
     pub fn add_decision(&mut self, package: P, version: V) {
+        println!("Add decision: {} @ {}", &package, &version);
         self.decision_level = self.decision_level + DecisionLevel(1);
         self.memory.add_decision(package.clone(), version.clone());
         self.history.push(DatedAssignment {


### PR DESCRIPTION
Inspired by the `contradicted_incompatibilities` change that was recently introduced in #88 I wanted to see if instead of checking for each incompat if it is in `contradicted_incompatibilities`, we could simply remove those contradicted incompats and only add them again when backtracking.

It works, but it's slower. I think because of few downsides:
1. I changed `self.incompatibilities` from a `Map<P, Vec<Id>>` to a `Map<P, Set<Id>>` to be able to remove contradicted incompats
2. We need to transfer incompats from `self.contradicted...` to `self.incompat...` when backtracking.
3. I changed `self.contradicted...` type from `Set<id>` to `Map<P, Set<Id>>` and so we don't know in Id was already contradicted when evaluating the other packages of the same incompat.

Regardless of the fact that it's slower, I thought it was cool enough to share (but not to merge)