### PR TITLE
ci: replace unmaintained action-rs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,16 +64,11 @@ jobs:
     name: Source code is formatted
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - name: Install stable Rust
-        uses: actions-rs/toolchain@v1
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: stable
-          profile: minimal
           components: rustfmt
-
-      - name: Check formatting
-        run: cargo fmt --all -- --check
+      - run: cargo fmt --all -- --check
 
   check_documentation:
     name: Documentation builds successfully

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,34 +14,10 @@ jobs:
     name: Tests pass
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - name: Install stable Rust
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          profile: minimal
-
-      - name: Get Cargo version
-        id: cargo_version
-        run: echo "::set-output name=version::$(cargo -V | tr -d ' ')"
-        shell: bash
-
-      - name: Download cache
-        uses: actions/cache@v2
-        with:
-          path: |
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: ${{ runner.os }}-${{ steps.cargo_version.outputs.version }}-${{ hashFiles('Cargo.toml') }}
-          restore-keys: ${{ runner.os }}-${{ steps.cargo_version.outputs.version }}
-
-      - name: Build
-        run: cargo build --verbose
-
-      - name: Run tests
-        run: cargo test --features=serde --verbose
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - run: cargo build --verbose
+      - run: cargo test --features=serde --verbose
 
   clippy:
     name: No warnings from Clippy

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,23 +46,8 @@ jobs:
     name: Documentation builds successfully
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - name: Install nightly Rust
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: nightly
-          profile: minimal
-
-      - name: Download cache
-        uses: actions/cache@v2
-        with:
-          path: |
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: documentation
-
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@nightly
       - name: Check documentation
         env:
           RUSTDOCFLAGS: -D warnings

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,14 +47,10 @@ jobs:
     name: No warnings from Clippy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - name: Install stable Rust
-        uses: actions-rs/toolchain@v1
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: stable
-          profile: minimal
           components: clippy
-
       - name: Check Clippy lints
         env:
           RUSTFLAGS: -D warnings


### PR DESCRIPTION
This fixes #164 

[actions-rs organization became unmaintained](https://www.reddit.com/r/rust/comments/vyx4oj/actionsrs_organization_became_unmaintained/) we should move our CI to no longer use it.

In this PR, I opted for using dtolnay's action. It is straightforward to use.

I've removed caches for the `test` and `check_documentation` jobs which had caching. The docs job is now faster, 15s against 20s. And the test job is slightly slower (50s against 43s roughly). Let's avoid the added complexity of caching as long as we can keep CI under a minute or so.