### PR TITLE
feat: constraining dependencies

### DIFF
--- a/examples/caching_dependency_provider.rs
+++ b/examples/caching_dependency_provider.rs
@@ -51,7 +51,7 @@ impl<P: Package, VS: VersionSet, DP: DependencyProvider<P, VS>> DependencyProvid
                 let dependencies = self.remote_dependencies.get_dependencies(package, version);
                 match dependencies {
                     Ok(Dependencies::Known(dependencies)) => {
-                        cache.add_dependencies(
+                        cache.add_requirements(
                             package.clone(),
                             version.clone(),
                             dependencies.clone(),

--- a/src/internal/incompatibility.rs
+++ b/src/internal/incompatibility.rs
@@ -105,13 +105,26 @@ impl<P: Package, VS: VersionSet> Incompatibility<P, VS> {
     }
 
     /// Build an incompatibility from a given dependency.
-    pub fn from_dependency(package: P, version: VS::V, dep: (&P, &VS)) -> Self {
+    pub fn from_required_dependency(package: P, version: VS::V, dep: (&P, &VS)) -> Self {
         let set1 = VS::singleton(version);
         let (p2, set2) = dep;
         Self {
             package_terms: SmallMap::Two([
                 (package.clone(), Term::Positive(set1.clone())),
                 (p2.clone(), Term::Negative(set2.clone())),
+            ]),
+            kind: Kind::FromDependencyOf(package, set1, p2.clone(), set2.clone()),
+        }
+    }
+
+    /// Build an incompatibility from a given constraint.
+    pub fn from_constrained_dependency(package: P, version: VS::V, dep: (&P, &VS)) -> Self {
+        let set1 = VS::singleton(version);
+        let (p2, set2) = dep;
+        Self {
+            package_terms: SmallMap::Two([
+                (package.clone(), Term::Positive(set1.clone())),
+                (p2.clone(), Term::Positive(set2.complement())),
             ]),
             kind: Kind::FromDependencyOf(package, set1, p2.clone(), set2.clone()),
         }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -3,9 +3,80 @@
 use pubgrub::error::PubGrubError;
 use pubgrub::range::Range;
 use pubgrub::solver::{resolve, OfflineDependencyProvider};
+use pubgrub::type_aliases::Map;
 use pubgrub::version::NumberVersion;
 
 type NumVS = Range<NumberVersion>;
+
+#[test]
+fn constrains_are_not_in_solution() {
+    let mut dependency_provider = OfflineDependencyProvider::<_, NumVS>::new();
+
+    dependency_provider.add_dependencies("a", 0, []);
+    dependency_provider.add_constraints("a", 0, [("c", Range::singleton(1))]);
+
+    // Run the algorithm
+    let computed_solution =
+        resolve(&dependency_provider, "a", NumberVersion(0)).expect("a solution was not found");
+
+    // Solution.
+    let mut expected_solution = Map::default();
+    expected_solution.insert("a", NumberVersion(0));
+
+    assert_eq!(computed_solution, expected_solution);
+}
+
+#[test]
+fn constrains_affect_the_solution() {
+    let mut dependency_provider = OfflineDependencyProvider::<_, NumVS>::new();
+
+    dependency_provider.add_dependencies("a", 0, [("b", Range::full())]);
+    dependency_provider.add_constraints("a", 0, [("c", Range::singleton(0))]);
+    dependency_provider.add_dependencies("b", 0, [("c", Range::full())]);
+    dependency_provider.add_dependencies("c", 0, []);
+    dependency_provider.add_dependencies("c", 1, []);
+
+    // Run the algorithm
+    let computed_solution =
+        resolve(&dependency_provider, "a", NumberVersion(0)).expect("a solution was not found");
+
+    // Solution.
+    let mut expected_solution = Map::default();
+    expected_solution.insert("a", NumberVersion(0));
+    expected_solution.insert("b", NumberVersion(0));
+    expected_solution.insert("c", NumberVersion(0));
+
+    assert_eq!(computed_solution, expected_solution);
+}
+
+#[test]
+fn constrains_can_exclude_dependency_from_the_solution() {
+    let mut dependency_provider = OfflineDependencyProvider::<_, NumVS>::new();
+
+    // "a" depends on "b" but requires that "c" is not included through an empty range constraint.
+    // version 0 of "b" depends on nothing
+    // version 1 of "b" depends on "c"
+    dependency_provider.add_dependencies("a", 0, [("b", Range::full())]);
+    dependency_provider.add_constraints("a", 0, [("c", Range::empty())]);
+    dependency_provider.add_dependencies("b", 0, []);
+    dependency_provider.add_dependencies("b", 1, [("c", Range::full())]);
+    dependency_provider.add_dependencies("c", 0, []);
+
+    // Run the algorithm
+    let computed_solution =
+        resolve(&dependency_provider, "a", NumberVersion(0)).expect("a solution was not found");
+
+    // Solution.
+    //
+    // - The expected result is that "b" version 0 is selected over version 1 because that latest
+    //   version (1) depends on the 'illegal' package "c".
+    // - Package "c" is not included.
+    let mut expected_solution = Map::default();
+    expected_solution.insert("a", NumberVersion(0));
+    expected_solution.insert("b", NumberVersion(0));
+
+    assert_eq!(computed_solution, expected_solution);
+}
 
 #[test]
 fn same_result_on_repeated_runs() {


### PR DESCRIPTION
This is an implementation of "constraining" dependencies or sometimes called "peer dependencies" as described in https://github.com/pubgrub-rs/pubgrub/issues/120.

The implementation is fully functioning. I've added some regular tests as well as modified the proptests to handle constraints.

I did have to modify the API of `DependencyProvider` and of `OfflineDependencyProvider`. I'm not really happy with the names and stuff but I'm curious to get your feedback.

I've also already used this branch in my Conda package solver and it works like a charm there! 🥳 