### PR TITLE
Logging to help debugging

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ include = ["Cargo.toml", "LICENSE", "README.md", "src/**", "tests/**", "examples
 thiserror = "1.0"
 rustc-hash = "1.1.0"
 serde = { version = "1.0", features = ["derive"], optional = true }
-log = { version = "0.4.14", default-features = false } # for debug logs in tests
+log = "0.4.14" # for debug logs in tests
 
 [dev-dependencies]
 proptest = "0.10.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,12 +23,14 @@ include = ["Cargo.toml", "LICENSE", "README.md", "src/**", "tests/**", "examples
 thiserror = "1.0"
 rustc-hash = "1.1.0"
 serde = { version = "1.0", features = ["derive"], optional = true }
+log = { version = "0.4.14", default-features = false } # for debug logs in tests
 
 [dev-dependencies]
 proptest = "0.10.1"
 ron = "0.6"
 varisat = "0.2.2"
 criterion = "0.3"
+env_logger = "0.9.0"
 
 [[bench]]
 name = "large_case"

--- a/src/internal/core.rs
+++ b/src/internal/core.rs
@@ -115,6 +115,10 @@ impl<P: Package, V: Version> State<P, V> {
                     // If the partial solution satisfies the incompatibility
                     // we must perform conflict resolution.
                     Relation::Satisfied => {
+                        log::info!(
+                            "Start conflict resolution because incompat satisfied:\n   {}",
+                            current_incompat
+                        );
                         conflict_id = Some(incompat_id);
                         break;
                     }
@@ -183,6 +187,7 @@ impl<P: Package, V: Version> State<P, V> {
                             current_incompat_changed,
                             previous_satisfier_level,
                         );
+                        log::info!("backtrack to {:?}", previous_satisfier_level);
                         return Ok((package, current_incompat_id));
                     }
                     SameDecisionLevels { satisfier_cause } => {
@@ -192,6 +197,7 @@ impl<P: Package, V: Version> State<P, V> {
                             &package,
                             &self.incompatibility_store,
                         );
+                        log::info!("prior cause: {}", prior_cause);
                         current_incompat_id = self.incompatibility_store.alloc(prior_cause);
                         current_incompat_changed = true;
                     }

--- a/src/internal/incompatibility.rs
+++ b/src/internal/incompatibility.rs
@@ -152,7 +152,7 @@ impl<P: Package, V: Version> Incompatibility<P, V> {
             false
         } else {
             let (package, term) = self.package_terms.iter().next().unwrap();
-            (package == root_package) && term.contains(&root_version)
+            (package == root_package) && term.contains(root_version)
         }
     }
 
@@ -220,7 +220,7 @@ impl<'a, P: Package, V: Version + 'a> Incompatibility<P, V> {
     pub fn relation(&self, terms: impl Fn(&P) -> Option<&'a Term<V>>) -> Relation<P> {
         let mut relation = Relation::Satisfied;
         for (package, incompat_term) in self.package_terms.iter() {
-            match terms(package).map(|term| incompat_term.relation_with(&term)) {
+            match terms(package).map(|term| incompat_term.relation_with(term)) {
                 Some(term::Relation::Satisfied) => {}
                 Some(term::Relation::Contradicted) => {
                     return Relation::Contradicted(package.clone());

--- a/src/internal/partial_solution.rs
+++ b/src/internal/partial_solution.rs
@@ -3,7 +3,6 @@
 //! A Memory acts like a structured partial solution
 //! where terms are regrouped by package in a [Map](crate::type_aliases::Map).
 
-use std::collections::BTreeSet;
 use std::fmt::Display;
 
 use crate::internal::arena::Arena;
@@ -37,18 +36,18 @@ pub struct PartialSolution<P: Package, V: Version> {
 
 impl<P: Package, V: Version> Display for PartialSolution<P, V> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let assignments: BTreeSet<String> = self
+        let mut assignments: Vec<_> = self
             .package_assignments
             .iter()
             .map(|(p, pa)| format!("{}: {}", p, pa))
             .collect();
-        let assignments: Vec<_> = assignments.into_iter().collect();
+        assignments.sort();
         write!(
             f,
             "next_global_index: {}\ncurrent_decision_level: {:?}\npackage_assignements:\n{}",
             self.next_global_index,
             self.current_decision_level,
-            assignments.join("\n")
+            assignments.join("\t\n")
         )
     }
 }
@@ -279,7 +278,7 @@ impl<P: Package, V: Version> PartialSolution<P, V> {
                     pa.dated_derivations
                         .iter()
                         .fold(Term::any(), |acc, dated_derivation| {
-                            let term = store[dated_derivation.cause].get(&p).unwrap().negate();
+                            let term = store[dated_derivation.cause].get(p).unwrap().negate();
                             acc.intersection(&term)
                         }),
                 );

--- a/src/internal/partial_solution.rs
+++ b/src/internal/partial_solution.rs
@@ -40,7 +40,7 @@ impl<P: Package, V: Version> Display for PartialSolution<P, V> {
         let assignments: BTreeSet<String> = self
             .package_assignments
             .iter()
-            .map(|(_, pa)| pa.to_string())
+            .map(|(p, pa)| format!("{}: {}", p, pa))
             .collect();
         let assignments: Vec<_> = assignments.into_iter().collect();
         write!(

--- a/src/internal/partial_solution.rs
+++ b/src/internal/partial_solution.rs
@@ -258,7 +258,14 @@ impl<P: Package, V: Version> PartialSolution<P, V> {
         // Check none of the dependencies (new_incompatibilities)
         // would create a conflict (be satisfied).
         if store[new_incompatibilities].iter().all(not_satisfied) {
+            log::info!("add_decision: {} @ {}", package, version);
             self.add_decision(package, version);
+        } else {
+            log::info!(
+                "not adding {} @ {} because of its dependencies",
+                package,
+                version
+            );
         }
     }
 

--- a/src/internal/partial_solution.rs
+++ b/src/internal/partial_solution.rs
@@ -35,7 +35,7 @@ pub struct PartialSolution<P: Package, V: Version> {
     package_assignments: Map<P, PackageAssignments<P, V>>,
 }
 
-impl<P: Package, I: Interval<V>, V: Version> Display for PartialSolution<P, I, V> {
+impl<P: Package, V: Version> Display for PartialSolution<P, V> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let assignments: BTreeSet<String> = self
             .package_assignments
@@ -64,7 +64,7 @@ struct PackageAssignments<P: Package, V: Version> {
     assignments_intersection: AssignmentsIntersection<V>,
 }
 
-impl<P: Package, I: Interval<V>, V: Version> Display for PackageAssignments<P, I, V> {
+impl<P: Package, V: Version> Display for PackageAssignments<P, V> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let derivations: Vec<_> = self
             .dated_derivations
@@ -89,7 +89,7 @@ pub struct DatedDerivation<P: Package, V: Version> {
     cause: IncompId<P, V>,
 }
 
-impl<P: Package, I: Interval<V>, V: Version> Display for DatedDerivation<P, I, V> {
+impl<P: Package, V: Version> Display for DatedDerivation<P, V> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{:?}, cause: {:?}", self.decision_level, self.cause)
     }
@@ -101,7 +101,7 @@ enum AssignmentsIntersection<V: Version> {
     Derivations(Term<V>),
 }
 
-impl<I: Interval<V>, V: Version> Display for AssignmentsIntersection<I, V> {
+impl<V: Version> Display for AssignmentsIntersection<V> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::Decision((lvl, version, _)) => {

--- a/src/internal/partial_solution.rs
+++ b/src/internal/partial_solution.rs
@@ -3,6 +3,9 @@
 //! A Memory acts like a structured partial solution
 //! where terms are regrouped by package in a [Map](crate::type_aliases::Map).
 
+use std::collections::BTreeSet;
+use std::fmt::Display;
+
 use crate::internal::arena::Arena;
 use crate::internal::incompatibility::{IncompId, Incompatibility, Relation};
 use crate::internal::small_map::SmallMap;
@@ -32,6 +35,24 @@ pub struct PartialSolution<P: Package, V: Version> {
     package_assignments: Map<P, PackageAssignments<P, V>>,
 }
 
+impl<P: Package, I: Interval<V>, V: Version> Display for PartialSolution<P, I, V> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let assignments: BTreeSet<String> = self
+            .package_assignments
+            .iter()
+            .map(|(_, pa)| pa.to_string())
+            .collect();
+        let assignments: Vec<_> = assignments.into_iter().collect();
+        write!(
+            f,
+            "next_global_index: {}\ncurrent_decision_level: {:?}\npackage_assignements:\n{}",
+            self.next_global_index,
+            self.current_decision_level,
+            assignments.join("\n")
+        )
+    }
+}
+
 /// Package assignments contain the potential decision and derivations
 /// that have already been made for a given package,
 /// as well as the intersection of terms by all of these.
@@ -43,6 +64,24 @@ struct PackageAssignments<P: Package, V: Version> {
     assignments_intersection: AssignmentsIntersection<V>,
 }
 
+impl<P: Package, I: Interval<V>, V: Version> Display for PackageAssignments<P, I, V> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let derivations: Vec<_> = self
+            .dated_derivations
+            .iter()
+            .map(|dd| dd.to_string())
+            .collect();
+        write!(
+            f,
+            "decision range: {:?}..{:?}\nderivations:\n  {}\n,assignments_intersection: {}",
+            self.smallest_decision_level,
+            self.highest_decision_level,
+            derivations.join("\n  "),
+            self.assignments_intersection
+        )
+    }
+}
+
 #[derive(Clone, Debug)]
 pub struct DatedDerivation<P: Package, V: Version> {
     global_index: u32,
@@ -50,10 +89,27 @@ pub struct DatedDerivation<P: Package, V: Version> {
     cause: IncompId<P, V>,
 }
 
+impl<P: Package, I: Interval<V>, V: Version> Display for DatedDerivation<P, I, V> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{:?}, cause: {:?}", self.decision_level, self.cause)
+    }
+}
+
 #[derive(Clone, Debug)]
 enum AssignmentsIntersection<V: Version> {
     Decision((u32, V, Term<V>)),
     Derivations(Term<V>),
+}
+
+impl<I: Interval<V>, V: Version> Display for AssignmentsIntersection<I, V> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Decision((lvl, version, _)) => {
+                write!(f, "Decision: level {}, v = {}", lvl, version)
+            }
+            Self::Derivations(term) => write!(f, "Derivations term: {}", term),
+        }
+    }
 }
 
 #[derive(Clone, Debug)]

--- a/src/solver.rs
+++ b/src/solver.rs
@@ -92,6 +92,7 @@ pub fn resolve<P: Package, V: Version>(
             .should_cancel()
             .map_err(|err| PubGrubError::ErrorInShouldCancel(err))?;
 
+        log::info!("unit_propagation: {}", &next);
         state.unit_propagation(next)?;
 
         let potential_packages = state.partial_solution.potential_packages();
@@ -109,6 +110,7 @@ pub fn resolve<P: Package, V: Version>(
         let decision = dependency_provider
             .choose_package_version(potential_packages.unwrap())
             .map_err(PubGrubError::ErrorChoosingPackageVersion)?;
+        log::info!("DP chose: {} @ {:?}", decision.0, decision.1);
         next = decision.0.clone();
 
         // Pick the next compatible version.
@@ -195,6 +197,7 @@ pub fn resolve<P: Package, V: Version>(
         } else {
             // `dep_incompats` are already in `incompatibilities` so we know there are not satisfied
             // terms and can add the decision directly.
+            log::info!("add_decision (not first time): {} @ {}", &next, v);
             state.partial_solution.add_decision(next.clone(), v);
         }
     }

--- a/src/solver.rs
+++ b/src/solver.rs
@@ -94,6 +94,10 @@ pub fn resolve<P: Package, V: Version>(
 
         log::info!("unit_propagation: {}", &next);
         state.unit_propagation(next)?;
+        log::debug!(
+            "Partial solution after unit propagation: {}",
+            state.partial_solution
+        );
 
         let potential_packages = state.partial_solution.potential_packages();
         if potential_packages.is_none() {

--- a/src/solver.rs
+++ b/src/solver.rs
@@ -143,38 +143,37 @@ pub fn resolve<P: Package, V: Version>(
         {
             // Retrieve that package dependencies.
             let p = &next;
-            let dependencies =
-                match dependency_provider
-                    .get_dependencies(&p, &v)
-                    .map_err(|err| PubGrubError::ErrorRetrievingDependencies {
-                        package: p.clone(),
-                        version: v.clone(),
-                        source: err,
-                    })? {
-                    Dependencies::Unknown => {
-                        state.add_incompatibility(Incompatibility::unavailable_dependencies(
-                            p.clone(),
-                            v.clone(),
-                        ));
-                        continue;
+            let dependencies = match dependency_provider.get_dependencies(p, &v).map_err(|err| {
+                PubGrubError::ErrorRetrievingDependencies {
+                    package: p.clone(),
+                    version: v.clone(),
+                    source: err,
+                }
+            })? {
+                Dependencies::Unknown => {
+                    state.add_incompatibility(Incompatibility::unavailable_dependencies(
+                        p.clone(),
+                        v.clone(),
+                    ));
+                    continue;
+                }
+                Dependencies::Known(x) => {
+                    if x.contains_key(p) {
+                        return Err(PubGrubError::SelfDependency {
+                            package: p.clone(),
+                            version: v.clone(),
+                        });
                     }
-                    Dependencies::Known(x) => {
-                        if x.contains_key(&p) {
-                            return Err(PubGrubError::SelfDependency {
-                                package: p.clone(),
-                                version: v.clone(),
-                            });
-                        }
-                        if let Some((dependent, _)) = x.iter().find(|(_, r)| r == &&Range::none()) {
-                            return Err(PubGrubError::DependencyOnTheEmptySet {
-                                package: p.clone(),
-                                version: v.clone(),
-                                dependent: dependent.clone(),
-                            });
-                        }
-                        x
+                    if let Some((dependent, _)) = x.iter().find(|(_, r)| r == &&Range::none()) {
+                        return Err(PubGrubError::DependencyOnTheEmptySet {
+                            package: p.clone(),
+                            version: v.clone(),
+                            dependent: dependent.clone(),
+                        });
                     }
-                };
+                    x
+                }
+            };
 
             // Add that package and version if the dependencies are not problematic.
             let dep_incompats =

--- a/src/term.rs
+++ b/src/term.rs
@@ -162,7 +162,7 @@ impl<'a, V: 'a + Version> Term<V> {
 
 impl<V: Version> AsRef<Term<V>> for Term<V> {
     fn as_ref(&self) -> &Term<V> {
-        &self
+        self
     }
 }
 

--- a/tests/examples.rs
+++ b/tests/examples.rs
@@ -5,9 +5,21 @@ use pubgrub::solver::{resolve, OfflineDependencyProvider};
 use pubgrub::type_aliases::Map;
 use pubgrub::version::{NumberVersion, SemanticVersion};
 
+use log::LevelFilter;
+use std::io::Write;
+
+fn init_log() {
+    let _ = env_logger::builder()
+        .filter_level(LevelFilter::Trace)
+        .format(|buf, record| writeln!(buf, "{}", record.args()))
+        .is_test(true)
+        .try_init();
+}
+
 #[test]
 /// https://github.com/dart-lang/pub/blob/master/doc/solver.md#no-conflicts
 fn no_conflict() {
+    init_log();
     let mut dependency_provider = OfflineDependencyProvider::<&str, SemanticVersion>::new();
     #[rustfmt::skip]
         dependency_provider.add_dependencies(
@@ -38,6 +50,7 @@ fn no_conflict() {
 #[test]
 /// https://github.com/dart-lang/pub/blob/master/doc/solver.md#avoiding-conflict-during-decision-making
 fn avoiding_conflict_during_decision_making() {
+    init_log();
     let mut dependency_provider = OfflineDependencyProvider::<&str, SemanticVersion>::new();
     #[rustfmt::skip]
         dependency_provider.add_dependencies(
@@ -73,6 +86,7 @@ fn avoiding_conflict_during_decision_making() {
 #[test]
 /// https://github.com/dart-lang/pub/blob/master/doc/solver.md#performing-conflict-resolution
 fn conflict_resolution() {
+    init_log();
     let mut dependency_provider = OfflineDependencyProvider::<&str, SemanticVersion>::new();
     #[rustfmt::skip]
         dependency_provider.add_dependencies(
@@ -106,6 +120,7 @@ fn conflict_resolution() {
 #[test]
 /// https://github.com/dart-lang/pub/blob/master/doc/solver.md#conflict-resolution-with-a-partial-satisfier
 fn conflict_with_partial_satisfier() {
+    init_log();
     let mut dependency_provider = OfflineDependencyProvider::<&str, SemanticVersion>::new();
     #[rustfmt::skip]
     // root 1.0.0 depends on foo ^1.0.0 and target ^2.0.0
@@ -171,6 +186,7 @@ fn conflict_with_partial_satisfier() {
 ///
 /// Solution: a0, b0, c0, d0
 fn double_choices() {
+    init_log();
     let mut dependency_provider = OfflineDependencyProvider::<&str, NumberVersion>::new();
     dependency_provider.add_dependencies("a", 0, vec![("b", Range::any()), ("c", Range::any())]);
     dependency_provider.add_dependencies("b", 0, vec![("d", Range::exact(0))]);


### PR DESCRIPTION
From my experiments with the interval design, I realized that being able to log the important steps of the solver was quite helpful to locate the origin of bugs. In this PR, I've introduced the `log` crate and added some calls to `log::info!()` in the solver. I've also added `env_logger` to the dev dependencies to be able to display logs in failing tests.

After running the benchmarks, I think this has an impact on the zuse bench where I saw roughly 10% slower performances. I did not notice performance changes on the other benchmarks. I wonder what it is though that could impact performances. I thought the `log` crate did not impact performances if it is not instantiated with a logger. Could this be because the few `Display` implementations that I added on some internal types?