### PR TITLE
Add incompatibility for unusable dependencies

### DIFF
--- a/examples/caching_dependency_provider.rs
+++ b/examples/caching_dependency_provider.rs
@@ -52,6 +52,7 @@ impl<P: Package, VS: VersionSet, DP: DependencyProvider<P, VS>> DependencyProvid
                         Ok(Dependencies::Known(dependencies))
                     }
                     Ok(Dependencies::Unknown) => Ok(Dependencies::Unknown),
+                    Ok(Dependencies::Unusable) => Ok(Dependencies::Unusable),
                     error @ Err(_) => error,
                 }
             }

--- a/src/report.rs
+++ b/src/report.rs
@@ -41,6 +41,8 @@ pub enum External<P: Package, VS: VersionSet> {
     NoVersions(P, VS),
     /// Dependencies of the package are unavailable for versions in that set.
     UnavailableDependencies(P, VS),
+    /// Dependencies of the package are unusable for versions in that set.
+    UnusableDependencies(P, VS),
     /// Incompatibility coming from the dependencies of a given package.
     FromDependencyOf(P, VS, P, VS),
 }
@@ -113,6 +115,9 @@ impl<P: Package, VS: VersionSet> DerivationTree<P, VS> {
             DerivationTree::External(External::UnavailableDependencies(_, r)) => Some(
                 DerivationTree::External(External::UnavailableDependencies(package, set.union(&r))),
             ),
+            DerivationTree::External(External::UnusableDependencies(_, r)) => Some(
+                DerivationTree::External(External::UnusableDependencies(package, set.union(&r))),
+            ),
             DerivationTree::External(External::FromDependencyOf(p1, r1, p2, r2)) => {
                 if p1 == package {
                     Some(DerivationTree::External(External::FromDependencyOf(
@@ -154,6 +159,17 @@ impl<P: Package, VS: VersionSet> fmt::Display for External<P, VS> {
                     write!(
                         f,
                         "dependencies of {} at version {} are unavailable",
+                        package, set
+                    )
+                }
+            }
+            Self::UnusableDependencies(package, set) => {
+                if set == &VS::full() {
+                    write!(f, "dependencies of {} are unusable", package)
+                } else {
+                    write!(
+                        f,
+                        "dependencies of {} at version {} are unusable",
                         package, set
                     )
                 }

--- a/src/solver.rs
+++ b/src/solver.rs
@@ -162,6 +162,13 @@ pub fn resolve<P: Package, VS: VersionSet>(
                     ));
                     continue;
                 }
+                Dependencies::Unusable => {
+                    state.add_incompatibility(Incompatibility::unusable_dependencies(
+                        p.clone(),
+                        v.clone(),
+                    ));
+                    continue;
+                }
                 Dependencies::Known(x) if x.contains_key(p) => {
                     return Err(PubGrubError::SelfDependency {
                         package: p.clone(),
@@ -199,6 +206,8 @@ pub fn resolve<P: Package, VS: VersionSet>(
 pub enum Dependencies<P: Package, VS: VersionSet> {
     /// Package dependencies are unavailable.
     Unknown,
+    /// Package dependencies are unusable.
+    Unusable,
     /// Container for all available package versions.
     Known(DependencyConstraints<P, VS>),
 }

--- a/tests/proptest.rs
+++ b/tests/proptest.rs
@@ -316,6 +316,7 @@ fn retain_versions<N: Package + Ord, VS: VersionSet>(
             }
             let deps = match dependency_provider.get_dependencies(&n, &v).unwrap() {
                 Dependencies::Unknown => panic!(),
+                Dependencies::Unusable => panic!(),
                 Dependencies::Known(deps) => deps,
             };
             smaller_dependency_provider.add_dependencies(n.clone(), v.clone(), deps)
@@ -340,6 +341,7 @@ fn retain_dependencies<N: Package + Ord, VS: VersionSet>(
         for v in dependency_provider.versions(n).unwrap() {
             let deps = match dependency_provider.get_dependencies(&n, &v).unwrap() {
                 Dependencies::Unknown => panic!(),
+                Dependencies::Unusable => panic!(),
                 Dependencies::Known(deps) => deps,
             };
             smaller_dependency_provider.add_dependencies(
@@ -511,6 +513,7 @@ proptest! {
                 .unwrap()
             {
                 Dependencies::Unknown => panic!(),
+                Dependencies::Unusable => panic!(),
                 Dependencies::Known(d) => d.into_iter().collect(),
             };
             if !dependencies.is_empty() {

--- a/tests/sat_dependency_provider.rs
+++ b/tests/sat_dependency_provider.rs
@@ -67,6 +67,7 @@ impl<P: Package, VS: VersionSet> SatResolve<P, VS> {
         for (p, v, var) in &all_versions {
             let deps = match dp.get_dependencies(p, v).unwrap() {
                 Dependencies::Unknown => panic!(),
+                Dependencies::Unusable => panic!(),
                 Dependencies::Known(d) => d,
             };
             for (p1, range) in &deps {


### PR DESCRIPTION
Adds a new incompatibility kind of unusable dependencies, which is a distinct case from unknown dependencies in that we _know_ the dependencies of the  package but we are unwilling to use them.

This incompatibility is useful for some of the cases described in https://github.com/pubgrub-rs/pubgrub/issues/152 allowing versions of a package to be marked as unusable due to a problem in their direct dependencies.

In my fork, I attach a `reason: Option<String>` to the `UnusableDependencies` types which allows the resolver to explain _why_ the dependencies are unusable. I have opted not to include that here yet, as I know there is interest in adding such labels to all incompatibility kinds which feels like a separate discussion.