### PR TITLE
perf: fewer intersections in satisfier

### DIFF
--- a/src/internal/core.rs
+++ b/src/internal/core.rs
@@ -194,6 +194,7 @@ impl<P: Package, VS: VersionSet, Priority: Ord + Clone> State<P, VS, Priority> {
                     DifferentDecisionLevels {
                         previous_satisfier_level,
                     } => {
+                        let package = package.clone();
                         self.backtrack(
                             current_incompat_id,
                             current_incompat_changed,
@@ -206,7 +207,7 @@ impl<P: Package, VS: VersionSet, Priority: Ord + Clone> State<P, VS, Priority> {
                         let prior_cause = Incompatibility::prior_cause(
                             current_incompat_id,
                             satisfier_cause,
-                            &package,
+                            package,
                             &self.incompatibility_store,
                         );
                         log::info!("prior cause: {}", prior_cause);

--- a/src/internal/partial_solution.rs
+++ b/src/internal/partial_solution.rs
@@ -504,8 +504,12 @@ impl<P: Package, VS: VersionSet> PackageAssignments<P, VS> {
         for (idx, dated_derivation) in self.dated_derivations.iter().enumerate() {
             let accumulated = dated_derivation
                 .accumulated_intersection
-                .intersection(start_term);
-            let new = accumulated == accumulated.intersection(incompat_term);
+                .intersection(start_term)
+                .intersection(&incompat_term.negate());
+            let new = accumulated
+                == accumulated
+                    .intersection(incompat_term)
+                    .intersection(&incompat_term.negate());
             #[cfg(debug_assertions)]
             {
                 let old = dated_derivation

--- a/src/internal/partial_solution.rs
+++ b/src/internal/partial_solution.rs
@@ -407,19 +407,16 @@ impl<P: Package, VS: VersionSet, Priority: Ord + Clone> PartialSolution<P, VS, P
             &self.package_assignments,
             store,
         );
-        if previous_satisfier_level < satisfier_decision_level {
-            let search_result = SatisfierSearch::DifferentDecisionLevels {
+        let search_result = if previous_satisfier_level < satisfier_decision_level {
+            SatisfierSearch::DifferentDecisionLevels {
                 previous_satisfier_level,
-            };
-            (satisfier_package, search_result)
+            }
         } else {
-            let satisfier_pa = self.package_assignments.get(satisfier_package).unwrap();
-            let dd = &satisfier_pa.dated_derivations[satisfier_index];
-            let search_result = SatisfierSearch::SameDecisionLevels {
-                satisfier_cause: dd.cause,
-            };
-            (satisfier_package, search_result)
-        }
+            let satisfier_pa = &self.package_assignments[satisfier_package];
+            let satisfier_cause = satisfier_pa.dated_derivations[satisfier_index].cause;
+            SatisfierSearch::SameDecisionLevels { satisfier_cause }
+        };
+        (satisfier_package, search_result)
     }
 
     /// A satisfier is the earliest assignment in partial solution such that the incompatibility

--- a/src/internal/partial_solution.rs
+++ b/src/internal/partial_solution.rs
@@ -502,10 +502,10 @@ impl<P: Package, VS: VersionSet> PackageAssignments<P, VS> {
     ) -> (usize, u32, DecisionLevel) {
         // Indicate if we found a satisfier in the list of derivations, otherwise it will be the decision.
         for (idx, dated_derivation) in self.dated_derivations.iter().enumerate() {
-            let new = dated_derivation
+            let accumulated = dated_derivation
                 .accumulated_intersection
-                .intersection(start_term)
-                .subset_of(incompat_term);
+                .intersection(start_term);
+            let new = accumulated == accumulated.intersection(incompat_term);
             #[cfg(debug_assertions)]
             {
                 let old = dated_derivation

--- a/src/internal/partial_solution.rs
+++ b/src/internal/partial_solution.rs
@@ -500,16 +500,14 @@ impl<P: Package, VS: VersionSet> PackageAssignments<P, VS> {
         incompat_term: &Term<VS>,
         start_term: &Term<VS>,
     ) -> (usize, u32, DecisionLevel) {
+        let empty = Term::empty();
         // Indicate if we found a satisfier in the list of derivations, otherwise it will be the decision.
         for (idx, dated_derivation) in self.dated_derivations.iter().enumerate() {
             let accumulated = dated_derivation
                 .accumulated_intersection
                 .intersection(start_term)
                 .intersection(&incompat_term.negate());
-            let new = accumulated
-                == accumulated
-                    .intersection(incompat_term)
-                    .intersection(&incompat_term.negate());
+            let new = accumulated == empty;
             #[cfg(debug_assertions)]
             {
                 let old = dated_derivation

--- a/src/internal/partial_solution.rs
+++ b/src/internal/partial_solution.rs
@@ -501,12 +501,12 @@ impl<P: Package, VS: VersionSet> PackageAssignments<P, VS> {
         start_term: &Term<VS>,
     ) -> (usize, u32, DecisionLevel) {
         let empty = Term::empty();
+        let intersection_term = start_term.intersection(&incompat_term.negate());
         // Indicate if we found a satisfier in the list of derivations, otherwise it will be the decision.
         for (idx, dated_derivation) in self.dated_derivations.iter().enumerate() {
             let accumulated = dated_derivation
                 .accumulated_intersection
-                .intersection(start_term)
-                .intersection(&incompat_term.negate());
+                .intersection(&intersection_term);
             let new = accumulated == empty;
             #[cfg(debug_assertions)]
             {

--- a/src/internal/partial_solution.rs
+++ b/src/internal/partial_solution.rs
@@ -502,11 +502,19 @@ impl<P: Package, VS: VersionSet> PackageAssignments<P, VS> {
     ) -> (usize, u32, DecisionLevel) {
         // Indicate if we found a satisfier in the list of derivations, otherwise it will be the decision.
         for (idx, dated_derivation) in self.dated_derivations.iter().enumerate() {
-            if dated_derivation
+            let new = dated_derivation
                 .accumulated_intersection
                 .intersection(start_term)
-                .subset_of(incompat_term)
+                .subset_of(incompat_term);
+            #[cfg(debug_assertions)]
             {
+                let old = dated_derivation
+                    .accumulated_intersection
+                    .intersection(start_term)
+                    .subset_of(incompat_term);
+                assert_eq!(old, new);
+            }
+            if new {
                 // We found the derivation causing satisfaction.
                 return (
                     idx,

--- a/src/internal/partial_solution.rs
+++ b/src/internal/partial_solution.rs
@@ -516,19 +516,6 @@ impl<P: Package, VS: VersionSet> PackageAssignments<P, VS> {
         let new_idx = self.dated_derivations.as_slice().partition_point(|dd| {
             dd.accumulated_intersection.intersection(&intersection_term) != empty
         });
-        #[cfg(debug_assertions)]
-        for (idx, dated_derivation) in self.dated_derivations.iter().enumerate() {
-            let old = dated_derivation
-                .accumulated_intersection
-                .intersection(start_term)
-                .subset_of(incompat_term);
-            if old {
-                assert_eq!(new_idx, idx);
-                break;
-            } else {
-                assert!(idx < new_idx);
-            }
-        }
         if let Some(dd) = self.dated_derivations.get(new_idx) {
             debug_assert_eq!(
                 dd.accumulated_intersection.intersection(&intersection_term),

--- a/src/internal/partial_solution.rs
+++ b/src/internal/partial_solution.rs
@@ -445,7 +445,7 @@ impl<P: Package, VS: VersionSet, Priority: Ord + Clone> PartialSolution<P, VS, P
                     package,
                     incompat_term,
                     &Term::any(),
-                    &Term::any().intersection(&incompat_term.negate()),
+                    &incompat_term.negate(),
                 ),
             );
         }

--- a/src/term.rs
+++ b/src/term.rs
@@ -107,6 +107,7 @@ impl<VS: VersionSet> Term<VS> {
     /// Indicate if this term is a subset of another term.
     /// Just like for sets, we say that t1 is a subset of t2
     /// if and only if t1 ∩ t2 = t1.
+    #[cfg(debug_assertions)]
     pub(crate) fn subset_of(&self, other: &Self) -> bool {
         self == &self.intersection(other)
     }

--- a/src/term.rs
+++ b/src/term.rs
@@ -107,7 +107,7 @@ impl<VS: VersionSet> Term<VS> {
     /// Indicate if this term is a subset of another term.
     /// Just like for sets, we say that t1 is a subset of t2
     /// if and only if t1 ∩ t2 = t1.
-    #[cfg(debug_assertions)]
+    #[cfg(test)]
     pub(crate) fn subset_of(&self, other: &Self) -> bool {
         self == &self.intersection(other)
     }


### PR DESCRIPTION
This is some "straightforward" re-factoring to the satisfier code to take advantage of #171. This is not my first time following this line of inquiry. In previous attempts I have only saved the final solution, and then not been confident that the final solution had the same semantics as the original. So this time I kept a separate commit for each transformation. I also kept the original code around with debug asserts to make sure they had the same behavior. Each commit passes all tests. I would strongly recommend reviewing this one commit at a time, and looking at the commit message for why I thought it was correct.

Some highlights: 1299c67 goes from 2 intersections to 1 for each decision searched in the history.  5127437 goes from a linear to a logarithmic scan. 78f8fb1 and the commits that follow are just things I noticed while staring at this code and can be left for follow-up PRs if their controversial.

As for performance the normal benchmarks think this is lost in the noise. Because they don't do much backtracking and intersection is fairly cheap. The new synthetic benchmark `slow_135_0_u16_NumberVersion` improves its runtime by **82%**!