### PR TITLE
perf: specialize range operations for better performances

### DIFF
--- a/src/internal/incompatibility.rs
+++ b/src/internal/incompatibility.rs
@@ -173,8 +173,11 @@ impl<P: Package, VS: VersionSet> Incompatibility<P, VS> {
         incompatibility_store: &Arena<Self>,
     ) -> Self {
         let kind = Kind::DerivedFrom(incompat, satisfier_cause);
-        let mut package_terms = incompatibility_store[incompat].package_terms.clone();
-        let t1 = package_terms.remove(package).unwrap();
+        // Optimization to avoid cloning and dropping t1
+        let (t1, mut package_terms) = incompatibility_store[incompat]
+            .package_terms
+            .split_one(package)
+            .unwrap();
         let satisfier_cause_terms = &incompatibility_store[satisfier_cause].package_terms;
         package_terms.merge(
             satisfier_cause_terms.iter().filter(|(p, _)| p != &package),

--- a/src/internal/partial_solution.rs
+++ b/src/internal/partial_solution.rs
@@ -501,7 +501,7 @@ impl<P: Package, VS: VersionSet> PackageAssignments<P, VS> {
         let idx = self
             .dated_derivations
             .as_slice()
-            .partition_point(|dd| dd.accumulated_intersection.intersection(start_term) != empty);
+            .partition_point(|dd| !dd.accumulated_intersection.is_disjoint(start_term));
         if let Some(dd) = self.dated_derivations.get(idx) {
             debug_assert_eq!(dd.accumulated_intersection.intersection(start_term), empty);
             return (Some(dd.cause), dd.global_index, dd.decision_level);

--- a/src/range.rs
+++ b/src/range.rs
@@ -301,7 +301,7 @@ impl<V: Ord> Range<V> {
                 assert!(end_before_start_with_gap(&p[0].1, &p[1].0));
             }
             for (s, e) in self.segments.iter() {
-                assert!(valid_segment(&s, &e));
+                assert!(valid_segment(s, e));
             }
         }
         self
@@ -518,7 +518,7 @@ impl<V: Ord + Clone> Range<V> {
             // But, we already know that the segments in our input are valid.
             // So we do not need to check if the `start`  from the input `end` came from is smaller then `end`.
             // If the `other_start` is larger than end, then the intersection will be invalid.
-            if !valid_segment(&other_start, &end) {
+            if !valid_segment(other_start, end) {
                 // Note: We can call `this_iter.next_if(!valid_segment(other_start, this_end))` in a loop.
                 // But the checks make it slower for the benchmarked inputs.
                 continue;

--- a/src/range.rs
+++ b/src/range.rs
@@ -298,14 +298,7 @@ impl<V: Ord> Range<V> {
     fn check_invariants(self) -> Self {
         if cfg!(debug_assertions) {
             for p in self.segments.as_slice().windows(2) {
-                match (&p[0].1, &p[1].0) {
-                    (Included(l_end), Included(r_start)) => assert!(l_end < r_start),
-                    (Included(l_end), Excluded(r_start)) => assert!(l_end < r_start),
-                    (Excluded(l_end), Included(r_start)) => assert!(l_end < r_start),
-                    (Excluded(l_end), Excluded(r_start)) => assert!(l_end <= r_start),
-                    (_, Unbounded) => panic!(),
-                    (Unbounded, _) => panic!(),
-                }
+                assert!(end_before_start_with_gap(&p[0].1, &p[1].0));
             }
             for (s, e) in self.segments.iter() {
                 assert!(valid_segment(s, e));
@@ -457,7 +450,6 @@ impl<V: Ord + Clone> Range<V> {
                     let accumulator_end = match (accumulator_.1, smaller_interval.1) {
                         (_, Unbounded) | (Unbounded, _) => &Unbounded,
                         (Included(l), Excluded(r) | Included(r)) if l == r => accumulator_.1,
-                        (Excluded(l) | Included(l), Included(r)) if l == r => smaller_interval.1,
                         (Included(l) | Excluded(l), Included(r) | Excluded(r)) => {
                             if l > r {
                                 accumulator_.1

--- a/src/range.rs
+++ b/src/range.rs
@@ -709,6 +709,14 @@ impl<T: Debug + Display + Clone + Eq + Ord> VersionSet for Range<T> {
     fn union(&self, other: &Self) -> Self {
         Range::union(self, other)
     }
+
+    fn is_disjoint(&self, other: &Self) -> bool {
+        Range::is_disjoint(self, other)
+    }
+
+    fn subset_of(&self, other: &Self) -> bool {
+        Range::subset_of(self, other)
+    }
 }
 
 // REPORT ######################################################################

--- a/src/term.rs
+++ b/src/term.rs
@@ -127,10 +127,10 @@ impl<VS: VersionSet> Term<VS> {
         match (self, other) {
             (Self::Positive(r1), Self::Positive(r2)) => Self::Positive(r1.union(r2)),
             (Self::Positive(r1), Self::Negative(r2)) => {
-                Self::Negative(r1.union(&r2.complement()).complement())
+                Self::Negative(r1.complement().intersection(r2))
             }
             (Self::Negative(r1), Self::Positive(r2)) => {
-                Self::Negative(r1.complement().union(r2).complement())
+                Self::Negative(r1.intersection(&r2.complement()))
             }
             (Self::Negative(r1), Self::Negative(r2)) => Self::Negative(r1.intersection(r2)),
         }

--- a/src/term.rs
+++ b/src/term.rs
@@ -142,7 +142,7 @@ impl<VS: VersionSet> Term<VS> {
     pub(crate) fn subset_of(&self, other: &Self) -> bool {
         match (self, other) {
             (Self::Positive(r1), Self::Positive(r2)) => r1.subset_of(r2),
-            (Self::Positive(r1), Self::Negative(r2)) => r1.subset_of(&r2.complement()),
+            (Self::Positive(r1), Self::Negative(r2)) => r1.is_disjoint(r2),
             (Self::Negative(_), Self::Positive(_)) => false,
             (Self::Negative(r1), Self::Negative(r2)) => r2.subset_of(r1),
         }

--- a/src/term.rs
+++ b/src/term.rs
@@ -144,7 +144,7 @@ impl<VS: VersionSet> Term<VS> {
             (Self::Positive(r1), Self::Positive(r2)) => r1.subset_of(r2),
             (Self::Positive(r1), Self::Negative(r2)) => r1.subset_of(&r2.complement()),
             (Self::Negative(_), Self::Positive(_)) => false,
-            (Self::Negative(r1), Self::Negative(r2)) => r2.subset_of(&r1),
+            (Self::Negative(r1), Self::Negative(r2)) => r2.subset_of(r1),
         }
     }
 }

--- a/src/term.rs
+++ b/src/term.rs
@@ -96,11 +96,8 @@ impl<VS: VersionSet> Term<VS> {
     pub(crate) fn intersection(&self, other: &Self) -> Self {
         match (self, other) {
             (Self::Positive(r1), Self::Positive(r2)) => Self::Positive(r1.intersection(r2)),
-            (Self::Positive(r1), Self::Negative(r2)) => {
-                Self::Positive(r1.intersection(&r2.complement()))
-            }
-            (Self::Negative(r1), Self::Positive(r2)) => {
-                Self::Positive(r1.complement().intersection(r2))
+            (Self::Positive(p), Self::Negative(n)) | (Self::Negative(n), Self::Positive(p)) => {
+                Self::Positive(n.complement().intersection(p))
             }
             (Self::Negative(r1), Self::Negative(r2)) => Self::Negative(r1.union(r2)),
         }
@@ -115,9 +112,9 @@ impl<VS: VersionSet> Term<VS> {
             (Self::Negative(r1), Self::Negative(r2)) => r1 == &VS::empty() && r2 == &VS::empty(),
             // If the positive term is a subset of the negative term, it lies fully in the region that the negative
             // term excludes.
-            (Self::Positive(r1), Self::Negative(r2)) => r1.subset_of(r2),
-            // Inversely, if there is a region outside the negative, they overlap in this region.
-            (Self::Negative(r1), Self::Positive(r2)) => r2.subset_of(r1),
+            (Self::Positive(p), Self::Negative(n)) | (Self::Negative(n), Self::Positive(p)) => {
+                p.subset_of(n)
+            }
         }
     }
 
@@ -126,11 +123,8 @@ impl<VS: VersionSet> Term<VS> {
     pub(crate) fn union(&self, other: &Self) -> Self {
         match (self, other) {
             (Self::Positive(r1), Self::Positive(r2)) => Self::Positive(r1.union(r2)),
-            (Self::Positive(r1), Self::Negative(r2)) => {
-                Self::Negative(r1.complement().intersection(r2))
-            }
-            (Self::Negative(r1), Self::Positive(r2)) => {
-                Self::Negative(r1.intersection(&r2.complement()))
+            (Self::Positive(p), Self::Negative(n)) | (Self::Negative(n), Self::Positive(p)) => {
+                Self::Negative(p.complement().intersection(n))
             }
             (Self::Negative(r1), Self::Negative(r2)) => Self::Negative(r1.intersection(r2)),
         }

--- a/src/version_set.rs
+++ b/src/version_set.rs
@@ -57,4 +57,14 @@ pub trait VersionSet: Debug + Display + Clone + Eq {
             .intersection(&other.complement())
             .complement()
     }
+
+    /// Whether the range have no overlapping segmets
+    fn is_disjoint(&self, other: &Self) -> bool {
+        self.intersection(other) == Self::empty()
+    }
+
+    /// Whether all range of `self` are contained in `other`
+    fn subset_of(&self, other: &Self) -> bool {
+        self == &self.intersection(other)
+    }
 }


### PR DESCRIPTION
In uv, we have a very slow case with bio_embeddings, which include boto3 and botocore. In the fully cached case, the great majority of time is spent in range operation with large ranges due to the many version. 
I replaced some range operations implemented by their mathematical definitions with optimized versions. This PR is based on profiling my test case, `bio_embeddings[all]` on python 3.12.

To reproduce, checkout `git clone https://github.com/astral-sh/uv` and replace the pubgrub dependency with https://github.com/astral-sh/pubgrub/pull/25, build with `cargo build --profile profiling` and run with `samply record`, i ran with `--rate 5000`.

**before** 12s

![image](https://github.com/pubgrub-rs/pubgrub/assets/6826232/80ffdc49-1159-453d-a3ea-0dd431df6d3b)

**after** 3s

![image](https://github.com/pubgrub-rs/pubgrub/assets/6826232/69508c29-73ab-4593-a588-d8c722242513)

The atomic/drop operations are clone and drop for our version type, which is an `Arc`.

This scenarios slow because we try a lot of versions:

```
Tried 101329 versions: pytest 2628, botocore 2627, blis 1314, boto3 1314, certifi 1314, charset-normalizer 1314, click 1314, conllu 1314, contourpy 1314, cycler 1314, cymem 1314, editdistance 1314, flaky 1314, flask 1314, flask-cors 1314, fonttools 1314, fsspec 1314, ftfy 1314, gevent 1314, huggingface-hub 1314, idna 1314, jinja2 1314, joblib 1314, jsonnet 1314, jsonpickle 1314, kiwisolver 1314, murmurhash 1314, networkx 1314, nltk 1314, numba 1314, numpydoc 1314, nvidia-cublas-cu12 1314, nvidia-cuda-cupti-cu12 1314, nvidia-cuda-nvrtc-cu12 1314, nvidia-cuda-runtime-cu12 1314, nvidia-cudnn-cu12 1314, nvidia-cufft-cu12 1314, nvidia-curand-cu12 1314, nvidia-cusolver-cu12 1314, nvidia-cusparse-cu12 1314, nvidia-nccl-cu12 1314, nvidia-nvtx-cu12 1314, overrides 1314, packaging 1314, parsimonious 1314, plac 1314, preshed 1314, protobuf 1314, pynndescent 1314, pyparsing 1314, python-dateutil 1314, pytorch-pretrained-bert 1314, pytorch-transformers 1314, pyyaml 1314, regex 1314, responses 1314, ruamel-yaml-clib 1314, safetensors 1314, sentencepiece 1314, six 1314, spacy 1314, sqlparse 1314, srsly 1314, sympy 1314, tenacity 1314, tensorboardx 1314, thinc 1314, threadpoolctl 1314, tokenizers 1314, typing-extensions 1314, tzdata 1314, unidecode 1314, wasabi 1314, word2number 1314, wrapt 1314, allennlp 27, torch 20, bio-embeddings[all] 10, bio-embeddings 4, biopython 4, gensim 4, h5py 4, matplotlib 3, numpy 3, pandas 3, plotly 3, ruamel-yaml 3, scikit-learn 3, scipy 3, Python 2, appdirs 2, importlib-metadata 2, jax-unirep 2, jaxlib 2, lock 2, alabaster 1, babel 1, bio-embeddings-allennlp 1, bio-embeddings-bepler 1, bio-embeddings-cpcprot 1, bio-embeddings-esm 1, bio-embeddings-plus 1, bio-embeddings-tape-proteins 1, blinker 1, docutils 1, filelock 1, greenlet 1, imagesize 1, iniconfig 1, itsdangerous 1, jmespath 1, llvmlite 1, markupsafe 1, mpmath 1, nvidia-nvjitlink-cu12 1, pillow 1, pluggy 1, pygments 1, pytz 1, requests 1, root 1, s3transfer 1, setuptools 1, smart-open 1, snowballstemmer 1, sphinx 1, sphinxcontrib-applehelp 1, sphinxcontrib-devhelp 1, sphinxcontrib-htmlhelp 1, sphinxcontrib-jsmath 1, sphinxcontrib-qthelp 1, sphinxcontrib-serializinghtml 1, tabulate 1, tqdm 1, transformers 1, umap-learn 1, urllib3 1, wcwidth 1, werkzeug 1, zope-event 1, zope-interface 1
```

(Taskset descreases the variance for a minimal slowdown, we're bound on single-threaded pubgrub in this benchmark and not on multithreaded io/parsing.)

```
$  taskset -c 0 hyperfine --warmup 1 "../uv/target/profiling/main-uv pip compile ../uv/scripts/requirements/bio_embeddings.in"  "../uv/target/profiling/branch-uv pip compile ../uv/scripts/requirements/bio_embeddings.in" 
Benchmark 1: ../uv/target/profiling/main-uv pip compile ../uv/scripts/requirements/bio_embeddings.in
  Time (mean ± σ):     12.321 s ±  0.064 s    [User: 12.014 s, System: 0.300 s]
  Range (min … max):   12.224 s … 12.406 s    10 runs
 
Benchmark 2: ../uv/target/profiling/branch-uv pip compile ../uv/scripts/requirements/bio_embeddings.in
  Time (mean ± σ):      3.109 s ±  0.004 s    [User: 2.782 s, System: 0.321 s]
  Range (min … max):    3.103 s …  3.116 s    10 runs
 
Summary
  ../uv/target/profiling/branch-uv pip compile ../uv/scripts/requirements/bio_embeddings.in ran
    3.96 ± 0.02 times faster than ../uv/target/profiling/main-uv pip compile ../uv/scripts/requirements/bio_embeddings.in
```

I'd say this closes #135.

---

The lack combination of lack of `Ord` on `Bound` and `Unbounded` being `-inf` or `inf` depending on the (untyped) context makes implementing these manually tedious, i wonder if we could add some abstraction?

---

The first two commits of this PR can be split out into separate PRs. From main over each of the three commits:

![image](https://github.com/pubgrub-rs/pubgrub/assets/6826232/bc52608a-bef2-4bda-a489-a0336e1b3a3b)

![image](https://github.com/pubgrub-rs/pubgrub/assets/6826232/97a547a5-3fa2-4e38-a306-bae149f44803)

![image](https://github.com/pubgrub-rs/pubgrub/assets/6826232/f8335912-d470-49e5-8c19-bc33d9fb7008)

![image](https://github.com/pubgrub-rs/pubgrub/assets/6826232/a40b2f1e-b030-46d3-bd4c-a521b8bc86ed)
