### PR TITLE
Extend error type to `Send + Sync`

### DIFF
--- a/examples/caching_dependency_provider.rs
+++ b/examples/caching_dependency_provider.rs
@@ -35,7 +35,7 @@ impl<P: Package, VS: VersionSet, DP: DependencyProvider<P, VS>> DependencyProvid
     fn choose_package_version<T: std::borrow::Borrow<P>, U: std::borrow::Borrow<VS>>(
         &self,
         packages: impl Iterator<Item = (T, U)>,
-    ) -> Result<(T, Option<VS::V>), Box<dyn Error>> {
+    ) -> Result<(T, Option<VS::V>), Box<dyn Error + Send + Sync>> {
         self.remote_dependencies.choose_package_version(packages)
     }
 
@@ -44,7 +44,7 @@ impl<P: Package, VS: VersionSet, DP: DependencyProvider<P, VS>> DependencyProvid
         &self,
         package: &P,
         version: &VS::V,
-    ) -> Result<Dependencies<P, VS>, Box<dyn Error>> {
+    ) -> Result<Dependencies<P, VS>, Box<dyn Error + Send + Sync>> {
         let mut cache = self.cached_dependencies.borrow_mut();
         match cache.get_dependencies(package, version) {
             Ok(Dependencies::Unknown) => {

--- a/src/error.rs
+++ b/src/error.rs
@@ -27,7 +27,7 @@ pub enum PubGrubError<P: Package, VS: VersionSet> {
         version: VS::V,
         /// Error raised by the implementer of
         /// [DependencyProvider](crate::solver::DependencyProvider).
-        source: Box<dyn std::error::Error>,
+        source: Box<dyn std::error::Error + Send + Sync>,
     },
 
     /// Error arising when the implementer of
@@ -63,12 +63,12 @@ pub enum PubGrubError<P: Package, VS: VersionSet> {
     /// returned an error in the method
     /// [choose_package_version](crate::solver::DependencyProvider::choose_package_version).
     #[error("Decision making failed")]
-    ErrorChoosingPackageVersion(Box<dyn std::error::Error>),
+    ErrorChoosingPackageVersion(Box<dyn std::error::Error + Send + Sync>),
 
     /// Error arising when the implementer of [DependencyProvider](crate::solver::DependencyProvider)
     /// returned an error in the method [should_cancel](crate::solver::DependencyProvider::should_cancel).
     #[error("We should cancel")]
-    ErrorInShouldCancel(Box<dyn std::error::Error>),
+    ErrorInShouldCancel(Box<dyn std::error::Error + Send + Sync>),
 
     /// Something unexpected happened.
     #[error("{0}")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,7 +89,7 @@
 //! type SemVS = Range<SemanticVersion>;
 //!
 //! impl DependencyProvider<String, SemVS> for MyDependencyProvider {
-//!     fn choose_package_version<T: Borrow<String>, U: Borrow<SemVS>>(&self,packages: impl Iterator<Item=(T, U)>) -> Result<(T, Option<SemanticVersion>), Box<dyn Error>> {
+//!     fn choose_package_version<T: Borrow<String>, U: Borrow<SemVS>>(&self,packages: impl Iterator<Item=(T, U)>) -> Result<(T, Option<SemanticVersion>), Box<dyn Error + Send + Sync>> {
 //!         unimplemented!()
 //!     }
 //!
@@ -97,7 +97,7 @@
 //!         &self,
 //!         package: &String,
 //!         version: &SemanticVersion,
-//!     ) -> Result<Dependencies<String, SemVS>, Box<dyn Error>> {
+//!     ) -> Result<Dependencies<String, SemVS>, Box<dyn Error + Send + Sync>> {
 //!         unimplemented!()
 //!     }
 //! }


### PR DESCRIPTION
## Summary

Though we may want to adopt a fully generic error type eventually, this at least makes the error type compatible with `anyhow` (and makes it async-friendly, which is both good and bad, since it requires that user errors are thread safe regardless of whether it's important for them to be).

See: https://github.com/pubgrub-rs/pubgrub/issues/116