### PR TITLE
ci: linter fixes

### DIFF
--- a/examples/unsat_root_message_no_version.rs
+++ b/examples/unsat_root_message_no_version.rs
@@ -92,13 +92,11 @@ impl ReportFormatter<Package, Range<SemanticVersion>> for CustomReportFormatter 
                     } else {
                         format!("{package} {package_set} depends on {dependency}")
                     }
+                } else if matches!(package, Package::Root) {
+                    // Exclude the dummy version for root packages
+                    format!("{package} depends on {dependency} {dependency_set}")
                 } else {
-                    if matches!(package, Package::Root) {
-                        // Exclude the dummy version for root packages
-                        format!("{package} depends on {dependency} {dependency_set}")
-                    } else {
-                        format!("{package} {package_set} depends on {dependency} {dependency_set}")
-                    }
+                    format!("{package} {package_set} depends on {dependency} {dependency_set}")
                 }
             }
         }

--- a/src/range.rs
+++ b/src/range.rs
@@ -629,7 +629,7 @@ pub mod tests {
                     segments.push((start_bound, Unbounded));
                 }
 
-                return Range { segments }.check_invariants();
+                Range { segments }.check_invariants()
             })
     }
 


### PR DESCRIPTION
`cargo test` and `cargo clippy` used to complain.

Tested commands:
```shell
cargo test
cargo test --all-features
cargo clippy
cargo clippy --tests
cargo clippy --tests --all-features
```