### PR TITLE
perf: more efficient intersection

### DIFF
--- a/src/range.rs
+++ b/src/range.rs
@@ -285,13 +285,19 @@ impl<V: Ord + Clone> Range<V> {
 
     /// Computes the intersection of two sets of versions.
     pub fn intersection(&self, other: &Self) -> Self {
-        let mut segments: SmallVec<Interval<V>> = SmallVec::empty();
+        let mut output: SmallVec<Interval<V>> = SmallVec::empty();
         let mut left_iter = self.segments.iter().peekable();
         let mut right_iter = other.segments.iter().peekable();
-
+        // By the definition of intersection any point that is matched by the output
+        // must have a segment in each of the inputs that it matches.
+        // Therefore, every segment in the output must be the intersection of a segment from each of the inputs.
+        // It would be correct to do the "O(n^2)" thing, by computing the intersection of every segment from one input
+        // with every segment of the other input, and sorting the result.
+        // We can avoid the sorting by generating our candidate segments with an increasing `end` value.
         while let Some(((left_start, left_end), (right_start, right_end))) =
             left_iter.peek().zip(right_iter.peek())
         {
+            // The next smallest `end` value is going to come from one of the inputs.
             let left_end_is_smaller = match (left_end, right_end) {
                 (Included(l), Included(r))
                 | (Excluded(l), Excluded(r))
@@ -301,6 +307,11 @@ impl<V: Ord + Clone> Range<V> {
                 (_, Unbounded) => true,
                 (Unbounded, _) => false,
             };
+            // Now that we are processing `end` we will never have to process any segment smaller than that.
+            // We can ensure that the input that `end` came from is larger than `end` by advancing it one step.
+            // `end` is the smaller available input, so we know the other input is already larger than `end`.
+            // Note: We can call `other_iter.next_if( == end)`, but the ends lining up is rare enough that
+            // it does not end up being faster in practice.
             let (other_start, end) = if left_end_is_smaller {
                 left_iter.next();
                 (right_start, left_end)
@@ -308,7 +319,14 @@ impl<V: Ord + Clone> Range<V> {
                 right_iter.next();
                 (left_start, right_end)
             };
+            // `start` will either come from the input `end` came from or the other input, whichever one is larger.
+            // The intersection is invalid if `start` > `end`.
+            // But, we already know that the segments in our input are valid.
+            // So we do not need to check if the `start`  from the input `end` came from is smaller then `end`.
+            // If the `other_start` is larger than end, then the intersection will be invalid.
             if !valid_segment(other_start, end) {
+                // Note: We can call `this_iter.next_if(!valid_segment(other_start, this_end))` in a loop.
+                // But the checks make it slower for the benchmarked inputs.
                 continue;
             }
             let start = match (left_start, right_start) {
@@ -324,11 +342,12 @@ impl<V: Ord + Clone> Range<V> {
                 }
                 (s, Unbounded) | (Unbounded, s) => s.as_ref(),
             };
-
-            segments.push((start.cloned(), end.clone()))
+            // Now we clone and push a new segment.
+            // By dealing with references until now we ensure that NO cloning happens when we reject the segment.
+            output.push((start.cloned(), end.clone()))
         }
 
-        Self { segments }.check_invariants()
+        Self { segments: output }.check_invariants()
     }
 }
 


### PR DESCRIPTION
I got nerds not by https://github.com/zanieb/pubgrub/pull/6. Which points out that intersection is slower than it needs to be when the basic operations on version are expensive. Here's what I've come up with.

The ideas are:
1. Like that PR, avoid cloning till the end
2. Instead of using `next_if` and `eq` keep track of which iter to advance directly.
3. Because we know which iter `end` came from, and we know that for each iterator `start < end`, check for validity before determining `start`
4. Don't redundantly check `e > i`

branch | clone to reject | compares to reject | clones to accept | comparisons to accept
-----|--------------------|-------------------|------------------|-------
`dev` | 2 | 5 | 2 | 5
`zanieb/#6` | 0 | 5 | 2 | 5
`this` | 0 | 2 | 2 | 3

I tested this synthetically by making a version that increasing a global counter every time `eq`/`cmp`/`clone`/`drop` is called. This global counter goes up much (~30%) less after this PR. 
Even on our normal benchmarks, where these operations are very cheap (a handful of CPU cycles), we see improvements (although only a few percent).

cc @konstin for real-world impact.
cc @baszalmstra https://github.com/mamba-org/resolvo/issues/2#issuecomment-1744436726 I don't know if these are improvements you'd be interested in include in your copy of this type.