### PR TITLE
Heuristic counting dependencies

### DIFF
--- a/benches/large_case.rs
+++ b/benches/large_case.rs
@@ -5,7 +5,7 @@ extern crate criterion;
 use self::criterion::*;
 
 use pubgrub::package::Package;
-use pubgrub::solver::{resolve, OfflineDependencyProvider};
+use pubgrub::solver::{resolve, OfflineDependencyProvider, SmartOfflineDependencyProvider};
 use pubgrub::version::{NumberVersion, SemanticVersion, Version};
 use serde::de::Deserialize;
 use std::hash::Hash;
@@ -14,7 +14,9 @@ fn bench<'a, P: Package + Deserialize<'a>, V: Version + Hash + Deserialize<'a>>(
     b: &mut Bencher,
     case: &'a str,
 ) {
-    let dependency_provider: OfflineDependencyProvider<P, V> = ron::de::from_str(&case).unwrap();
+    // let dependency_provider: OfflineDependencyProvider<P, V> = ron::de::from_str(&case).unwrap();
+    let dependency_provider: SmartOfflineDependencyProvider<P, V> =
+        ron::de::from_str(&case).unwrap();
 
     b.iter(|| {
         for p in dependency_provider.packages() {

--- a/src/solver.rs
+++ b/src/solver.rs
@@ -303,6 +303,113 @@ where
 #[derive(Debug, Clone, Default)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(transparent))]
+pub struct SmartOfflineDependencyProvider<P: Package, V: Version> {
+    dependencies: Map<P, BTreeMap<V, DependencyConstraints<P, V>>>,
+}
+
+impl<P: Package, V: Version> SmartOfflineDependencyProvider<P, V> {
+    /// Creates an empty SmartOfflineDependencyProvider with no dependencies.
+    pub fn new() -> Self {
+        Self {
+            dependencies: Map::default(),
+        }
+    }
+
+    /// Registers the dependencies of a package and version pair.
+    /// Dependencies must be added with a single call to
+    /// [add_dependencies](SmartOfflineDependencyProvider::add_dependencies).
+    /// All subsequent calls to
+    /// [add_dependencies](SmartOfflineDependencyProvider::add_dependencies) for a given
+    /// package version pair will replace the dependencies by the new ones.
+    ///
+    /// The API does not allow to add dependencies one at a time to uphold an assumption that
+    /// [SmartOfflineDependencyProvider.get_dependencies(p, v)](SmartOfflineDependencyProvider::get_dependencies)
+    /// provides all dependencies of a given package (p) and version (v) pair.
+    pub fn add_dependencies<I: IntoIterator<Item = (P, Range<V>)>>(
+        &mut self,
+        package: P,
+        version: impl Into<V>,
+        dependencies: I,
+    ) {
+        let package_deps = dependencies.into_iter().collect();
+        let v = version.into();
+        *self
+            .dependencies
+            .entry(package)
+            .or_default()
+            .entry(v)
+            .or_default() = package_deps;
+    }
+
+    /// Lists packages that have been saved.
+    pub fn packages(&self) -> impl Iterator<Item = &P> {
+        self.dependencies.keys()
+    }
+
+    /// Lists versions of saved packages in sorted order.
+    /// Returns [None] if no information is available regarding that package.
+    pub fn versions(&self, package: &P) -> Option<impl Iterator<Item = &V>> {
+        self.dependencies.get(package).map(|k| k.keys())
+    }
+
+    /// Lists dependencies of a given package and version.
+    /// Returns [None] if no information is available regarding that package and version pair.
+    fn dependencies(&self, package: &P, version: &V) -> Option<DependencyConstraints<P, V>> {
+        self.dependencies.get(package)?.get(version).cloned()
+    }
+}
+
+/// An implementation of [DependencyProvider] that
+/// contains all dependency information available in memory.
+/// Packages are picked with the fewest versions contained in the constraints first.
+/// Versions are picked with the newest versions first.
+impl<P: Package, V: Version> DependencyProvider<P, V> for SmartOfflineDependencyProvider<P, V> {
+    fn choose_package_version<T: Borrow<P>, U: Borrow<Range<V>>>(
+        &self,
+        potential_packages: impl Iterator<Item = (T, U)>,
+    ) -> Result<(T, Option<V>), Box<dyn Error>> {
+        let mut lowest_score = usize::MAX;
+        let mut picked_version = None;
+        let mut picked_package = None;
+        for (p, range) in potential_packages {
+            let mut versions_iter = self
+                .dependencies
+                .get(p.borrow())
+                .into_iter()
+                .flat_map(|k| k.iter())
+                .rev()
+                .filter(|(v, _)| range.borrow().contains(v.borrow()));
+            match versions_iter.next() {
+                None => return Ok((p, None)),
+                Some((v, deps)) => {
+                    let score = 1 + versions_iter.count() + deps.len();
+                    if score < lowest_score {
+                        lowest_score = score;
+                        picked_version = Some(v.clone());
+                        picked_package = Some(p);
+                    }
+                }
+            }
+        }
+        Ok((picked_package.unwrap(), picked_version))
+    }
+
+    fn get_dependencies(
+        &self,
+        package: &P,
+        version: &V,
+    ) -> Result<Dependencies<P, V>, Box<dyn Error>> {
+        Ok(match self.dependencies(package, version) {
+            None => Dependencies::Unknown,
+            Some(dependencies) => Dependencies::Known(dependencies),
+        })
+    }
+}
+
+/// A basic implementation of [DependencyProvider].
+#[derive(Debug, Clone, Default)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(transparent))]
 pub struct OfflineDependencyProvider<P: Package, V: Version> {
     dependencies: Map<P, BTreeMap<V, DependencyConstraints<P, V>>>,
 }


### PR DESCRIPTION
I implement a variant of the heuristics we talked about using both the number of versions and the number of dependencies to pick a package. In this implementation, what I'm doing is:
- if there is no valid version, pick that package
- if there is at least one valid version, pick the package with the lowest score, where score is computed as : number of valid versions + number of dependencies of the version we would pick.

I'm seeing respectively 7%, 45% and 10% improvements on the elm, zuse, synthetic benchmarks.