### PR TITLE
feat: add a `simplify` for error messages

### DIFF
--- a/src/range.rs
+++ b/src/range.rs
@@ -319,10 +319,12 @@ fn valid_segment<T: PartialOrd>(start: &Bound<T>, end: &Bound<T>) -> bool {
 }
 
 /// group adjacent versions locations
+/// ```text
 /// [None, 3, 6, 7, None] -> [(3, 7)]
 /// [3, 6, 7, None] -> [(None, 7)]
 /// [3, 6, 7] -> [(None, None)]
 /// [None, 1, 4, 7, None, None, None, 8, None, 9] -> [(1, 7), (8, 8), (9, None)]
+/// ```
 fn group_adjacent_locations(
     mut locations: impl Iterator<Item = Option<usize>>,
 ) -> impl Iterator<Item = (Option<usize>, Option<usize>)> {

--- a/src/range.rs
+++ b/src/range.rs
@@ -417,7 +417,10 @@ impl<V: Ord + Clone> Range<V> {
         self.keep_segments(kept_segments)
     }
 
-    /// simplify range with segments at given location bounds.
+    /// Create a new range with a subset of segments at given location bounds.
+    ///
+    /// Each new segment is constructed from a pair of segments, taking the
+    /// start of the first and the end of the second.
     fn keep_segments(
         &self,
         kept_segments: impl Iterator<Item = (Option<usize>, Option<usize>)>,

--- a/src/range.rs
+++ b/src/range.rs
@@ -309,7 +309,8 @@ fn valid_segment<T: PartialOrd>(start: &Bound<T>, end: &Bound<T>) -> bool {
     }
 }
 
-/// group adjacent versions locations
+/// Group adjacent versions locations.
+///
 /// ```text
 /// [None, 3, 6, 7, None] -> [(3, 7)]
 /// [3, 6, 7, None] -> [(None, 7)]


### PR DESCRIPTION
Ranges generated by PubGrub often end up being verbose and pedantic about versions that do not matter. To take an example from #155 `2 | 3 | 4 | 5` could be more concisely stated as `>=2, <=5` given that it's not possible to have versions in between the integers. More generally it could be expressed as `>=2`, if the list of available versions were taken into account.

The logic for simplifying a VS given a complete set of versions feels like it should be simple. But it is trickier to implement than I expected. Especially if you want to guarantee `O(len(VS) + len(versions))` time and `O(1)` allocations.

While working through the logic I had to implement a check which versions match from a list in `O(len(VS) + len(versions))` time, which felt useful enough to be worth including in the API. In implementing that I noticed that our implementation of `contains`, did not aggressively short-circuit. The short-circuiting implementation is just as easy to read, so I decided to include that as well.