### PR TITLE
refactor: replace Range with a bounded implementation

### DIFF
--- a/benches/large_case.rs
+++ b/benches/large_case.rs
@@ -11,13 +11,13 @@ use pubgrub::version::{NumberVersion, SemanticVersion};
 use pubgrub::version_set::VersionSet;
 use serde::de::Deserialize;
 
-fn bench<'a, P: Package + Deserialize<'a>, V: VersionSet + Deserialize<'a>>(
+fn bench<'a, P: Package + Deserialize<'a>, VS: VersionSet + Deserialize<'a>>(
     b: &mut Bencher,
     case: &'a str,
 ) where
-    <V as VersionSet>::V: Deserialize<'a>,
+    <VS as VersionSet>::V: Deserialize<'a>,
 {
-    let dependency_provider: OfflineDependencyProvider<P, V> = ron::de::from_str(&case).unwrap();
+    let dependency_provider: OfflineDependencyProvider<P, VS> = ron::de::from_str(&case).unwrap();
 
     b.iter(|| {
         for p in dependency_provider.packages() {

--- a/benches/large_case.rs
+++ b/benches/large_case.rs
@@ -5,15 +5,18 @@ extern crate criterion;
 use self::criterion::*;
 
 use pubgrub::package::Package;
+use pubgrub::range::Range;
 use pubgrub::solver::{resolve, OfflineDependencyProvider};
-use pubgrub::version::{NumberVersion, SemanticVersion, Version};
+use pubgrub::version::{NumberVersion, SemanticVersion};
+use pubgrub::version_set::VersionSet;
 use serde::de::Deserialize;
-use std::hash::Hash;
 
-fn bench<'a, P: Package + Deserialize<'a>, V: Version + Hash + Deserialize<'a>>(
+fn bench<'a, P: Package + Deserialize<'a>, V: VersionSet + Deserialize<'a>>(
     b: &mut Bencher,
     case: &'a str,
-) {
+) where
+    <V as VersionSet>::V: Deserialize<'a>,
+{
     let dependency_provider: OfflineDependencyProvider<P, V> = ron::de::from_str(&case).unwrap();
 
     b.iter(|| {
@@ -35,11 +38,11 @@ fn bench_nested(c: &mut Criterion) {
         let data = std::fs::read_to_string(&case).unwrap();
         if name.ends_with("u16_NumberVersion.ron") {
             group.bench_function(name, |b| {
-                bench::<u16, NumberVersion>(b, &data);
+                bench::<u16, Range<NumberVersion>>(b, &data);
             });
         } else if name.ends_with("str_SemanticVersion.ron") {
             group.bench_function(name, |b| {
-                bench::<&str, SemanticVersion>(b, &data);
+                bench::<&str, Range<SemanticVersion>>(b, &data);
             });
         }
     }

--- a/examples/doc_interface.rs
+++ b/examples/doc_interface.rs
@@ -14,10 +14,10 @@ type NumVS = Range<NumberVersion>;
 fn main() {
     let mut dependency_provider = OfflineDependencyProvider::<&str, NumVS>::new();
     dependency_provider.add_dependencies(
-        "root", 1, [("menu", Range::any()), ("icons", Range::any())],
+        "root", 1, [("menu", Range::full()), ("icons", Range::full())],
     );
-    dependency_provider.add_dependencies("menu", 1, [("dropdown", Range::any())]);
-    dependency_provider.add_dependencies("dropdown", 1, [("icons", Range::any())]);
+    dependency_provider.add_dependencies("menu", 1, [("dropdown", Range::full())]);
+    dependency_provider.add_dependencies("dropdown", 1, [("icons", Range::full())]);
     dependency_provider.add_dependencies("icons", 1, []);
 
     // Run the algorithm.

--- a/examples/doc_interface_error.rs
+++ b/examples/doc_interface_error.rs
@@ -20,9 +20,9 @@ fn main() {
     let mut dependency_provider = OfflineDependencyProvider::<&str, SemVS>::new();
     // Direct dependencies: menu and icons.
     dependency_provider.add_dependencies("root", (1, 0, 0), [
-        ("menu", Range::any()),
-        ("icons", Range::exact((1, 0, 0))),
-        ("intl", Range::exact((5, 0, 0))),
+        ("menu", Range::full()),
+        ("icons", Range::singleton((1, 0, 0))),
+        ("intl", Range::singleton((5, 0, 0))),
     ]);
 
     // Dependencies of the menu lib.
@@ -47,19 +47,19 @@ fn main() {
 
     // Dependencies of the dropdown lib.
     dependency_provider.add_dependencies("dropdown", (1, 8, 0), [
-        ("intl", Range::exact((3, 0, 0))),
+        ("intl", Range::singleton((3, 0, 0))),
     ]);
     dependency_provider.add_dependencies("dropdown", (2, 0, 0), [
-        ("icons", Range::exact((2, 0, 0))),
+        ("icons", Range::singleton((2, 0, 0))),
     ]);
     dependency_provider.add_dependencies("dropdown", (2, 1, 0), [
-        ("icons", Range::exact((2, 0, 0))),
+        ("icons", Range::singleton((2, 0, 0))),
     ]);
     dependency_provider.add_dependencies("dropdown", (2, 2, 0), [
-        ("icons", Range::exact((2, 0, 0))),
+        ("icons", Range::singleton((2, 0, 0))),
     ]);
     dependency_provider.add_dependencies("dropdown", (2, 3, 0), [
-        ("icons", Range::exact((2, 0, 0))),
+        ("icons", Range::singleton((2, 0, 0))),
     ]);
 
     // Icons have no dependencies.

--- a/examples/doc_interface_semantic.rs
+++ b/examples/doc_interface_semantic.rs
@@ -19,8 +19,8 @@ fn main() {
     let mut dependency_provider = OfflineDependencyProvider::<&str, SemVS>::new();
     // Direct dependencies: menu and icons.
     dependency_provider.add_dependencies("root", (1, 0, 0), [
-        ("menu", Range::any()),
-        ("icons", Range::exact((1, 0, 0))),
+        ("menu", Range::full()),
+        ("icons", Range::singleton((1, 0, 0))),
     ]);
 
     // Dependencies of the menu lib.
@@ -46,16 +46,16 @@ fn main() {
     // Dependencies of the dropdown lib.
     dependency_provider.add_dependencies("dropdown", (1, 8, 0), []);
     dependency_provider.add_dependencies("dropdown", (2, 0, 0), [
-        ("icons", Range::exact((2, 0, 0))),
+        ("icons", Range::singleton((2, 0, 0))),
     ]);
     dependency_provider.add_dependencies("dropdown", (2, 1, 0), [
-        ("icons", Range::exact((2, 0, 0))),
+        ("icons", Range::singleton((2, 0, 0))),
     ]);
     dependency_provider.add_dependencies("dropdown", (2, 2, 0), [
-        ("icons", Range::exact((2, 0, 0))),
+        ("icons", Range::singleton((2, 0, 0))),
     ]);
     dependency_provider.add_dependencies("dropdown", (2, 3, 0), [
-        ("icons", Range::exact((2, 0, 0))),
+        ("icons", Range::singleton((2, 0, 0))),
     ]);
 
     // Icons has no dependency.

--- a/src/internal/incompatibility.rs
+++ b/src/internal/incompatibility.rs
@@ -276,12 +276,12 @@ pub mod tests {
             let mut store = Arena::new();
             let i1 = store.alloc(Incompatibility {
                 package_terms: SmallMap::Two([("p1", t1.clone()), ("p2", t2.negate())]),
-                kind: Kind::UnavailableDependencies("0", Range::any())
+                kind: Kind::UnavailableDependencies("0", Range::full())
             });
 
             let i2 = store.alloc(Incompatibility {
                 package_terms: SmallMap::Two([("p2", t2), ("p3", t3.clone())]),
-                kind: Kind::UnavailableDependencies("0", Range::any())
+                kind: Kind::UnavailableDependencies("0", Range::full())
             });
 
             let mut i3 = Map::default();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,10 +55,10 @@
 //! let mut dependency_provider = OfflineDependencyProvider::<&str, NumVS>::new();
 //!
 //! dependency_provider.add_dependencies(
-//!     "root", 1, [("menu", Range::any()), ("icons", Range::any())],
+//!     "root", 1, [("menu", Range::full()), ("icons", Range::full())],
 //! );
-//! dependency_provider.add_dependencies("menu", 1, [("dropdown", Range::any())]);
-//! dependency_provider.add_dependencies("dropdown", 1, [("icons", Range::any())]);
+//! dependency_provider.add_dependencies("menu", 1, [("dropdown", Range::full())]);
+//! dependency_provider.add_dependencies("dropdown", 1, [("icons", Range::full())]);
 //! dependency_provider.add_dependencies("icons", 1, []);
 //!
 //! // Run the algorithm.

--- a/src/range.rs
+++ b/src/range.rs
@@ -221,14 +221,6 @@ impl<V: Ord> Range<V> {
 
     fn check_invariants(self) -> Self {
         if cfg!(debug_assertions) {
-            for (i, (s, e)) in self.segments.iter().enumerate() {
-                if matches!(s, Unbounded) && i != 0 {
-                    panic!()
-                }
-                if matches!(e, Unbounded) && i != (self.segments.len() - 1) {
-                    panic!()
-                }
-            }
             for p in self.segments.as_slice().windows(2) {
                 match (&p[0].1, &p[1].0) {
                     (Included(l_end), Included(r_start)) => assert!(l_end < r_start),

--- a/src/range.rs
+++ b/src/range.rs
@@ -7,309 +7,158 @@
 //! of the ranges building blocks.
 //!
 //! Those building blocks are:
-//!  - [none()](Range::none): the empty set
-//!  - [any()](Range::any): the set of all possible versions
-//!  - [exact(v)](Range::exact): the set containing only the version v
+//!  - [empty()](Range::empty): the empty set
+//!  - [full()](Range::full): the set of all possible versions
+//!  - [singleton(v)](Range::singleton): the set containing only the version v
 //!  - [higher_than(v)](Range::higher_than): the set defined by `v <= versions`
+//!  - [strictly_higher_than(v)](Range::strictly_higher_than): the set defined by `v < versions`
+//!  - [lower_than(v)](Range::lower_than): the set defined by `versions <= v`
 //!  - [strictly_lower_than(v)](Range::strictly_lower_than): the set defined by `versions < v`
 //!  - [between(v1, v2)](Range::between): the set defined by `v1 <= versions < v2`
 
-use std::cmp::Ordering;
-use std::fmt;
-use std::ops::{Bound, RangeBounds};
+use crate::{internal::small_vec::SmallVec, version_set::VersionSet};
+use std::ops::RangeBounds;
+use std::{
+    cmp::Ordering,
+    fmt::{Debug, Display, Formatter},
+    ops::Bound::{self, Excluded, Included, Unbounded},
+};
 
-use crate::internal::small_vec::SmallVec;
-use crate::version::Version;
-use crate::version_set::VersionSet;
-
-impl<V: Version> VersionSet for Range<V> {
-    type V = V;
-    // Constructors
-    fn empty() -> Self {
-        Range::none()
-    }
-    fn singleton(v: Self::V) -> Self {
-        Range::exact(v)
-    }
-    // Operations
-    fn complement(&self) -> Self {
-        self.negate()
-    }
-    fn intersection(&self, other: &Self) -> Self {
-        self.intersection(other)
-    }
-    // Membership
-    fn contains(&self, v: &Self::V) -> bool {
-        self.contains(v)
-    }
-}
-
-/// A Range is a set of versions.
-#[derive(Debug, Clone, Eq, PartialEq)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+/// A Range represents multiple intervals of a continuous range of monotone increasing
+/// values.
+#[derive(Debug, Clone, Eq, PartialEq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize))]
 #[cfg_attr(feature = "serde", serde(transparent))]
-pub struct Range<V: Version> {
+pub struct Range<V> {
     segments: SmallVec<Interval<V>>,
 }
 
-type Interval<V> = (V, Option<V>);
+type Interval<V> = (Bound<V>, Bound<V>);
 
-// Range building blocks.
-impl<V: Version> Range<V> {
+impl<V> Range<V> {
     /// Empty set of versions.
-    pub fn none() -> Self {
+    pub fn empty() -> Self {
         Self {
             segments: SmallVec::empty(),
         }
     }
 
-    /// Set of all possible versions.
-    pub fn any() -> Self {
-        Self::higher_than(V::lowest())
-    }
-
-    /// Set containing exactly one version.
-    pub fn exact(v: impl Into<V>) -> Self {
-        let v = v.into();
+    /// Set of all possible versions
+    pub fn full() -> Self {
         Self {
-            segments: SmallVec::one((v.clone(), Some(v.bump()))),
+            segments: SmallVec::one((Unbounded, Unbounded)),
         }
     }
 
-    /// Set of all versions higher or equal to some version.
+    /// Set of all versions higher or equal to some version
     pub fn higher_than(v: impl Into<V>) -> Self {
         Self {
-            segments: SmallVec::one((v.into(), None)),
+            segments: SmallVec::one((Included(v.into()), Unbounded)),
         }
     }
 
-    /// Set of all versions strictly lower than some version.
+    /// Set of all versions higher to some version
+    pub fn strictly_higher_than(v: impl Into<V>) -> Self {
+        Self {
+            segments: SmallVec::one((Excluded(v.into()), Unbounded)),
+        }
+    }
+
+    /// Set of all versions lower to some version
     pub fn strictly_lower_than(v: impl Into<V>) -> Self {
-        let v = v.into();
-        if v == V::lowest() {
-            Self::none()
-        } else {
-            Self {
-                segments: SmallVec::one((V::lowest(), Some(v))),
-            }
+        Self {
+            segments: SmallVec::one((Unbounded, Excluded(v.into()))),
         }
     }
 
-    /// Set of all versions comprised between two given versions.
-    /// The lower bound is included and the higher bound excluded.
-    /// `v1 <= v < v2`.
+    /// Set of all versions lower or equal to some version
+    pub fn lower_than(v: impl Into<V>) -> Self {
+        Self {
+            segments: SmallVec::one((Unbounded, Included(v.into()))),
+        }
+    }
+
+    /// Set of versions greater or equal to `v1` but less than `v2`.
     pub fn between(v1: impl Into<V>, v2: impl Into<V>) -> Self {
-        let v1 = v1.into();
-        let v2 = v2.into();
-        if v1 < v2 {
-            Self {
-                segments: SmallVec::one((v1, Some(v2))),
-            }
-        } else {
-            Self::none()
-        }
-    }
-
-    /// Construct a simple range from anything that impls [RangeBounds] like `v1..v2`.
-    pub fn from_range_bounds<R, IV>(bounds: R) -> Self
-    where
-        R: RangeBounds<IV>,
-        for<'a> &'a IV: Into<V>,
-    {
-        let start = match bounds.start_bound() {
-            Bound::Included(s) => s.into(),
-            Bound::Excluded(s) => s.into().bump(),
-            Bound::Unbounded => V::lowest(),
-        };
-        let end = match bounds.end_bound() {
-            Bound::Included(e) => Some(e.into().bump()),
-            Bound::Excluded(e) => Some(e.into()),
-            Bound::Unbounded => None,
-        };
-        if end.is_some() && end.as_ref() <= Some(&start) {
-            Self::none()
-        } else {
-            Self {
-                segments: SmallVec::one((start, end)),
-            }
+        Self {
+            segments: SmallVec::one((Included(v1.into()), Excluded(v2.into()))),
         }
     }
 }
 
-// Set operations.
-impl<V: Version> Range<V> {
-    // Negate ##################################################################
+impl<V: Clone> Range<V> {
+    /// Set containing exactly one version
+    pub fn singleton(v: impl Into<V>) -> Self {
+        let v = v.into();
+        Self {
+            segments: SmallVec::one((Included(v.clone()), Included(v))),
+        }
+    }
 
-    /// Compute the complement set of versions.
-    pub fn negate(&self) -> Self {
+    /// Set containing all versions expect one
+    pub fn not_equal(v: impl Into<V>) -> Self {
+        let v = v.into();
+        Self {
+            segments: SmallVec::Two([(Unbounded, Excluded(v.clone())), (Excluded(v), Unbounded)]),
+        }
+    }
+
+    /// Returns the complement of this Range.
+    pub fn complement(&self) -> Self {
         match self.segments.first() {
-            None => Self::any(), // Complement of ∅  is *
+            // Complement of ∅ is ∞
+            None => Self::full(),
+
+            // Complement of ∞ is ∅
+            Some((Unbounded, Unbounded)) => Self::empty(),
 
             // First high bound is +∞
-            Some((v, None)) => {
-                // Complement of * is ∅
-                if v == &V::lowest() {
-                    Self::none()
-                // Complement of "v <= _" is "_ < v"
-                } else {
-                    Self::strictly_lower_than(v.clone())
-                }
-            }
+            Some((Included(v), Unbounded)) => Self::strictly_lower_than(v.clone()),
+            Some((Excluded(v), Unbounded)) => Self::lower_than(v.clone()),
 
-            // First high bound is not +∞
-            Some((v1, Some(v2))) => {
-                if v1 == &V::lowest() {
-                    Self::negate_segments(v2.clone(), &self.segments[1..])
-                } else {
-                    Self::negate_segments(V::lowest(), &self.segments)
-                }
+            Some((Unbounded, Included(v))) => {
+                Self::negate_segments(Excluded(v.clone()), &self.segments[1..])
             }
+            Some((Unbounded, Excluded(v))) => {
+                Self::negate_segments(Included(v.clone()), &self.segments[1..])
+            }
+            Some((Included(_), Included(_)))
+            | Some((Included(_), Excluded(_)))
+            | Some((Excluded(_), Included(_)))
+            | Some((Excluded(_), Excluded(_))) => Self::negate_segments(Unbounded, &self.segments),
         }
     }
 
     /// Helper function performing the negation of intervals in segments.
-    /// For example:
-    ///    [ (v1, None) ] => [ (start, Some(v1)) ]
-    ///    [ (v1, Some(v2)) ] => [ (start, Some(v1)), (v2, None) ]
-    fn negate_segments(start: V, segments: &[Interval<V>]) -> Range<V> {
-        let mut complement_segments = SmallVec::empty();
-        let mut start = Some(start);
-        for (v1, maybe_v2) in segments {
-            // start.unwrap() is fine because `segments` is not exposed,
-            // and our usage guaranties that only the last segment may contain a None.
-            complement_segments.push((start.unwrap(), Some(v1.to_owned())));
-            start = maybe_v2.to_owned();
+    fn negate_segments(start: Bound<V>, segments: &[Interval<V>]) -> Self {
+        let mut complement_segments: SmallVec<Interval<V>> = SmallVec::empty();
+        let mut start = start;
+        for (v1, v2) in segments {
+            complement_segments.push((
+                start,
+                match v1 {
+                    Included(v) => Excluded(v.clone()),
+                    Excluded(v) => Included(v.clone()),
+                    Unbounded => unreachable!(),
+                },
+            ));
+            start = match v2 {
+                Included(v) => Excluded(v.clone()),
+                Excluded(v) => Included(v.clone()),
+                Unbounded => Unbounded,
+            }
         }
-        if let Some(last) = start {
-            complement_segments.push((last, None));
+        if !matches!(start, Unbounded) {
+            complement_segments.push((start, Unbounded));
         }
 
         Self {
             segments: complement_segments,
         }
     }
-
-    // Union and intersection ##################################################
-
-    /// Compute the union of two sets of versions.
-    pub fn union(&self, other: &Self) -> Self {
-        self.negate().intersection(&other.negate()).negate()
-    }
-
-    /// Compute the intersection of two sets of versions.
-    pub fn intersection(&self, other: &Self) -> Self {
-        let mut segments = SmallVec::empty();
-        let mut left_iter = self.segments.iter();
-        let mut right_iter = other.segments.iter();
-        let mut left = left_iter.next();
-        let mut right = right_iter.next();
-        loop {
-            match (left, right) {
-                // Both left and right still contain a finite interval:
-                (Some((l1, Some(l2))), Some((r1, Some(r2)))) => {
-                    if l2 <= r1 {
-                        // Intervals are disjoint, progress on the left.
-                        left = left_iter.next();
-                    } else if r2 <= l1 {
-                        // Intervals are disjoint, progress on the right.
-                        right = right_iter.next();
-                    } else {
-                        // Intervals are not disjoint.
-                        let start = l1.max(r1).to_owned();
-                        if l2 < r2 {
-                            segments.push((start, Some(l2.to_owned())));
-                            left = left_iter.next();
-                        } else {
-                            segments.push((start, Some(r2.to_owned())));
-                            right = right_iter.next();
-                        }
-                    }
-                }
-
-                // Right contains an infinite interval:
-                (Some((l1, Some(l2))), Some((r1, None))) => match l2.cmp(r1) {
-                    Ordering::Less => {
-                        left = left_iter.next();
-                    }
-                    Ordering::Equal => {
-                        for l in left_iter.cloned() {
-                            segments.push(l)
-                        }
-                        break;
-                    }
-                    Ordering::Greater => {
-                        let start = l1.max(r1).to_owned();
-                        segments.push((start, Some(l2.to_owned())));
-                        for l in left_iter.cloned() {
-                            segments.push(l)
-                        }
-                        break;
-                    }
-                },
-
-                // Left contains an infinite interval:
-                (Some((l1, None)), Some((r1, Some(r2)))) => match r2.cmp(l1) {
-                    Ordering::Less => {
-                        right = right_iter.next();
-                    }
-                    Ordering::Equal => {
-                        for r in right_iter.cloned() {
-                            segments.push(r)
-                        }
-                        break;
-                    }
-                    Ordering::Greater => {
-                        let start = l1.max(r1).to_owned();
-                        segments.push((start, Some(r2.to_owned())));
-                        for r in right_iter.cloned() {
-                            segments.push(r)
-                        }
-                        break;
-                    }
-                },
-
-                // Both sides contain an infinite interval:
-                (Some((l1, None)), Some((r1, None))) => {
-                    let start = l1.max(r1).to_owned();
-                    segments.push((start, None));
-                    break;
-                }
-
-                // Left or right has ended.
-                _ => {
-                    break;
-                }
-            }
-        }
-
-        Self { segments }
-    }
 }
 
-// Other useful functions.
-impl<V: Version> Range<V> {
-    /// Check if a range contains a given version.
-    pub fn contains(&self, version: &V) -> bool {
-        for (v1, maybe_v2) in &self.segments {
-            match maybe_v2 {
-                None => return v1 <= version,
-                Some(v2) => {
-                    if version < v1 {
-                        return false;
-                    } else if version < v2 {
-                        return true;
-                    }
-                }
-            }
-        }
-        false
-    }
-
-    /// Return the lowest version in the range (if there is one).
-    pub fn lowest_version(&self) -> Option<V> {
-        self.segments.first().map(|(start, _)| start).cloned()
-    }
-
+impl<V: Ord> Range<V> {
     /// Convert to something that can be used with
     /// [BTreeMap::range](std::collections::BTreeMap::range).
     /// All versions contained in self, will be in the output,
@@ -317,44 +166,299 @@ impl<V: Version> Range<V> {
     /// Returns None if the range is empty.
     pub fn bounding_range(&self) -> Option<(Bound<&V>, Bound<&V>)> {
         self.segments.first().map(|(start, _)| {
-            let end = {
-                self.segments
-                    .last()
-                    .and_then(|(_, l)| l.as_ref())
-                    .map(Bound::Excluded)
-                    .unwrap_or(Bound::Unbounded)
-            };
-            (Bound::Included(start), end)
+            let end = self
+                .segments
+                .last()
+                .expect("if there is a first element, there must be a last element");
+            (bound_as_ref(start), bound_as_ref(&end.1))
         })
+    }
+
+    /// Returns true if the this Range contains the specified value.
+    pub fn contains(&self, v: &V) -> bool {
+        if let Some(bounding_range) = self.bounding_range() {
+            if !bounding_range.contains(v) {
+                return false;
+            }
+        }
+
+        for segment in self.segments.iter() {
+            if match segment {
+                (Unbounded, Unbounded) => true,
+                (Unbounded, Included(end)) => v <= end,
+                (Unbounded, Excluded(end)) => v < end,
+                (Included(start), Unbounded) => v >= start,
+                (Included(start), Included(end)) => v >= start && v <= end,
+                (Included(start), Excluded(end)) => v >= start && v < end,
+                (Excluded(start), Unbounded) => v > start,
+                (Excluded(start), Included(end)) => v > start && v <= end,
+                (Excluded(start), Excluded(end)) => v > start && v < end,
+            } {
+                return true;
+            }
+        }
+        false
+    }
+
+    /// Construct a simple range from anything that impls [RangeBounds] like `v1..v2`.
+    pub fn from_range_bounds<R, IV>(bounds: R) -> Self
+    where
+        R: RangeBounds<IV>,
+        IV: Clone + Into<V>,
+    {
+        let start = match bounds.start_bound() {
+            Included(v) => Included(v.clone().into()),
+            Excluded(v) => Excluded(v.clone().into()),
+            Unbounded => Unbounded,
+        };
+        let end = match bounds.end_bound() {
+            Included(v) => Included(v.clone().into()),
+            Excluded(v) => Excluded(v.clone().into()),
+            Unbounded => Unbounded,
+        };
+        match (start, end) {
+            (Included(a), Included(b)) if b < a => Self::empty(),
+            (Excluded(a), Excluded(b)) if b < a => Self::empty(),
+            (Included(a), Excluded(b)) if b <= a => Self::empty(),
+            (Excluded(a), Included(b)) if b <= a => Self::empty(),
+            (a, b) => Self {
+                segments: SmallVec::one((a, b)),
+            },
+        }
+    }
+}
+
+/// Implementation of [`Bound::as_ref`] which is currently marked as unstable.
+fn bound_as_ref<V>(bound: &Bound<V>) -> Bound<&V> {
+    match bound {
+        Included(v) => Included(v),
+        Excluded(v) => Excluded(v),
+        Unbounded => Unbounded,
+    }
+}
+
+impl<V: Ord + Clone> Range<V> {
+    /// Computes the intersection of two sets of versions.
+    pub fn intersection(&self, other: &Self) -> Self {
+        let mut segments: SmallVec<Interval<V>> = SmallVec::empty();
+        let mut left_iter = self.segments.iter();
+        let mut right_iter = other.segments.iter();
+        let mut left = left_iter.next();
+        let mut right = right_iter.next();
+        while let (Some((left_lower, left_upper)), Some((right_lower, right_upper))) = (left, right)
+        {
+            // Check if the left range completely smaller than the right range.
+            if let (
+                Included(left_upper_version) | Excluded(left_upper_version),
+                Included(right_lower_version) | Excluded(right_lower_version),
+            ) = (left_upper, right_lower)
+            {
+                match left_upper_version.cmp(right_lower_version) {
+                    Ordering::Less => {
+                        // Left range is disjoint from the right range.
+                        left = left_iter.next();
+                        continue;
+                    }
+                    Ordering::Equal => {
+                        if !matches!((left_upper, right_lower), (Included(_), Included(_))) {
+                            // Left and right are overlapping exactly, but one of the bounds is exclusive, therefor the ranges are disjoint
+                            left = left_iter.next();
+                            continue;
+                        }
+                    }
+                    Ordering::Greater => {
+                        // Left upper bound is greater than right lower bound, so the lower bound is the right lower bound
+                    }
+                }
+            }
+            // Check if the right range completely smaller than the left range.
+            if let (
+                Included(left_lower_version) | Excluded(left_lower_version),
+                Included(right_upper_version) | Excluded(right_upper_version),
+            ) = (left_lower, right_upper)
+            {
+                match right_upper_version.cmp(left_lower_version) {
+                    Ordering::Less => {
+                        // Right range is disjoint from the left range.
+                        right = right_iter.next();
+                        continue;
+                    }
+                    Ordering::Equal => {
+                        if !matches!((right_upper, left_lower), (Included(_), Included(_))) {
+                            // Left and right are overlapping exactly, but one of the bounds is exclusive, therefor the ranges are disjoint
+                            right = right_iter.next();
+                            continue;
+                        }
+                    }
+                    Ordering::Greater => {
+                        // Right upper bound is greater than left lower bound, so the lower bound is the left lower bound
+                    }
+                }
+            }
+
+            // At this point we know there is an overlap between the versions, find the lowest bound
+            let lower = match (left_lower, right_lower) {
+                (Unbounded, Included(_) | Excluded(_)) => right_lower.clone(),
+                (Included(_) | Excluded(_), Unbounded) => left_lower.clone(),
+                (Unbounded, Unbounded) => Unbounded,
+                (Included(l) | Excluded(l), Included(r) | Excluded(r)) => match l.cmp(r) {
+                    Ordering::Less => right_lower.clone(),
+                    Ordering::Equal => match (left_lower, right_lower) {
+                        (Included(_), Excluded(v)) => Excluded(v.clone()),
+                        (Excluded(_), Excluded(v)) => Excluded(v.clone()),
+                        (Excluded(v), Included(_)) => Excluded(v.clone()),
+                        (Included(_), Included(v)) => Included(v.clone()),
+                        _ => unreachable!(),
+                    },
+                    Ordering::Greater => left_lower.clone(),
+                },
+            };
+
+            // At this point we know there is an overlap between the versions, find the lowest bound
+            let upper = match (left_upper, right_upper) {
+                (Unbounded, Included(_) | Excluded(_)) => {
+                    right = right_iter.next();
+                    right_upper.clone()
+                }
+                (Included(_) | Excluded(_), Unbounded) => {
+                    left = left_iter.next();
+                    left_upper.clone()
+                }
+                (Unbounded, Unbounded) => {
+                    left = left_iter.next();
+                    right = right_iter.next();
+                    Unbounded
+                }
+                (Included(l) | Excluded(l), Included(r) | Excluded(r)) => match l.cmp(r) {
+                    Ordering::Less => {
+                        left = left_iter.next();
+                        left_upper.clone()
+                    }
+                    Ordering::Equal => match (left_upper, right_upper) {
+                        (Included(_), Excluded(v)) => {
+                            right = right_iter.next();
+                            Excluded(v.clone())
+                        }
+                        (Excluded(_), Excluded(v)) => {
+                            left = left_iter.next();
+                            right = right_iter.next();
+                            Excluded(v.clone())
+                        }
+                        (Excluded(v), Included(_)) => {
+                            left = left_iter.next();
+                            Excluded(v.clone())
+                        }
+                        (Included(_), Included(v)) => {
+                            left = left_iter.next();
+                            right = right_iter.next();
+                            Included(v.clone())
+                        }
+                        _ => unreachable!(),
+                    },
+                    Ordering::Greater => {
+                        right = right_iter.next();
+                        right_upper.clone()
+                    }
+                },
+            };
+
+            segments.push((lower, upper));
+        }
+
+        Self { segments }
+    }
+}
+
+impl<T: Debug + Display + Clone + Eq + Ord> VersionSet for Range<T> {
+    type V = T;
+
+    fn empty() -> Self {
+        Range::empty()
+    }
+
+    fn singleton(v: Self::V) -> Self {
+        Range::singleton(v)
+    }
+
+    fn complement(&self) -> Self {
+        Range::complement(self)
+    }
+
+    fn intersection(&self, other: &Self) -> Self {
+        Range::intersection(self, other)
+    }
+
+    fn contains(&self, v: &Self::V) -> bool {
+        Range::contains(self, v)
+    }
+
+    fn full() -> Self {
+        Range::full()
     }
 }
 
 // REPORT ######################################################################
 
-impl<V: Version> fmt::Display for Range<V> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self.segments.as_slice() {
-            [] => write!(f, "∅"),
-            [(start, None)] if start == &V::lowest() => write!(f, "∗"),
-            [(start, None)] => write!(f, "{} <= v", start),
-            [(start, Some(end))] if end == &start.bump() => write!(f, "{}", start),
-            [(start, Some(end))] if start == &V::lowest() => write!(f, "v < {}", end),
-            [(start, Some(end))] => write!(f, "{} <= v < {}", start, end),
-            more_than_one_interval => {
-                let string_intervals: Vec<_> = more_than_one_interval
-                    .iter()
-                    .map(interval_to_string)
-                    .collect();
-                write!(f, "{}", string_intervals.join("  "))
+impl<V: Display + Eq> Display for Range<V> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        if self.segments.is_empty() {
+            write!(f, "∅")?;
+        } else {
+            for (idx, segment) in self.segments.iter().enumerate() {
+                if idx > 0 {
+                    write!(f, ", ")?;
+                }
+                match segment {
+                    (Unbounded, Unbounded) => write!(f, "*")?,
+                    (Unbounded, Included(v)) => write!(f, "<={v}")?,
+                    (Unbounded, Excluded(v)) => write!(f, "<{v}")?,
+                    (Included(v), Unbounded) => write!(f, ">={v}")?,
+                    (Included(v), Included(b)) => {
+                        if v == b {
+                            write!(f, "{v}")?
+                        } else {
+                            write!(f, ">={v},<={b}")?
+                        }
+                    }
+                    (Included(v), Excluded(b)) => write!(f, ">={v}, <{b}")?,
+                    (Excluded(v), Unbounded) => write!(f, ">{v}")?,
+                    (Excluded(v), Included(b)) => write!(f, ">{v}, <={b}")?,
+                    (Excluded(v), Excluded(b)) => write!(f, ">{v}, <{b}")?,
+                };
             }
         }
+        Ok(())
     }
 }
 
-fn interval_to_string<V: Version>((start, maybe_end): &Interval<V>) -> String {
-    match maybe_end {
-        Some(end) => format!("[ {}, {} [", start, end),
-        None => format!("[ {}, ∞ [", start),
+// SERIALIZATION ###############################################################
+
+#[cfg(feature = "serde")]
+impl<'de, V: serde::Deserialize<'de>> serde::Deserialize<'de> for Range<V> {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        // This enables conversion from the "old" discrete implementation of `Range` to the new
+        // bounded one.
+        //
+        // Serialization is always performed in the new format.
+        #[derive(serde::Deserialize)]
+        #[serde(untagged)]
+        enum EitherInterval<V> {
+            B(Bound<V>, Bound<V>),
+            D(V, Option<V>),
+        }
+
+        let bounds: SmallVec<EitherInterval<V>> = serde::Deserialize::deserialize(deserializer)?;
+
+        let mut segments = SmallVec::Empty;
+        for i in bounds {
+            match i {
+                EitherInterval::B(l, r) => segments.push((l, r)),
+                EitherInterval::D(l, Some(r)) => segments.push((Included(l), Excluded(r))),
+                EitherInterval::D(l, None) => segments.push((Included(l), Unbounded)),
+            }
+        }
+
+        Ok(Range { segments })
     }
 }
 
@@ -363,29 +467,61 @@ fn interval_to_string<V: Version>((start, maybe_end): &Interval<V>) -> String {
 #[cfg(test)]
 pub mod tests {
     use proptest::prelude::*;
-
-    use crate::version::NumberVersion;
+    use proptest::test_runner::TestRng;
 
     use super::*;
 
-    pub fn strategy() -> impl Strategy<Value = Range<NumberVersion>> {
-        prop::collection::vec(any::<u32>(), 0..10).prop_map(|mut vec| {
-            vec.sort_unstable();
-            vec.dedup();
-            let mut pair_iter = vec.chunks_exact(2);
-            let mut segments = SmallVec::empty();
-            while let Some([v1, v2]) = pair_iter.next() {
-                segments.push((NumberVersion(*v1), Some(NumberVersion(*v2))));
-            }
-            if let [v] = pair_iter.remainder() {
-                segments.push((NumberVersion(*v), None));
-            }
-            Range { segments }
-        })
+    pub fn strategy() -> impl Strategy<Value = Range<u32>> {
+        prop::collection::vec(any::<u32>(), 0..10)
+            .prop_map(|mut vec| {
+                vec.sort_unstable();
+                vec.dedup();
+                vec
+            })
+            .prop_perturb(|vec, mut rng| {
+                let mut segments = SmallVec::empty();
+                let mut iter = vec.into_iter().peekable();
+                if let Some(first) = iter.next() {
+                    fn next_bound<I: Iterator<Item = u32>>(
+                        iter: &mut I,
+                        rng: &mut TestRng,
+                    ) -> Bound<u32> {
+                        if let Some(next) = iter.next() {
+                            if rng.gen_bool(0.5) {
+                                Included(next)
+                            } else {
+                                Excluded(next)
+                            }
+                        } else {
+                            Unbounded
+                        }
+                    }
+
+                    let start = if rng.gen_bool(0.3) {
+                        Unbounded
+                    } else {
+                        if rng.gen_bool(0.5) {
+                            Included(first)
+                        } else {
+                            Excluded(first)
+                        }
+                    };
+
+                    let end = next_bound(&mut iter, &mut rng);
+                    segments.push((start, end));
+
+                    while iter.peek().is_some() {
+                        let start = next_bound(&mut iter, &mut rng);
+                        let end = next_bound(&mut iter, &mut rng);
+                        segments.push((start, end));
+                    }
+                }
+                return Range { segments };
+            })
     }
 
-    fn version_strat() -> impl Strategy<Value = NumberVersion> {
-        any::<u32>().prop_map(NumberVersion)
+    fn version_strat() -> impl Strategy<Value = u32> {
+        any::<u32>()
     }
 
     proptest! {
@@ -394,17 +530,17 @@ pub mod tests {
 
         #[test]
         fn negate_is_different(range in strategy()) {
-            assert_ne!(range.negate(), range);
+            assert_ne!(range.complement(), range);
         }
 
         #[test]
         fn double_negate_is_identity(range in strategy()) {
-            assert_eq!(range.negate().negate(), range);
+            assert_eq!(range.complement().complement(), range);
         }
 
         #[test]
         fn negate_contains_opposite(range in strategy(), version in version_strat()) {
-            assert_ne!(range.contains(&version), range.negate().contains(&version));
+            assert_ne!(range.contains(&version), range.complement().contains(&version));
         }
 
         // Testing intersection ----------------------------
@@ -416,12 +552,12 @@ pub mod tests {
 
         #[test]
         fn intersection_with_any_is_identity(range in strategy()) {
-            assert_eq!(Range::any().intersection(&range), range);
+            assert_eq!(Range::full().intersection(&range), range);
         }
 
         #[test]
         fn intersection_with_none_is_none(range in strategy()) {
-            assert_eq!(Range::none().intersection(&range), Range::none());
+            assert_eq!(Range::empty().intersection(&range), Range::empty());
         }
 
         #[test]
@@ -436,7 +572,7 @@ pub mod tests {
 
         #[test]
         fn intesection_of_complements_is_none(range in strategy()) {
-            assert_eq!(range.negate().intersection(&range), Range::none());
+            assert_eq!(range.complement().intersection(&range), Range::empty());
         }
 
         #[test]
@@ -448,7 +584,7 @@ pub mod tests {
 
         #[test]
         fn union_of_complements_is_any(range in strategy()) {
-            assert_eq!(range.negate().union(&range), Range::any());
+            assert_eq!(range.complement().union(&range), Range::full());
         }
 
         #[test]
@@ -460,17 +596,17 @@ pub mod tests {
 
         #[test]
         fn always_contains_exact(version in version_strat()) {
-            assert!(Range::exact(version).contains(&version));
+            assert!(Range::singleton(version).contains(&version));
         }
 
         #[test]
         fn contains_negation(range in strategy(), version in version_strat()) {
-            assert_ne!(range.contains(&version), range.negate().contains(&version));
+            assert_ne!(range.contains(&version), range.complement().contains(&version));
         }
 
         #[test]
         fn contains_intersection(range in strategy(), version in version_strat()) {
-            assert_eq!(range.contains(&version), range.intersection(&Range::exact(version)) != Range::none());
+            assert_eq!(range.contains(&version), range.intersection(&Range::singleton(version)) != Range::empty());
         }
 
         #[test]
@@ -482,14 +618,14 @@ pub mod tests {
 
         #[test]
         fn from_range_bounds(range in any::<(Bound<u32>, Bound<u32>)>(), version in version_strat()) {
-            let rv: Range<NumberVersion> = Range::from_range_bounds(range);
-            assert_eq!(range.contains(&version.0), rv.contains(&version));
+            let rv: Range<u32> = Range::from_range_bounds(range);
+            assert_eq!(range.contains(&version), rv.contains(&version));
         }
 
         #[test]
         fn from_range_bounds_round_trip(range in any::<(Bound<u32>, Bound<u32>)>()) {
-            let rv: Range<NumberVersion> = Range::from_range_bounds(range);
-            let rv2: Range<NumberVersion> = rv.bounding_range().map(Range::from_range_bounds::<_, NumberVersion>).unwrap_or_else(Range::none);
+            let rv: Range<u32> = Range::from_range_bounds(range);
+            let rv2: Range<u32> = rv.bounding_range().map(Range::from_range_bounds::<_, u32>).unwrap_or_else(Range::empty);
             assert_eq!(rv, rv2);
         }
     }

--- a/src/range.rs
+++ b/src/range.rs
@@ -444,8 +444,12 @@ pub mod tests {
             any::<bool>(),
             prop::collection::vec(any::<(u32, bool)>(), 1..10),
         )
-            .prop_map(|(start_bounded, deltas)| {
-                let mut start = if start_bounded { Some(Unbounded) } else { None };
+            .prop_map(|(start_unbounded, deltas)| {
+                let mut start = if start_unbounded {
+                    Some(Unbounded)
+                } else {
+                    None
+                };
                 let mut largest: u32 = 0;
                 let mut last_bound_was_inclusive = false;
                 let mut segments = SmallVec::Empty;

--- a/src/range.rs
+++ b/src/range.rs
@@ -168,12 +168,6 @@ impl<V: Ord> Range<V> {
 
     /// Returns true if the this Range contains the specified value.
     pub fn contains(&self, v: &V) -> bool {
-        if let Some(bounding_range) = self.bounding_range() {
-            if !bounding_range.contains(v) {
-                return false;
-            }
-        }
-
         for segment in self.segments.iter() {
             if match segment {
                 (Unbounded, Unbounded) => true,
@@ -230,6 +224,13 @@ fn bound_as_ref<V>(bound: &Bound<V>) -> Bound<&V> {
 }
 
 impl<V: Ord + Clone> Range<V> {
+    /// Computes the union of this `Range` and another.
+    pub fn union(&self, other: &Self) -> Self {
+        self.complement()
+            .intersection(&other.complement())
+            .complement()
+    }
+
     /// Computes the intersection of two sets of versions.
     pub fn intersection(&self, other: &Self) -> Self {
         let mut segments: SmallVec<Interval<V>> = SmallVec::empty();
@@ -386,6 +387,10 @@ impl<T: Debug + Display + Clone + Eq + Ord> VersionSet for Range<T> {
 
     fn full() -> Self {
         Range::full()
+    }
+
+    fn union(&self, other: &Self) -> Self {
+        Range::union(self, other)
     }
 }
 

--- a/src/range.rs
+++ b/src/range.rs
@@ -95,14 +95,6 @@ impl<V: Clone> Range<V> {
         }
     }
 
-    /// Set containing all versions expect one
-    pub fn not_equal(v: impl Into<V>) -> Self {
-        let v = v.into();
-        Self {
-            segments: SmallVec::Two([(Unbounded, Excluded(v.clone())), (Excluded(v), Unbounded)]),
-        }
-    }
-
     /// Returns the complement of this Range.
     pub fn complement(&self) -> Self {
         match self.segments.first() {

--- a/src/range.rs
+++ b/src/range.rs
@@ -15,6 +15,15 @@
 //!  - [lower_than(v)](Range::lower_than): the set defined by `versions <= v`
 //!  - [strictly_lower_than(v)](Range::strictly_lower_than): the set defined by `versions < v`
 //!  - [between(v1, v2)](Range::between): the set defined by `v1 <= versions < v2`
+//!
+//! Ranges can be created from any type that implements [`Ord`] + [`Clone`].
+//!
+//! In general any range will always be represented in the same way unless the the type `T` does not
+//! represent a continuous space. If the type `T` does not represent a continuous space there is
+//! no way to distinguish an unbounded bound from the minimal or maximum value of the range. For
+//! instance the segment `[Unbounded, Exclusive(0u32)]` does not include any value but its
+//! representation differs from the empty set. This means that for types that represent a discrete
+//! range there is the potential that the same set of versions is represented in multiple ways.
 
 use crate::{internal::small_vec::SmallVec, version_set::VersionSet};
 use std::ops::RangeBounds;

--- a/src/term.rs
+++ b/src/term.rs
@@ -182,10 +182,9 @@ impl<VS: VersionSet + Display> Display for Term<VS> {
 pub mod tests {
     use super::*;
     use crate::range::Range;
-    use crate::version::NumberVersion;
     use proptest::prelude::*;
 
-    pub fn strategy() -> impl Strategy<Value = Term<Range<NumberVersion>>> {
+    pub fn strategy() -> impl Strategy<Value = Term<Range<u32>>> {
         prop_oneof![
             crate::range::tests::strategy().prop_map(Term::Positive),
             crate::range::tests::strategy().prop_map(Term::Negative),

--- a/tests/examples.rs
+++ b/tests/examples.rs
@@ -191,11 +191,11 @@ fn conflict_with_partial_satisfier() {
 fn double_choices() {
     init_log();
     let mut dependency_provider = OfflineDependencyProvider::<&str, NumVS>::new();
-    dependency_provider.add_dependencies("a", 0, [("b", Range::any()), ("c", Range::any())]);
-    dependency_provider.add_dependencies("b", 0, [("d", Range::exact(0))]);
-    dependency_provider.add_dependencies("b", 1, [("d", Range::exact(1))]);
+    dependency_provider.add_dependencies("a", 0, [("b", Range::full()), ("c", Range::full())]);
+    dependency_provider.add_dependencies("b", 0, [("d", Range::singleton(0))]);
+    dependency_provider.add_dependencies("b", 1, [("d", Range::singleton(1))]);
     dependency_provider.add_dependencies("c", 0, []);
-    dependency_provider.add_dependencies("c", 1, [("d", Range::exact(2))]);
+    dependency_provider.add_dependencies("c", 1, [("d", Range::singleton(2))]);
     dependency_provider.add_dependencies("d", 0, []);
 
     // Solution.

--- a/tests/proptest.rs
+++ b/tests/proptest.rs
@@ -97,7 +97,7 @@ type SemVS = Range<SemanticVersion>;
 #[should_panic]
 fn should_cancel_can_panic() {
     let mut dependency_provider = OfflineDependencyProvider::<_, NumVS>::new();
-    dependency_provider.add_dependencies(0, 0, [(666, Range::any())]);
+    dependency_provider.add_dependencies(0, 0, [(666, Range::full())]);
 
     // Run the algorithm.
     let _ = resolve(
@@ -197,13 +197,13 @@ pub fn registry_strategy<N: Package + Ord>(
                         deps.push((
                             dep_name,
                             if c == 0 && d == s_last_index {
-                                Range::any()
+                                Range::full()
                             } else if c == 0 {
                                 Range::strictly_lower_than(s[d].0 + 1)
                             } else if d == s_last_index {
                                 Range::higher_than(s[c].0)
                             } else if c == d {
-                                Range::exact(s[c].0)
+                                Range::singleton(s[c].0)
                             } else {
                                 Range::between(s[c].0, s[d].0 + 1)
                             },
@@ -227,7 +227,7 @@ pub fn registry_strategy<N: Package + Ord>(
                     dependency_provider.add_dependencies(
                         name,
                         ver,
-                        deps.unwrap_or_else(|| vec![(bad_name.clone(), Range::any())]),
+                        deps.unwrap_or_else(|| vec![(bad_name.clone(), Range::full())]),
                     );
                 }
 

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -16,7 +16,7 @@ fn same_result_on_repeated_runs() {
     dependency_provider.add_dependencies("b", 0, []);
     dependency_provider.add_dependencies("b", 1, [("c", Range::between(0, 1))]);
 
-    dependency_provider.add_dependencies("a", 0, [("b", Range::any()), ("c", Range::any())]);
+    dependency_provider.add_dependencies("a", 0, [("b", Range::full()), ("c", Range::full())]);
 
     let name = "a";
     let ver = NumberVersion(0);
@@ -32,13 +32,13 @@ fn same_result_on_repeated_runs() {
 #[test]
 fn should_always_find_a_satisfier() {
     let mut dependency_provider = OfflineDependencyProvider::<_, NumVS>::new();
-    dependency_provider.add_dependencies("a", 0, [("b", Range::none())]);
+    dependency_provider.add_dependencies("a", 0, [("b", Range::empty())]);
     assert!(matches!(
         resolve(&dependency_provider, "a", 0),
         Err(PubGrubError::DependencyOnTheEmptySet { .. })
     ));
 
-    dependency_provider.add_dependencies("c", 0, [("a", Range::any())]);
+    dependency_provider.add_dependencies("c", 0, [("a", Range::full())]);
     assert!(matches!(
         resolve(&dependency_provider, "c", 0),
         Err(PubGrubError::DependencyOnTheEmptySet { .. })
@@ -48,7 +48,7 @@ fn should_always_find_a_satisfier() {
 #[test]
 fn cannot_depend_on_self() {
     let mut dependency_provider = OfflineDependencyProvider::<_, NumVS>::new();
-    dependency_provider.add_dependencies("a", 0, [("a", Range::any())]);
+    dependency_provider.add_dependencies("a", 0, [("a", Range::full())]);
     assert!(matches!(
         resolve(&dependency_provider, "a", 0),
         Err(PubGrubError::SelfDependency { .. })


### PR DESCRIPTION
This PR replaces `Range<T>` with an implementation that allows inclusive or exclusive bounds to be used. This enables `T` to be any type that implements `Ord + Clone` and doesn't require the `Version` trait.

It also renames some of the functions from `Range` to be more aligned with the names used in the `VersionSet` trait.

This is a cleaned-up version of #111 .