### PR TITLE
feat: merge dependencies for better error messages

### DIFF
--- a/src/internal/core.rs
+++ b/src/internal/core.rs
@@ -30,6 +30,8 @@ pub struct State<P: Package, VS: VersionSet, Priority: Ord + Clone> {
     /// and will stay that way until the next conflict and backtrack is operated.
     contradicted_incompatibilities: rustc_hash::FxHashSet<IncompId<P, VS>>,
 
+    dependencies: Map<(P, P), SmallVec<IncompId<P, VS>>>,
+
     /// Partial solution.
     /// TODO: remove pub.
     pub partial_solution: PartialSolution<P, VS, Priority>,
@@ -61,6 +63,7 @@ impl<P: Package, VS: VersionSet, Priority: Ord + Clone> State<P, VS, Priority> {
             partial_solution: PartialSolution::empty(),
             incompatibility_store,
             unit_propagation_buffer: SmallVec::Empty,
+            dependencies: Map::default(),
         }
     }
 
@@ -78,11 +81,15 @@ impl<P: Package, VS: VersionSet, Priority: Ord + Clone> State<P, VS, Priority> {
         deps: &DependencyConstraints<P, VS>,
     ) -> std::ops::Range<IncompId<P, VS>> {
         // Create incompatibilities and allocate them in the store.
-        let new_incompats_id_range = self
-            .incompatibility_store
-            .alloc_iter(deps.iter().map(|dep| {
-                Incompatibility::from_dependency(package.clone(), version.clone(), dep)
-            }));
+        let new_incompats_id_range =
+            self.incompatibility_store
+                .alloc_iter(deps.iter().map(|dep| {
+                    Incompatibility::from_dependency(
+                        package.clone(),
+                        VS::singleton(version.clone()),
+                        dep,
+                    )
+                }));
         // Merge the newly created incompatibilities with the older ones.
         for id in IncompId::range_to_iter(new_incompats_id_range.clone()) {
             self.merge_incompatibility(id);
@@ -234,7 +241,47 @@ impl<P: Package, VS: VersionSet, Priority: Ord + Clone> State<P, VS, Priority> {
     /// Here we do the simple stupid thing of just growing the Vec.
     /// It may not be trivial since those incompatibilities
     /// may already have derived others.
-    fn merge_incompatibility(&mut self, id: IncompId<P, VS>) {
+    fn merge_incompatibility(&mut self, mut id: IncompId<P, VS>) {
+        if let Some((p1, p2)) = self.incompatibility_store[id].as_dependency() {
+            let vs = self.incompatibility_store[id].get(p2);
+            let deps_lookup = self
+                .dependencies
+                .entry((p1.clone(), p2.clone()))
+                .or_default();
+            if let Some(past) = deps_lookup
+                .as_mut_slice()
+                .iter_mut()
+                .find(|past| self.incompatibility_store[**past].get(p2) == vs)
+            {
+                let incompat = &self.incompatibility_store[id];
+                let new = self
+                    .incompatibility_store
+                    .alloc(Incompatibility::from_dependency(
+                        p1.clone(),
+                        self.incompatibility_store[*past]
+                            .get(p1)
+                            .unwrap()
+                            .unwrap_positive()
+                            .union(incompat.get(p1).unwrap().unwrap_positive()), // It is safe to `simplify` here
+                        (
+                            &p2,
+                            incompat
+                                .get(p2)
+                                .map_or(&VS::empty(), |v| v.unwrap_negative()),
+                        ),
+                    ));
+                for (pkg, _) in self.incompatibility_store[new].iter() {
+                    let ids = self.incompatibilities.entry(pkg.clone()).or_default();
+                    if let Some(slot) = ids.iter().position(|id| id == past) {
+                        ids.remove(slot);
+                    }
+                }
+                *past = new;
+                id = new;
+            } else {
+                deps_lookup.push(id);
+            }
+        }
         for (pkg, term) in self.incompatibility_store[id].iter() {
             if cfg!(debug_assertions) {
                 assert_ne!(term, &crate::term::Term::any());

--- a/src/internal/core.rs
+++ b/src/internal/core.rs
@@ -246,7 +246,7 @@ impl<P: Package, VS: VersionSet, Priority: Ord + Clone> State<P, VS, Priority> {
                 .or_default();
             if let Some((past, mergeed)) = deps_lookup.as_mut_slice().iter_mut().find_map(|past| {
                 self.incompatibility_store[id]
-                    .merge_dependants(&self.incompatibility_store[*past])
+                    .merge_dependents(&self.incompatibility_store[*past])
                     .map(|m| (past, m))
             }) {
                 let new = self.incompatibility_store.alloc(mergeed);

--- a/src/internal/core.rs
+++ b/src/internal/core.rs
@@ -246,12 +246,12 @@ impl<P: Package, VS: VersionSet, Priority: Ord + Clone> State<P, VS, Priority> {
                 .merged_dependencies
                 .entry((p1.clone(), p2.clone()))
                 .or_default();
-            if let Some((past, mergeed)) = deps_lookup.as_mut_slice().iter_mut().find_map(|past| {
+            if let Some((past, merged)) = deps_lookup.as_mut_slice().iter_mut().find_map(|past| {
                 self.incompatibility_store[id]
                     .merge_dependents(&self.incompatibility_store[*past])
                     .map(|m| (past, m))
             }) {
-                let new = self.incompatibility_store.alloc(mergeed);
+                let new = self.incompatibility_store.alloc(merged);
                 for (pkg, _) in self.incompatibility_store[new].iter() {
                     self.incompatibilities
                         .entry(pkg.clone())

--- a/src/internal/core.rs
+++ b/src/internal/core.rs
@@ -246,7 +246,7 @@ impl<P: Package, VS: VersionSet, Priority: Ord + Clone> State<P, VS, Priority> {
                 .or_default();
             if let Some((past, mergeed)) = deps_lookup.as_mut_slice().iter_mut().find_map(|past| {
                 self.incompatibility_store[id]
-                    .merge_dependency(&self.incompatibility_store[*past])
+                    .merge_dependants(&self.incompatibility_store[*past])
                     .map(|m| (past, m))
             }) {
                 let new = self.incompatibility_store.alloc(mergeed);

--- a/src/internal/incompatibility.rs
+++ b/src/internal/incompatibility.rs
@@ -138,7 +138,7 @@ impl<P: Package, VS: VersionSet> Incompatibility<P, VS> {
     ///
     /// It is a special case of prior cause computation where the unified package
     /// is the common dependant in the two incompatibilities expressing dependencies.
-    pub fn merge_dependency(&self, other: &Self) -> Option<Self> {
+    pub fn merge_dependants(&self, other: &Self) -> Option<Self> {
         // It is almost certainly a bug to call this method without checking that self is a dependency
         debug_assert!(self.as_dependency().is_some());
         // Check that both incompatibilities are of the shape p1 depends on p2,

--- a/src/internal/incompatibility.rs
+++ b/src/internal/incompatibility.rs
@@ -138,7 +138,7 @@ impl<P: Package, VS: VersionSet> Incompatibility<P, VS> {
     ///
     /// It is a special case of prior cause computation where the unified package
     /// is the common dependant in the two incompatibilities expressing dependencies.
-    pub fn merge_dependants(&self, other: &Self) -> Option<Self> {
+    pub fn merge_dependents(&self, other: &Self) -> Option<Self> {
         // It is almost certainly a bug to call this method without checking that self is a dependency
         debug_assert!(self.as_dependency().is_some());
         // Check that both incompatibilities are of the shape p1 depends on p2,

--- a/src/internal/incompatibility.rs
+++ b/src/internal/incompatibility.rs
@@ -107,19 +107,25 @@ impl<P: Package, VS: VersionSet> Incompatibility<P, VS> {
     }
 
     /// Build an incompatibility from a given dependency.
-    pub fn from_dependency(package: P, version: VS::V, dep: (&P, &VS)) -> Self {
-        let set1 = VS::singleton(version);
+    pub fn from_dependency(package: P, versions: VS, dep: (&P, &VS)) -> Self {
         let (p2, set2) = dep;
         Self {
             package_terms: if set2 == &VS::empty() {
-                SmallMap::One([(package.clone(), Term::Positive(set1.clone()))])
+                SmallMap::One([(package.clone(), Term::Positive(versions.clone()))])
             } else {
                 SmallMap::Two([
-                    (package.clone(), Term::Positive(set1.clone())),
+                    (package.clone(), Term::Positive(versions.clone())),
                     (p2.clone(), Term::Negative(set2.clone())),
                 ])
             },
-            kind: Kind::FromDependencyOf(package, set1, p2.clone(), set2.clone()),
+            kind: Kind::FromDependencyOf(package, versions, p2.clone(), set2.clone()),
+        }
+    }
+
+    pub fn as_dependency(&self) -> Option<(&P, &P)> {
+        match &self.kind {
+            Kind::FromDependencyOf(p1, _, p2, _) => Some((p1, p2)),
+            _ => None,
         }
     }
 

--- a/src/internal/small_vec.rs
+++ b/src/internal/small_vec.rs
@@ -28,6 +28,15 @@ impl<T> SmallVec<T> {
         }
     }
 
+    pub fn as_mut_slice(&mut self) -> &mut [T] {
+        match self {
+            Self::Empty => &mut [],
+            Self::One(v) => v,
+            Self::Two(v) => v,
+            Self::Flexible(v) => v,
+        }
+    }
+
     pub fn push(&mut self, new: T) {
         *self = match std::mem::take(self) {
             Self::Empty => Self::One([new]),

--- a/src/term.rs
+++ b/src/term.rs
@@ -70,6 +70,15 @@ impl<VS: VersionSet> Term<VS> {
             _ => panic!("Negative term cannot unwrap positive set"),
         }
     }
+
+    /// Unwrap the set contained in a negative term.
+    /// Will panic if used on a positive set.
+    pub(crate) fn unwrap_negative(&self) -> &VS {
+        match self {
+            Self::Negative(set) => set,
+            _ => panic!("Positive term cannot unwrap negative set"),
+        }
+    }
 }
 
 /// Set operations with terms.

--- a/tests/examples.rs
+++ b/tests/examples.rs
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: MPL-2.0
 
+use pubgrub::error::PubGrubError;
 use pubgrub::range::Range;
+use pubgrub::report::{DefaultStringReporter, Reporter as _};
 use pubgrub::solver::{resolve, OfflineDependencyProvider};
 use pubgrub::type_aliases::Map;
 use pubgrub::version::{NumberVersion, SemanticVersion};
@@ -208,4 +210,48 @@ fn double_choices() {
     // Run the algorithm.
     let computed_solution = resolve(&dependency_provider, "a", 0).unwrap();
     assert_eq!(expected_solution, computed_solution);
+}
+
+#[test]
+fn confusing_with_lots_of_holes() {
+    let mut dependency_provider = OfflineDependencyProvider::<&str, NumVS>::new();
+
+    // root depends on foo...
+    dependency_provider.add_dependencies("root", 1, vec![("foo", Range::full())]);
+
+    for i in 1..6 {
+        // foo depends on bar...
+        dependency_provider.add_dependencies("foo", i as u32, vec![("bar", Range::full())]);
+    }
+
+    let Err(PubGrubError::NoSolution(mut derivation_tree)) =
+        resolve(&dependency_provider, "root", 1)
+    else {
+        unreachable!()
+    };
+    assert_eq!(
+        &DefaultStringReporter::report(&derivation_tree),
+        r#"Because there is no available version for bar and foo 1 depends on bar, foo 1 is forbidden.
+And because there is no version of foo in <1 | >1, <2 | >2, <3 | >3, <4 | >4, <5 | >5, foo <2 | >2, <3 | >3, <4 | >4, <5 | >5 is forbidden. (1)
+
+Because there is no available version for bar and foo 2 depends on bar, foo 2 is forbidden.
+And because foo <2 | >2, <3 | >3, <4 | >4, <5 | >5 is forbidden (1), foo <3 | >3, <4 | >4, <5 | >5 is forbidden. (2)
+
+Because there is no available version for bar and foo 3 depends on bar, foo 3 is forbidden.
+And because foo <3 | >3, <4 | >4, <5 | >5 is forbidden (2), foo <4 | >4, <5 | >5 is forbidden. (3)
+
+Because there is no available version for bar and foo 4 depends on bar, foo 4 is forbidden.
+And because foo <4 | >4, <5 | >5 is forbidden (3), foo <5 | >5 is forbidden. (4)
+
+Because there is no available version for bar and foo 5 depends on bar, foo 5 is forbidden.
+And because foo <5 | >5 is forbidden (4), foo * is forbidden.
+And because root 1 depends on foo, root 1 is forbidden."#
+    );
+    derivation_tree.collapse_no_versions();
+    assert_eq!(
+        &DefaultStringReporter::report(&derivation_tree),
+        r#"Because foo <2 | >2, <3 | >3, <4 | >4, <5 | >5 depends on bar and foo 2 depends on bar, foo <3 | >3, <4 | >4, <5 | >5 is forbidden.
+And because foo 3 depends on bar and foo 4 depends on bar, foo <5 | >5 is forbidden.
+And because foo 5 depends on bar and root 1 depends on foo, root 1 is forbidden."#
+    );
 }

--- a/tests/examples.rs
+++ b/tests/examples.rs
@@ -231,27 +231,12 @@ fn confusing_with_lots_of_holes() {
     };
     assert_eq!(
         &DefaultStringReporter::report(&derivation_tree),
-        r#"Because there is no available version for bar and foo 1 depends on bar, foo 1 is forbidden.
-And because there is no version of foo in <1 | >1, <2 | >2, <3 | >3, <4 | >4, <5 | >5, foo <2 | >2, <3 | >3, <4 | >4, <5 | >5 is forbidden. (1)
-
-Because there is no available version for bar and foo 2 depends on bar, foo 2 is forbidden.
-And because foo <2 | >2, <3 | >3, <4 | >4, <5 | >5 is forbidden (1), foo <3 | >3, <4 | >4, <5 | >5 is forbidden. (2)
-
-Because there is no available version for bar and foo 3 depends on bar, foo 3 is forbidden.
-And because foo <3 | >3, <4 | >4, <5 | >5 is forbidden (2), foo <4 | >4, <5 | >5 is forbidden. (3)
-
-Because there is no available version for bar and foo 4 depends on bar, foo 4 is forbidden.
-And because foo <4 | >4, <5 | >5 is forbidden (3), foo <5 | >5 is forbidden. (4)
-
-Because there is no available version for bar and foo 5 depends on bar, foo 5 is forbidden.
-And because foo <5 | >5 is forbidden (4), foo * is forbidden.
-And because root 1 depends on foo, root 1 is forbidden."#
+        r#"Because there is no available version for bar and foo 1 | 2 | 3 | 4 | 5 depends on bar, foo 1 | 2 | 3 | 4 | 5 is forbidden.
+And because there is no version of foo in <1 | >1, <2 | >2, <3 | >3, <4 | >4, <5 | >5 and root 1 depends on foo, root 1 is forbidden."#
     );
     derivation_tree.collapse_no_versions();
     assert_eq!(
         &DefaultStringReporter::report(&derivation_tree),
-        r#"Because foo <2 | >2, <3 | >3, <4 | >4, <5 | >5 depends on bar and foo 2 depends on bar, foo <3 | >3, <4 | >4, <5 | >5 is forbidden.
-And because foo 3 depends on bar and foo 4 depends on bar, foo <5 | >5 is forbidden.
-And because foo 5 depends on bar and root 1 depends on foo, root 1 is forbidden."#
+        "Because foo depends on bar and root 1 depends on foo, root 1 is forbidden."
     );
 }


### PR DESCRIPTION
This is the "simplest thing that could possibly work", when adding a new dependency incompatibility we check to see if there is an existing incompatibility with the same parent package and dependent package and dependent VS, if so we construct a new incompatibility that represents the merging of the two incompatibilities. We remove the old incompatibility from all lookup tables and at the new one. This effectively brings us on par with Dart for #19. When it applies this can massively reduce the number of incompatibilities the algorithm scans through. So it may help a little bit with #135, depending on whether there real problem contain this exact case. The union of versions done when merging incompatibilities here is definitely a candidate for #163.

The big advantage of this is the improvement to error messages. In fact this is split up into several commits the first one as a test case with the old error message and the second one shows the new error message. Our error messages tend to have "holes" constructed by discovering the individual versions don't work. When each version doesn't work for a different reason then we are in a complicated mess and the "holes" are the least of the users problems. In this case, the only reason we discovered the issues one at a time is that we loaded the data one version at a time, which is not useful information for the user to see. I consider this improvement to error messages as justifying a lot of "half-baked" details about this approach.

Unfortunately this is pure overhead when the optimization does not apply. Most problematically this does not apply if we never load more than one version of a package, that is to say when we easily construct a solution. All told this adds a 5% to 20% cost on our benchmarks. After several days of experimenting this slowdown is caused not by any of the inefficient/half-baked things that I would like to improve. :-( Instead it is caused by constructing, populating, and dropping the additional hash table.

Can you think of a more space efficient way to find the incompatibility to merge with?
Do you think the performance cost is worth the error message improvement?
What is the performance cost on your preferred workload?