### PR TITLE
Use arrays to provide dependency lists

### DIFF
--- a/examples/branching_error_reporting.rs
+++ b/examples/branching_error_reporting.rs
@@ -13,13 +13,13 @@ fn main() {
     // root 1.0.0 depends on foo ^1.0.0
         dependency_provider.add_dependencies(
         "root", (1, 0, 0),
-        vec![("foo", Range::between((1, 0, 0), (2, 0, 0)))],
+        [("foo", Range::between((1, 0, 0), (2, 0, 0)))],
     );
     #[rustfmt::skip]
     // foo 1.0.0 depends on a ^1.0.0 and b ^1.0.0
         dependency_provider.add_dependencies(
         "foo", (1, 0, 0),
-        vec![
+        [
             ("a", Range::between((1, 0, 0), (2, 0, 0))),
             ("b", Range::between((1, 0, 0), (2, 0, 0))),
         ],
@@ -28,7 +28,7 @@ fn main() {
     // foo 1.1.0 depends on x ^1.0.0 and y ^1.0.0
         dependency_provider.add_dependencies(
         "foo", (1, 1, 0),
-        vec![
+        [
             ("x", Range::between((1, 0, 0), (2, 0, 0))),
             ("y", Range::between((1, 0, 0), (2, 0, 0))),
         ],
@@ -37,20 +37,20 @@ fn main() {
     // a 1.0.0 depends on b ^2.0.0
         dependency_provider.add_dependencies(
         "a", (1, 0, 0),
-        vec![("b", Range::between((2, 0, 0), (3, 0, 0)))],
+        [("b", Range::between((2, 0, 0), (3, 0, 0)))],
     );
     // b 1.0.0 and 2.0.0 have no dependencies.
-    dependency_provider.add_dependencies("b", (1, 0, 0), vec![]);
-    dependency_provider.add_dependencies("b", (2, 0, 0), vec![]);
+    dependency_provider.add_dependencies("b", (1, 0, 0), []);
+    dependency_provider.add_dependencies("b", (2, 0, 0), []);
     #[rustfmt::skip]
     // x 1.0.0 depends on y ^2.0.0.
         dependency_provider.add_dependencies(
         "x", (1, 0, 0),
-        vec![("y", Range::between((2, 0, 0), (3, 0, 0)))],
+        [("y", Range::between((2, 0, 0), (3, 0, 0)))],
     );
     // y 1.0.0 and 2.0.0 have no dependencies.
-    dependency_provider.add_dependencies("y", (1, 0, 0), vec![]);
-    dependency_provider.add_dependencies("y", (2, 0, 0), vec![]);
+    dependency_provider.add_dependencies("y", (1, 0, 0), []);
+    dependency_provider.add_dependencies("y", (2, 0, 0), []);
 
     // Run the algorithm.
     match resolve(&dependency_provider, "root", (1, 0, 0)) {

--- a/examples/caching_dependency_provider.rs
+++ b/examples/caching_dependency_provider.rs
@@ -49,7 +49,7 @@ impl<P: Package, V: Version, DP: DependencyProvider<P, V>> DependencyProvider<P,
                         cache.add_dependencies(
                             package.clone(),
                             version.clone(),
-                            dependencies.clone().into_iter(),
+                            dependencies.clone(),
                         );
                         Ok(Dependencies::Known(dependencies))
                     }

--- a/examples/doc_interface.rs
+++ b/examples/doc_interface.rs
@@ -12,11 +12,11 @@ use pubgrub::version::NumberVersion;
 fn main() {
     let mut dependency_provider = OfflineDependencyProvider::<&str, NumberVersion>::new();
     dependency_provider.add_dependencies(
-        "root", 1, vec![("menu", Range::any()), ("icons", Range::any())],
+        "root", 1, [("menu", Range::any()), ("icons", Range::any())],
     );
-    dependency_provider.add_dependencies("menu", 1, vec![("dropdown", Range::any())]);
-    dependency_provider.add_dependencies("dropdown", 1, vec![("icons", Range::any())]);
-    dependency_provider.add_dependencies("icons", 1, vec![]);
+    dependency_provider.add_dependencies("menu", 1, [("dropdown", Range::any())]);
+    dependency_provider.add_dependencies("dropdown", 1, [("icons", Range::any())]);
+    dependency_provider.add_dependencies("icons", 1, []);
 
     // Run the algorithm.
     let solution = resolve(&dependency_provider, "root", 1);

--- a/examples/doc_interface_error.rs
+++ b/examples/doc_interface_error.rs
@@ -17,57 +17,57 @@ use pubgrub::version::SemanticVersion;
 fn main() {
     let mut dependency_provider = OfflineDependencyProvider::<&str, SemanticVersion>::new();
     // Direct dependencies: menu and icons.
-    dependency_provider.add_dependencies("root", (1, 0, 0), vec![
+    dependency_provider.add_dependencies("root", (1, 0, 0), [
         ("menu", Range::any()),
         ("icons", Range::exact((1, 0, 0))),
         ("intl", Range::exact((5, 0, 0))),
     ]);
 
     // Dependencies of the menu lib.
-    dependency_provider.add_dependencies("menu", (1, 0, 0), vec![
+    dependency_provider.add_dependencies("menu", (1, 0, 0), [
         ("dropdown", Range::strictly_lower_than((2, 0, 0))),
     ]);
-    dependency_provider.add_dependencies("menu", (1, 1, 0), vec![
+    dependency_provider.add_dependencies("menu", (1, 1, 0), [
         ("dropdown", Range::higher_than((2, 0, 0))),
     ]);
-    dependency_provider.add_dependencies("menu", (1, 2, 0), vec![
+    dependency_provider.add_dependencies("menu", (1, 2, 0), [
         ("dropdown", Range::higher_than((2, 0, 0))),
     ]);
-    dependency_provider.add_dependencies("menu", (1, 3, 0), vec![
+    dependency_provider.add_dependencies("menu", (1, 3, 0), [
         ("dropdown", Range::higher_than((2, 0, 0))),
     ]);
-    dependency_provider.add_dependencies("menu", (1, 4, 0), vec![
+    dependency_provider.add_dependencies("menu", (1, 4, 0), [
         ("dropdown", Range::higher_than((2, 0, 0))),
     ]);
-    dependency_provider.add_dependencies("menu", (1, 5, 0), vec![
+    dependency_provider.add_dependencies("menu", (1, 5, 0), [
         ("dropdown", Range::higher_than((2, 0, 0))),
     ]);
 
     // Dependencies of the dropdown lib.
-    dependency_provider.add_dependencies("dropdown", (1, 8, 0), vec![
+    dependency_provider.add_dependencies("dropdown", (1, 8, 0), [
         ("intl", Range::exact((3, 0, 0))),
     ]);
-    dependency_provider.add_dependencies("dropdown", (2, 0, 0), vec![
+    dependency_provider.add_dependencies("dropdown", (2, 0, 0), [
         ("icons", Range::exact((2, 0, 0))),
     ]);
-    dependency_provider.add_dependencies("dropdown", (2, 1, 0), vec![
+    dependency_provider.add_dependencies("dropdown", (2, 1, 0), [
         ("icons", Range::exact((2, 0, 0))),
     ]);
-    dependency_provider.add_dependencies("dropdown", (2, 2, 0), vec![
+    dependency_provider.add_dependencies("dropdown", (2, 2, 0), [
         ("icons", Range::exact((2, 0, 0))),
     ]);
-    dependency_provider.add_dependencies("dropdown", (2, 3, 0), vec![
+    dependency_provider.add_dependencies("dropdown", (2, 3, 0), [
         ("icons", Range::exact((2, 0, 0))),
     ]);
 
     // Icons have no dependencies.
-    dependency_provider.add_dependencies("icons", (1, 0, 0), vec![]);
-    dependency_provider.add_dependencies("icons", (2, 0, 0), vec![]);
+    dependency_provider.add_dependencies("icons", (1, 0, 0), []);
+    dependency_provider.add_dependencies("icons", (2, 0, 0), []);
 
     // Intl have no dependencies.
-    dependency_provider.add_dependencies("intl", (3, 0, 0), vec![]);
-    dependency_provider.add_dependencies("intl", (4, 0, 0), vec![]);
-    dependency_provider.add_dependencies("intl", (5, 0, 0), vec![]);
+    dependency_provider.add_dependencies("intl", (3, 0, 0), []);
+    dependency_provider.add_dependencies("intl", (4, 0, 0), []);
+    dependency_provider.add_dependencies("intl", (5, 0, 0), []);
 
     // Run the algorithm.
     match resolve(&dependency_provider, "root", (1, 0, 0)) {

--- a/examples/doc_interface_semantic.rs
+++ b/examples/doc_interface_semantic.rs
@@ -16,49 +16,49 @@ use pubgrub::version::SemanticVersion;
 fn main() {
     let mut dependency_provider = OfflineDependencyProvider::<&str, SemanticVersion>::new();
     // Direct dependencies: menu and icons.
-    dependency_provider.add_dependencies("root", (1, 0, 0), vec![
+    dependency_provider.add_dependencies("root", (1, 0, 0), [
         ("menu", Range::any()),
         ("icons", Range::exact((1, 0, 0))),
     ]);
 
     // Dependencies of the menu lib.
-    dependency_provider.add_dependencies("menu", (1, 0, 0), vec![
+    dependency_provider.add_dependencies("menu", (1, 0, 0), [
         ("dropdown", Range::strictly_lower_than((2, 0, 0))),
     ]);
-    dependency_provider.add_dependencies("menu", (1, 1, 0), vec![
+    dependency_provider.add_dependencies("menu", (1, 1, 0), [
         ("dropdown", Range::higher_than((2, 0, 0))),
     ]);
-    dependency_provider.add_dependencies("menu", (1, 2, 0), vec![
+    dependency_provider.add_dependencies("menu", (1, 2, 0), [
         ("dropdown", Range::higher_than((2, 0, 0))),
     ]);
-    dependency_provider.add_dependencies("menu", (1, 3, 0), vec![
+    dependency_provider.add_dependencies("menu", (1, 3, 0), [
         ("dropdown", Range::higher_than((2, 0, 0))),
     ]);
-    dependency_provider.add_dependencies("menu", (1, 4, 0), vec![
+    dependency_provider.add_dependencies("menu", (1, 4, 0), [
         ("dropdown", Range::higher_than((2, 0, 0))),
     ]);
-    dependency_provider.add_dependencies("menu", (1, 5, 0), vec![
+    dependency_provider.add_dependencies("menu", (1, 5, 0), [
         ("dropdown", Range::higher_than((2, 0, 0))),
     ]);
 
     // Dependencies of the dropdown lib.
-    dependency_provider.add_dependencies("dropdown", (1, 8, 0), vec![]);
-    dependency_provider.add_dependencies("dropdown", (2, 0, 0), vec![
+    dependency_provider.add_dependencies("dropdown", (1, 8, 0), []);
+    dependency_provider.add_dependencies("dropdown", (2, 0, 0), [
         ("icons", Range::exact((2, 0, 0))),
     ]);
-    dependency_provider.add_dependencies("dropdown", (2, 1, 0), vec![
+    dependency_provider.add_dependencies("dropdown", (2, 1, 0), [
         ("icons", Range::exact((2, 0, 0))),
     ]);
-    dependency_provider.add_dependencies("dropdown", (2, 2, 0), vec![
+    dependency_provider.add_dependencies("dropdown", (2, 2, 0), [
         ("icons", Range::exact((2, 0, 0))),
     ]);
-    dependency_provider.add_dependencies("dropdown", (2, 3, 0), vec![
+    dependency_provider.add_dependencies("dropdown", (2, 3, 0), [
         ("icons", Range::exact((2, 0, 0))),
     ]);
 
     // Icons has no dependency.
-    dependency_provider.add_dependencies("icons", (1, 0, 0), vec![]);
-    dependency_provider.add_dependencies("icons", (2, 0, 0), vec![]);
+    dependency_provider.add_dependencies("icons", (1, 0, 0), []);
+    dependency_provider.add_dependencies("icons", (2, 0, 0), []);
 
     // Run the algorithm.
     match resolve(&dependency_provider, "root", (1, 0, 0)) {

--- a/examples/linear_error_reporting.rs
+++ b/examples/linear_error_reporting.rs
@@ -13,7 +13,7 @@ fn main() {
     // root 1.0.0 depends on foo ^1.0.0 and baz ^1.0.0
         dependency_provider.add_dependencies(
         "root", (1, 0, 0),
-        vec![
+        [
             ("foo", Range::between((1, 0, 0), (2, 0, 0))),
             ("baz", Range::between((1, 0, 0), (2, 0, 0))),
         ],
@@ -22,17 +22,17 @@ fn main() {
     // foo 1.0.0 depends on bar ^2.0.0
         dependency_provider.add_dependencies(
         "foo", (1, 0, 0),
-        vec![("bar", Range::between((2, 0, 0), (3, 0, 0)))],
+        [("bar", Range::between((2, 0, 0), (3, 0, 0)))],
     );
     #[rustfmt::skip]
     // bar 2.0.0 depends on baz ^3.0.0
         dependency_provider.add_dependencies(
         "bar", (2, 0, 0),
-        vec![("baz", Range::between((3, 0, 0), (4, 0, 0)))],
+        [("baz", Range::between((3, 0, 0), (4, 0, 0)))],
     );
     // baz 1.0.0 and 3.0.0 have no dependencies
-    dependency_provider.add_dependencies("baz", (1, 0, 0), vec![]);
-    dependency_provider.add_dependencies("baz", (3, 0, 0), vec![]);
+    dependency_provider.add_dependencies("baz", (1, 0, 0), []);
+    dependency_provider.add_dependencies("baz", (3, 0, 0), []);
 
     // Run the algorithm.
     match resolve(&dependency_provider, "root", (1, 0, 0)) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,11 +53,11 @@
 //! let mut dependency_provider = OfflineDependencyProvider::<&str, NumberVersion>::new();
 //!
 //! dependency_provider.add_dependencies(
-//!     "root", 1, vec![("menu", Range::any()), ("icons", Range::any())],
+//!     "root", 1, [("menu", Range::any()), ("icons", Range::any())],
 //! );
-//! dependency_provider.add_dependencies("menu", 1, vec![("dropdown", Range::any())]);
-//! dependency_provider.add_dependencies("dropdown", 1, vec![("icons", Range::any())]);
-//! dependency_provider.add_dependencies("icons", 1, vec![]);
+//! dependency_provider.add_dependencies("menu", 1, [("dropdown", Range::any())]);
+//! dependency_provider.add_dependencies("dropdown", 1, [("icons", Range::any())]);
+//! dependency_provider.add_dependencies("icons", 1, []);
 //!
 //! // Run the algorithm.
 //! let solution = resolve(&dependency_provider, "root", 1).unwrap();

--- a/tests/examples.rs
+++ b/tests/examples.rs
@@ -24,15 +24,15 @@ fn no_conflict() {
     #[rustfmt::skip]
         dependency_provider.add_dependencies(
         "root", (1, 0, 0),
-        vec![("foo", Range::between((1, 0, 0), (2, 0, 0)))],
+        [("foo", Range::between((1, 0, 0), (2, 0, 0)))],
     );
     #[rustfmt::skip]
         dependency_provider.add_dependencies(
         "foo", (1, 0, 0),
-        vec![("bar", Range::between((1, 0, 0), (2, 0, 0)))],
+        [("bar", Range::between((1, 0, 0), (2, 0, 0)))],
     );
-    dependency_provider.add_dependencies("bar", (1, 0, 0), vec![]);
-    dependency_provider.add_dependencies("bar", (2, 0, 0), vec![]);
+    dependency_provider.add_dependencies("bar", (1, 0, 0), []);
+    dependency_provider.add_dependencies("bar", (2, 0, 0), []);
 
     // Run the algorithm.
     let computed_solution = resolve(&dependency_provider, "root", (1, 0, 0)).unwrap();
@@ -55,7 +55,7 @@ fn avoiding_conflict_during_decision_making() {
     #[rustfmt::skip]
         dependency_provider.add_dependencies(
         "root", (1, 0, 0),
-        vec![
+        [
             ("foo", Range::between((1, 0, 0), (2, 0, 0))),
             ("bar", Range::between((1, 0, 0), (2, 0, 0))),
         ],
@@ -63,12 +63,12 @@ fn avoiding_conflict_during_decision_making() {
     #[rustfmt::skip]
         dependency_provider.add_dependencies(
         "foo", (1, 1, 0),
-        vec![("bar", Range::between((2, 0, 0), (3, 0, 0)))],
+        [("bar", Range::between((2, 0, 0), (3, 0, 0)))],
     );
-    dependency_provider.add_dependencies("foo", (1, 0, 0), vec![]);
-    dependency_provider.add_dependencies("bar", (1, 0, 0), vec![]);
-    dependency_provider.add_dependencies("bar", (1, 1, 0), vec![]);
-    dependency_provider.add_dependencies("bar", (2, 0, 0), vec![]);
+    dependency_provider.add_dependencies("foo", (1, 0, 0), []);
+    dependency_provider.add_dependencies("bar", (1, 0, 0), []);
+    dependency_provider.add_dependencies("bar", (1, 1, 0), []);
+    dependency_provider.add_dependencies("bar", (2, 0, 0), []);
 
     // Run the algorithm.
     let computed_solution = resolve(&dependency_provider, "root", (1, 0, 0)).unwrap();
@@ -91,18 +91,18 @@ fn conflict_resolution() {
     #[rustfmt::skip]
         dependency_provider.add_dependencies(
         "root", (1, 0, 0),
-        vec![("foo", Range::higher_than((1, 0, 0)))],
+        [("foo", Range::higher_than((1, 0, 0)))],
     );
     #[rustfmt::skip]
         dependency_provider.add_dependencies(
         "foo", (2, 0, 0),
-        vec![("bar", Range::between((1, 0, 0), (2, 0, 0)))],
+        [("bar", Range::between((1, 0, 0), (2, 0, 0)))],
     );
-    dependency_provider.add_dependencies("foo", (1, 0, 0), vec![]);
+    dependency_provider.add_dependencies("foo", (1, 0, 0), []);
     #[rustfmt::skip]
         dependency_provider.add_dependencies(
         "bar", (1, 0, 0),
-        vec![("foo", Range::between((1, 0, 0), (2, 0, 0)))],
+        [("foo", Range::between((1, 0, 0), (2, 0, 0)))],
     );
 
     // Run the algorithm.
@@ -126,7 +126,7 @@ fn conflict_with_partial_satisfier() {
     // root 1.0.0 depends on foo ^1.0.0 and target ^2.0.0
         dependency_provider.add_dependencies(
         "root", (1, 0, 0),
-        vec![
+        [
             ("foo", Range::between((1, 0, 0), (2, 0, 0))),
             ("target", Range::between((2, 0, 0), (3, 0, 0))),
         ],
@@ -135,33 +135,33 @@ fn conflict_with_partial_satisfier() {
     // foo 1.1.0 depends on left ^1.0.0 and right ^1.0.0
         dependency_provider.add_dependencies(
         "foo", (1, 1, 0),
-        vec![
+        [
             ("left", Range::between((1, 0, 0), (2, 0, 0))),
             ("right", Range::between((1, 0, 0), (2, 0, 0))),
         ],
     );
-    dependency_provider.add_dependencies("foo", (1, 0, 0), vec![]);
+    dependency_provider.add_dependencies("foo", (1, 0, 0), []);
     #[rustfmt::skip]
     // left 1.0.0 depends on shared >=1.0.0
         dependency_provider.add_dependencies(
         "left", (1, 0, 0),
-        vec![("shared", Range::higher_than((1, 0, 0)))],
+        [("shared", Range::higher_than((1, 0, 0)))],
     );
     #[rustfmt::skip]
     // right 1.0.0 depends on shared <2.0.0
         dependency_provider.add_dependencies(
         "right", (1, 0, 0),
-        vec![("shared", Range::strictly_lower_than((2, 0, 0)))],
+        [("shared", Range::strictly_lower_than((2, 0, 0)))],
     );
-    dependency_provider.add_dependencies("shared", (2, 0, 0), vec![]);
+    dependency_provider.add_dependencies("shared", (2, 0, 0), []);
     #[rustfmt::skip]
     // shared 1.0.0 depends on target ^1.0.0
         dependency_provider.add_dependencies(
         "shared", (1, 0, 0),
-        vec![("target", Range::between((1, 0, 0), (2, 0, 0)))],
+        [("target", Range::between((1, 0, 0), (2, 0, 0)))],
     );
-    dependency_provider.add_dependencies("target", (2, 0, 0), vec![]);
-    dependency_provider.add_dependencies("target", (1, 0, 0), vec![]);
+    dependency_provider.add_dependencies("target", (2, 0, 0), []);
+    dependency_provider.add_dependencies("target", (1, 0, 0), []);
 
     // Run the algorithm.
     let computed_solution = resolve(&dependency_provider, "root", (1, 0, 0)).unwrap();
@@ -188,12 +188,12 @@ fn conflict_with_partial_satisfier() {
 fn double_choices() {
     init_log();
     let mut dependency_provider = OfflineDependencyProvider::<&str, NumberVersion>::new();
-    dependency_provider.add_dependencies("a", 0, vec![("b", Range::any()), ("c", Range::any())]);
-    dependency_provider.add_dependencies("b", 0, vec![("d", Range::exact(0))]);
-    dependency_provider.add_dependencies("b", 1, vec![("d", Range::exact(1))]);
-    dependency_provider.add_dependencies("c", 0, vec![]);
-    dependency_provider.add_dependencies("c", 1, vec![("d", Range::exact(2))]);
-    dependency_provider.add_dependencies("d", 0, vec![]);
+    dependency_provider.add_dependencies("a", 0, [("b", Range::any()), ("c", Range::any())]);
+    dependency_provider.add_dependencies("b", 0, [("d", Range::exact(0))]);
+    dependency_provider.add_dependencies("b", 1, [("d", Range::exact(1))]);
+    dependency_provider.add_dependencies("c", 0, []);
+    dependency_provider.add_dependencies("c", 1, [("d", Range::exact(2))]);
+    dependency_provider.add_dependencies("d", 0, []);
 
     // Solution.
     let mut expected_solution = Map::default();

--- a/tests/proptest.rs
+++ b/tests/proptest.rs
@@ -89,7 +89,7 @@ impl<P: Package, V: Version, DP: DependencyProvider<P, V>> DependencyProvider<P,
 #[should_panic]
 fn should_cancel_can_panic() {
     let mut dependency_provider = OfflineDependencyProvider::<_, NumberVersion>::new();
-    dependency_provider.add_dependencies(0, 0, vec![(666, Range::any())]);
+    dependency_provider.add_dependencies(0, 0, [(666, Range::any())]);
 
     // Run the algorithm.
     let _ = resolve(
@@ -333,8 +333,8 @@ proptest! {
                     (Ok(l), Ok(r)) => assert_eq!(l, r),
                     (Err(PubGrubError::NoSolution(derivation_l)), Err(PubGrubError::NoSolution(derivation_r))) => {
                         prop_assert_eq!(
-                            DefaultStringReporter::report(&derivation_l),
-                            DefaultStringReporter::report(&derivation_r)
+                            DefaultStringReporter::report(derivation_l),
+                            DefaultStringReporter::report(derivation_r)
                         )},
                     _ => panic!("not the same result")
                 }
@@ -423,7 +423,7 @@ proptest! {
                 dependency_provider
                     .versions(&p)
                     .unwrap()
-                    .map(move |v| (p, v.clone()))
+                    .map(move |&v| (p, v))
             })
             .collect();
         let to_remove: Set<(_, _)> = indexes_to_remove.iter().map(|x| x.get(&all_versions)).cloned().collect();

--- a/tests/sat_dependency_provider.rs
+++ b/tests/sat_dependency_provider.rs
@@ -82,7 +82,7 @@ impl<P: Package, V: Version> SatResolve<P, V> {
             for (p1, range) in &deps {
                 let empty_vec = vec![];
                 let mut matches: Vec<varisat::Lit> = all_versions_by_p
-                    .get(&p1)
+                    .get(p1)
                     .unwrap_or(&empty_vec)
                     .iter()
                     .filter(|(v1, _)| range.contains(v1))

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -9,12 +9,12 @@ use pubgrub::version::NumberVersion;
 fn same_result_on_repeated_runs() {
     let mut dependency_provider = OfflineDependencyProvider::<_, NumberVersion>::new();
 
-    dependency_provider.add_dependencies("c", 0, vec![]);
-    dependency_provider.add_dependencies("c", 2, vec![]);
-    dependency_provider.add_dependencies("b", 0, vec![]);
-    dependency_provider.add_dependencies("b", 1, vec![("c", Range::between(0, 1))]);
+    dependency_provider.add_dependencies("c", 0, []);
+    dependency_provider.add_dependencies("c", 2, []);
+    dependency_provider.add_dependencies("b", 0, []);
+    dependency_provider.add_dependencies("b", 1, [("c", Range::between(0, 1))]);
 
-    dependency_provider.add_dependencies("a", 0, vec![("b", Range::any()), ("c", Range::any())]);
+    dependency_provider.add_dependencies("a", 0, [("b", Range::any()), ("c", Range::any())]);
 
     let name = "a";
     let ver = NumberVersion(0);
@@ -30,13 +30,13 @@ fn same_result_on_repeated_runs() {
 #[test]
 fn should_always_find_a_satisfier() {
     let mut dependency_provider = OfflineDependencyProvider::<_, NumberVersion>::new();
-    dependency_provider.add_dependencies("a", 0, vec![("b", Range::none())]);
+    dependency_provider.add_dependencies("a", 0, [("b", Range::none())]);
     assert!(matches!(
         resolve(&dependency_provider, "a", 0),
         Err(PubGrubError::DependencyOnTheEmptySet { .. })
     ));
 
-    dependency_provider.add_dependencies("c", 0, vec![("a", Range::any())]);
+    dependency_provider.add_dependencies("c", 0, [("a", Range::any())]);
     assert!(matches!(
         resolve(&dependency_provider, "c", 0),
         Err(PubGrubError::DependencyOnTheEmptySet { .. })
@@ -46,7 +46,7 @@ fn should_always_find_a_satisfier() {
 #[test]
 fn cannot_depend_on_self() {
     let mut dependency_provider = OfflineDependencyProvider::<_, NumberVersion>::new();
-    dependency_provider.add_dependencies("a", 0, vec![("a", Range::any())]);
+    dependency_provider.add_dependencies("a", 0, [("a", Range::any())]);
     assert!(matches!(
         resolve(&dependency_provider, "a", 0),
         Err(PubGrubError::SelfDependency { .. })


### PR DESCRIPTION
Use arrays instead of vecs in examples, docs and tests (IntoIterator implemented since Rust 1.53)