### PR TITLE
ci: false positive

### DIFF
--- a/src/internal/small_map.rs
+++ b/src/internal/small_map.rs
@@ -177,6 +177,8 @@ impl<'a, K: 'a, V: 'a> Iterator for IterSmallMap<'a, K, V> {
 
     fn next(&mut self) -> Option<Self::Item> {
         match self {
+            // False-positive, remove when stable is >=1.76 February 24
+            #[allow(clippy::map_identity)]
             IterSmallMap::Inline(inner) => inner.next().map(|(k, v)| (k, v)),
             IterSmallMap::Map(inner) => inner.next(),
         }


### PR DESCRIPTION
Stable clippy complains about this line. Nightly does not. Furthermore following the suggestion, or any variant of the suggestion I've tried, does not lead to code that compiles. I think this is a false positive and we should ignore it for six weeks.