### PR TITLE
feat!: allocation free errors

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -10,7 +10,7 @@ use crate::version_set::VersionSet;
 
 /// Errors that may occur while solving dependencies.
 #[derive(Error, Debug)]
-pub enum PubGrubError<P: Package, VS: VersionSet> {
+pub enum PubGrubError<P: Package, VS: VersionSet, E: std::error::Error> {
     /// There is no solution for this set of dependencies.
     #[error("No solution")]
     NoSolution(DerivationTree<P, VS>),
@@ -27,7 +27,7 @@ pub enum PubGrubError<P: Package, VS: VersionSet> {
         version: VS::V,
         /// Error raised by the implementer of
         /// [DependencyProvider](crate::solver::DependencyProvider).
-        source: Box<dyn std::error::Error + Send + Sync>,
+        source: E,
     },
 
     /// Error arising when the implementer of
@@ -48,12 +48,12 @@ pub enum PubGrubError<P: Package, VS: VersionSet> {
     /// returned an error in the method
     /// [choose_version](crate::solver::DependencyProvider::choose_version).
     #[error("Decision making failed")]
-    ErrorChoosingPackageVersion(Box<dyn std::error::Error + Send + Sync>),
+    ErrorChoosingPackageVersion(E),
 
     /// Error arising when the implementer of [DependencyProvider](crate::solver::DependencyProvider)
     /// returned an error in the method [should_cancel](crate::solver::DependencyProvider::should_cancel).
     #[error("We should cancel")]
-    ErrorInShouldCancel(Box<dyn std::error::Error + Send + Sync>),
+    ErrorInShouldCancel(E),
 
     /// Something unexpected happened.
     #[error("{0}")]

--- a/src/internal/core.rs
+++ b/src/internal/core.rs
@@ -4,6 +4,7 @@
 //! to write a functional PubGrub algorithm.
 
 use std::collections::HashSet as Set;
+use std::error::Error;
 
 use crate::error::PubGrubError;
 use crate::internal::arena::Arena;
@@ -92,7 +93,7 @@ impl<P: Package, VS: VersionSet, Priority: Ord + Clone> State<P, VS, Priority> {
 
     /// Unit propagation is the core mechanism of the solving algorithm.
     /// CF <https://github.com/dart-lang/pub/blob/master/doc/solver.md#unit-propagation>
-    pub fn unit_propagation(&mut self, package: P) -> Result<(), PubGrubError<P, VS>> {
+    pub fn unit_propagation<E: Error>(&mut self, package: P) -> Result<(), PubGrubError<P, VS, E>> {
         self.unit_propagation_buffer.clear();
         self.unit_propagation_buffer.push(package);
         while let Some(current_package) = self.unit_propagation_buffer.pop() {
@@ -154,10 +155,11 @@ impl<P: Package, VS: VersionSet, Priority: Ord + Clone> State<P, VS, Priority> {
 
     /// Return the root cause and the backtracked model.
     /// CF <https://github.com/dart-lang/pub/blob/master/doc/solver.md#unit-propagation>
-    fn conflict_resolution(
+    #[allow(clippy::type_complexity)]
+    fn conflict_resolution<E: Error>(
         &mut self,
         incompatibility: IncompId<P, VS>,
-    ) -> Result<(P, IncompId<P, VS>), PubGrubError<P, VS>> {
+    ) -> Result<(P, IncompId<P, VS>), PubGrubError<P, VS, E>> {
         let mut current_incompat_id = incompatibility;
         let mut current_incompat_changed = false;
         loop {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83,13 +83,14 @@
 //! # use pubgrub::type_aliases::Map;
 //! # use std::error::Error;
 //! # use std::borrow::Borrow;
+//! # use std::convert::Infallible;
 //! #
 //! # struct MyDependencyProvider;
 //! #
 //! type SemVS = Range<SemanticVersion>;
 //!
 //! impl DependencyProvider<String, SemVS> for MyDependencyProvider {
-//!     fn choose_version(&self, package: &String, range: &SemVS) -> Result<Option<SemanticVersion>, Box<dyn Error + Send + Sync>> {
+//!     fn choose_version(&self, package: &String, range: &SemVS) -> Result<Option<SemanticVersion>, Infallible> {
 //!         unimplemented!()
 //!     }
 //!
@@ -102,9 +103,11 @@
 //!         &self,
 //!         package: &String,
 //!         version: &SemanticVersion,
-//!     ) -> Result<Dependencies<String, SemVS>, Box<dyn Error + Send + Sync>> {
+//!     ) -> Result<Dependencies<String, SemVS>, Infallible> {
 //!         unimplemented!()
 //!     }
+//!
+//!     type Err = Infallible;
 //! }
 //! ```
 //!

--- a/tests/sat_dependency_provider.rs
+++ b/tests/sat_dependency_provider.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
+use std::convert::Infallible;
+
 use pubgrub::error::PubGrubError;
 use pubgrub::package::Package;
 use pubgrub::solver::{Dependencies, DependencyProvider, OfflineDependencyProvider};
@@ -135,7 +137,7 @@ impl<P: Package, VS: VersionSet> SatResolve<P, VS> {
 
     pub fn check_resolve(
         &mut self,
-        res: &Result<SelectedDependencies<P, VS::V>, PubGrubError<P, VS>>,
+        res: &Result<SelectedDependencies<P, VS::V>, PubGrubError<P, VS, Infallible>>,
         p: &P,
         v: &VS::V,
     ) {


### PR DESCRIPTION
This replaces the work in #136 and fixes #116 this allows the user to pick the error type that best suits their needs.

Working on this is a prerequisite for allowing the user to associate data with unavailable dependencies.