### PR TITLE
perf: invalidate less contradicted_incompatibilities

### DIFF
--- a/src/internal/core.rs
+++ b/src/internal/core.rs
@@ -29,7 +29,7 @@ pub struct State<P: Package, VS: VersionSet, Priority: Ord + Clone> {
 
     /// Store the ids of incompatibilities that are already contradicted
     /// and will stay that way until the next conflict and backtrack is operated.
-    contradicted_incompatibilities: rustc_hash::FxHashSet<IncompId<P, VS>>,
+    contradicted_incompatibilities: Map<IncompId<P, VS>, DecisionLevel>,
 
     /// All incompatibilities expressing dependencies,
     /// with common dependents merged.
@@ -62,7 +62,7 @@ impl<P: Package, VS: VersionSet, Priority: Ord + Clone> State<P, VS, Priority> {
             root_package,
             root_version,
             incompatibilities,
-            contradicted_incompatibilities: rustc_hash::FxHashSet::default(),
+            contradicted_incompatibilities: Map::default(),
             partial_solution: PartialSolution::empty(),
             incompatibility_store,
             unit_propagation_buffer: SmallVec::Empty,
@@ -111,7 +111,10 @@ impl<P: Package, VS: VersionSet, Priority: Ord + Clone> State<P, VS, Priority> {
             let mut conflict_id = None;
             // We only care about incompatibilities if it contains the current package.
             for &incompat_id in self.incompatibilities[&current_package].iter().rev() {
-                if self.contradicted_incompatibilities.contains(&incompat_id) {
+                if self
+                    .contradicted_incompatibilities
+                    .contains_key(&incompat_id)
+                {
                     continue;
                 }
                 let current_incompat = &self.incompatibility_store[incompat_id];
@@ -135,10 +138,12 @@ impl<P: Package, VS: VersionSet, Priority: Ord + Clone> State<P, VS, Priority> {
                             &self.incompatibility_store,
                         );
                         // With the partial solution updated, the incompatibility is now contradicted.
-                        self.contradicted_incompatibilities.insert(incompat_id);
+                        self.contradicted_incompatibilities
+                            .insert(incompat_id, self.partial_solution.current_decision_level());
                     }
                     Relation::Contradicted(_) => {
-                        self.contradicted_incompatibilities.insert(incompat_id);
+                        self.contradicted_incompatibilities
+                            .insert(incompat_id, self.partial_solution.current_decision_level());
                     }
                     _ => {}
                 }
@@ -155,7 +160,8 @@ impl<P: Package, VS: VersionSet, Priority: Ord + Clone> State<P, VS, Priority> {
                 );
                 // After conflict resolution and the partial solution update,
                 // the root cause incompatibility is now contradicted.
-                self.contradicted_incompatibilities.insert(root_cause);
+                self.contradicted_incompatibilities
+                    .insert(root_cause, self.partial_solution.current_decision_level());
             }
         }
         // If there are no more changed packages, unit propagation is done.
@@ -220,7 +226,8 @@ impl<P: Package, VS: VersionSet, Priority: Ord + Clone> State<P, VS, Priority> {
     ) {
         self.partial_solution
             .backtrack(decision_level, &self.incompatibility_store);
-        self.contradicted_incompatibilities.clear();
+        self.contradicted_incompatibilities
+            .retain(|_, dl| *dl <= decision_level);
         if incompat_changed {
             self.merge_incompatibility(incompat);
         }

--- a/src/internal/partial_solution.rs
+++ b/src/internal/partial_solution.rs
@@ -493,6 +493,10 @@ impl<P: Package, VS: VersionSet, Priority: Ord + Clone> PartialSolution<P, VS, P
             .unwrap();
         decision_level.max(DecisionLevel(1))
     }
+
+    pub fn current_decision_level(&self) -> DecisionLevel {
+        self.current_decision_level
+    }
 }
 
 impl<P: Package, VS: VersionSet> PackageAssignments<P, VS> {


### PR DESCRIPTION
This extends the work from #88. To quote:

> It is possible to figure out witch IncompIds are still used after a backtrack, but so far nothing that is pulls its weight.

Looking at our normal benchmarks this is still within the noise. Looking at `hobo` it is a 5% improvement. However it does reduce the number of times intersection is called, and our users are telling us that intersections in their code are more expensive than in our benchmarks.

There are more efficient alternatives to calling `retain(|_, dl| *dl <= decision_level)`. (The insertion order is also sorted by `dl`, so binary search and truncate is an option. Or ...) But I have not seen it in profiles so I don't think it is worth more complexity at this time.

**If** this is a big win for our users then we should merge soon. Otherwise, this can stick around until other optimizations make the background noise smaller.