### PR TITLE
Allow DependencyOnTheEmptySet

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -32,21 +32,6 @@ pub enum PubGrubError<P: Package, VS: VersionSet> {
 
     /// Error arising when the implementer of
     /// [DependencyProvider](crate::solver::DependencyProvider)
-    /// returned a dependency on an empty range.
-    /// This technically means that the package can not be selected,
-    /// but is clearly some kind of mistake.
-    #[error("Package {dependent} required by {package} {version} depends on the empty set")]
-    DependencyOnTheEmptySet {
-        /// Package whose dependencies we want.
-        package: P,
-        /// Version of the package for which we want the dependencies.
-        version: VS::V,
-        /// The dependent package that requires us to pick from the empty set.
-        dependent: P,
-    },
-
-    /// Error arising when the implementer of
-    /// [DependencyProvider](crate::solver::DependencyProvider)
     /// returned a dependency on the requested package.
     /// This technically means that the package directly depends on itself,
     /// and is clearly some kind of mistake.

--- a/src/internal/core.rs
+++ b/src/internal/core.rs
@@ -90,11 +90,6 @@ impl<P: Package, VS: VersionSet> State<P, VS> {
         new_incompats_id_range
     }
 
-    /// Check if an incompatibility is terminal.
-    pub fn is_terminal(&self, incompatibility: &Incompatibility<P, VS>) -> bool {
-        incompatibility.is_terminal(&self.root_package, &self.root_version)
-    }
-
     /// Unit propagation is the core mechanism of the solving algorithm.
     /// CF <https://github.com/dart-lang/pub/blob/master/doc/solver.md#unit-propagation>
     pub fn unit_propagation(&mut self, package: P) -> Result<(), PubGrubError<P, VS>> {
@@ -240,7 +235,10 @@ impl<P: Package, VS: VersionSet> State<P, VS> {
     /// It may not be trivial since those incompatibilities
     /// may already have derived others.
     fn merge_incompatibility(&mut self, id: IncompId<P, VS>) {
-        for (pkg, _term) in self.incompatibility_store[id].iter() {
+        for (pkg, term) in self.incompatibility_store[id].iter() {
+            if cfg!(debug_assertions) {
+                assert_ne!(term, &crate::term::Term::any());
+            }
             self.incompatibilities
                 .entry(pkg.clone())
                 .or_default()

--- a/src/internal/incompatibility.rs
+++ b/src/internal/incompatibility.rs
@@ -109,10 +109,14 @@ impl<P: Package, VS: VersionSet> Incompatibility<P, VS> {
         let set1 = VS::singleton(version);
         let (p2, set2) = dep;
         Self {
-            package_terms: SmallMap::Two([
-                (package.clone(), Term::Positive(set1.clone())),
-                (p2.clone(), Term::Negative(set2.clone())),
-            ]),
+            package_terms: if set2 == &VS::empty() {
+                SmallMap::One([(package.clone(), Term::Positive(set1.clone()))])
+            } else {
+                SmallMap::Two([
+                    (package.clone(), Term::Positive(set1.clone())),
+                    (p2.clone(), Term::Negative(set2.clone())),
+                ])
+            },
             kind: Kind::FromDependencyOf(package, set1, p2.clone(), set2.clone()),
         }
     }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -35,13 +35,13 @@ fn should_always_find_a_satisfier() {
     dependency_provider.add_dependencies("a", 0, [("b", Range::empty())]);
     assert!(matches!(
         resolve(&dependency_provider, "a", 0),
-        Err(PubGrubError::DependencyOnTheEmptySet { .. })
+        Err(PubGrubError::NoSolution { .. })
     ));
 
     dependency_provider.add_dependencies("c", 0, [("a", Range::full())]);
     assert!(matches!(
         resolve(&dependency_provider, "c", 0),
-        Err(PubGrubError::DependencyOnTheEmptySet { .. })
+        Err(PubGrubError::NoSolution { .. })
     ));
 }
 


### PR DESCRIPTION
This closes #125

I started by adding a panic to the sat solver when it is had a `DependencyOnTheEmptySet`, all tests passed because proptest  was not configured to generate them. I modified proptest and confirmed that this test now failed. `meta_test_deep_trees_from_strategy` then informed me that I had too many ways for package to be invalid. Removing `allow_deps` and reducing the probability of generating `DependencyOnTheEmptySet` made it happy. Then I could get to the meat of the experiment. I removed the code that generates `DependencyOnTheEmptySet` and all test pass. Well prop test passing once don't mean much, so I increased the `cases` in the `ProptestConfig`. It has been running for a long time without finding a problem.

Excitement over this progress is a little premature. This library is surprisingly robust against violations of its internal assumptions. In a number of places we filter out and assume that no term of an incompatibility is `Term::any()`, which turns out to be exactly what's generated when `DependencyOnTheEmptySet`. Adding a check for that property in `merge_incompatibility` makes everything unhappy. This is easy enough, when we generate the incompatibility for the dependency just leave off that term. Unfortunately, this causes another problem if the root package has one of these dependencies then it is automatically terminal, leading to the unhelpful error message "Root package depends on itself at a different version?". That check is always been suspect, it even has a comment about removing it. If we do remove it, everything passes. The next call is to `add_version` which does a more complicated check and decides not to add the package. So the loop continues to `unit_propagation` which correctly generates a proof of unSAT.