### PR TITLE
provoke bugs that rely on iteration order of hash maps/sets

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ thiserror = "1.0"
 rustc-hash = "1.1.0"
 serde = { version = "1.0", features = ["derive"], optional = true }
 log = "0.4.14" # for debug logs in tests
+rand = "0.8.5"
 
 [dev-dependencies]
 proptest = "0.10.1"

--- a/src/internal/core.rs
+++ b/src/internal/core.rs
@@ -3,7 +3,6 @@
 //! Core model and functions
 //! to write a functional PubGrub algorithm.
 
-use std::collections::HashSet as Set;
 use std::error::Error;
 
 use crate::error::PubGrubError;
@@ -16,7 +15,7 @@ use crate::internal::partial_solution::{DecisionLevel, PartialSolution};
 use crate::internal::small_vec::SmallVec;
 use crate::package::Package;
 use crate::report::DerivationTree;
-use crate::type_aliases::{DependencyConstraints, Map};
+use crate::type_aliases::{DependencyConstraints, Map, Set};
 use crate::version_set::VersionSet;
 
 /// Current state of the PubGrub algorithm.
@@ -294,8 +293,8 @@ impl<P: Package, VS: VersionSet, Priority: Ord + Clone> State<P, VS, Priority> {
     }
 
     fn find_shared_ids(&self, incompat: IncompId<P, VS>) -> Set<IncompId<P, VS>> {
-        let mut all_ids = Set::new();
-        let mut shared_ids = Set::new();
+        let mut all_ids = Set::default();
+        let mut shared_ids = Set::default();
         let mut stack = vec![incompat];
         while let Some(i) = stack.pop() {
             if let Some((id1, id2)) = self.incompatibility_store[i].causes() {

--- a/src/internal/incompatibility.rs
+++ b/src/internal/incompatibility.rs
@@ -3,7 +3,6 @@
 //! An incompatibility is a set of terms for different packages
 //! that should never be satisfied all together.
 
-use std::collections::HashSet as Set;
 use std::fmt;
 
 use crate::internal::arena::{Arena, Id};
@@ -13,6 +12,7 @@ use crate::report::{
     DefaultStringReportFormatter, DerivationTree, Derived, External, ReportFormatter,
 };
 use crate::term::{self, Term};
+use crate::type_aliases::Set;
 use crate::version_set::VersionSet;
 
 /// An incompatibility is a set of terms for different packages

--- a/src/internal/small_map.rs
+++ b/src/internal/small_map.rs
@@ -1,4 +1,4 @@
-use crate::type_aliases::Map;
+use crate::type_aliases::{Map, MapIter};
 use std::hash::Hash;
 
 #[derive(Debug, Clone)]
@@ -169,10 +169,10 @@ impl<K: Eq + Hash + Clone, V: Clone> SmallMap<K, V> {
 
 enum IterSmallMap<'a, K, V> {
     Inline(std::slice::Iter<'a, (K, V)>),
-    Map(std::collections::hash_map::Iter<'a, K, V>),
+    Map(MapIter<'a, K, V>),
 }
 
-impl<'a, K: 'a, V: 'a> Iterator for IterSmallMap<'a, K, V> {
+impl<'a, K: 'a + Eq + Hash, V: 'a> Iterator for IterSmallMap<'a, K, V> {
     type Item = (&'a K, &'a V);
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -185,7 +185,7 @@ impl<'a, K: 'a, V: 'a> Iterator for IterSmallMap<'a, K, V> {
     }
 }
 
-impl<K, V> SmallMap<K, V> {
+impl<K: Eq + Hash, V> SmallMap<K, V> {
     pub fn iter(&self) -> impl Iterator<Item = (&K, &V)> {
         match self {
             Self::Empty => IterSmallMap::Inline([].iter()),

--- a/src/type_aliases.rs
+++ b/src/type_aliases.rs
@@ -5,6 +5,9 @@
 /// Map implementation used by the library.
 pub type Map<K, V> = rustc_hash::FxHashMap<K, V>;
 
+/// Set implementation used by the library.
+pub type Set<V> = rustc_hash::FxHashSet<V>;
+
 /// Concrete dependencies picked by the library during [resolve](crate::solver::resolve)
 /// from [DependencyConstraints].
 pub type SelectedDependencies<P, V> = Map<P, V>;

--- a/src/type_aliases.rs
+++ b/src/type_aliases.rs
@@ -2,11 +2,20 @@
 
 //! Publicly exported type aliases.
 
-/// Map implementation used by the library.
-pub type Map<K, V> = rustc_hash::FxHashMap<K, V>;
+#![allow(warnings)]
 
-/// Set implementation used by the library.
-pub type Set<V> = rustc_hash::FxHashSet<V>;
+use std::{
+    borrow::Borrow,
+    hash::{BuildHasher, BuildHasherDefault, Hash},
+};
+
+// /// Map implementation used by the library.
+// pub type Map<K, V> = rustc_hash::FxHashMap<K, V>;
+
+// /// Set implementation used by the library.
+// pub type Set<V> = rustc_hash::FxHashSet<V>;
+
+pub type Map<K, V> = MapI<K, V, BuildHasherDefault<rustc_hash::FxHasher>>;
 
 /// Concrete dependencies picked by the library during [resolve](crate::solver::resolve)
 /// from [DependencyConstraints].
@@ -18,3 +27,165 @@ pub type SelectedDependencies<P, V> = Map<P, V>;
 /// the former means the package has no dependency and it is a known fact,
 /// while the latter means they could not be fetched by the [DependencyProvider](crate::solver::DependencyProvider).
 pub type DependencyConstraints<P, VS> = Map<P, VS>;
+
+#[derive(Debug, Clone)]
+pub struct MapI<K, V, S> {
+    map: std::collections::HashMap<K, V, S>,
+}
+
+impl<K, V, S> MapI<K, V, S> {
+    pub fn with_capacity_and_hasher(capacity: usize, hasher: S) -> MapI<K, V, S> {
+        MapI {
+            map: std::collections::HashMap::with_capacity_and_hasher(capacity, hasher),
+        }
+    }
+
+    pub fn iter(&self) -> std::collections::hash_map::Iter<'_, K, V> {
+        self.map.iter()
+    }
+
+    pub fn keys(&self) -> impl Iterator<Item = &K> {
+        self.map.keys()
+    }
+
+    pub fn len(&self) -> usize {
+        self.map.len()
+    }
+
+    pub fn retain(&mut self, f: impl FnMut(&K, &mut V) -> bool) {
+        self.map.retain(f)
+    }
+}
+
+impl<K: Hash + Eq, V, S: BuildHasher> MapI<K, V, S> {
+    pub fn insert(&mut self, k: K, v: V) -> Option<V> {
+        self.map.insert(k, v)
+    }
+
+    pub fn remove(&mut self, k: &K) -> Option<V> {
+        self.map.remove(k)
+    }
+
+    pub fn contains_key(&self, k: &K) -> bool {
+        self.map.contains_key(k)
+    }
+
+    pub fn get(&self, k: &K) -> Option<&V> {
+        self.map.get(k)
+    }
+
+    pub fn get_mut(&mut self, k: &K) -> Option<&mut V> {
+        self.map.get_mut(k)
+    }
+
+    pub fn entry(&mut self, k: K) -> std::collections::hash_map::Entry<'_, K, V> {
+        self.map.entry(k)
+    }
+}
+
+impl<K, V, S: Default> Default for MapI<K, V, S> {
+    fn default() -> MapI<K, V, S> {
+        MapI {
+            map: std::collections::HashMap::default(),
+        }
+    }
+}
+
+impl<K: Eq + Hash, V: PartialEq, S: BuildHasher> PartialEq for MapI<K, V, S> {
+    fn eq(&self, other: &MapI<K, V, S>) -> bool {
+        self.map.eq(&other.map)
+    }
+}
+
+impl<K: Hash + Eq, V, S: BuildHasher> Extend<(K, V)> for MapI<K, V, S> {
+    fn extend<T: IntoIterator<Item = (K, V)>>(&mut self, it: T) {
+        self.map.extend(it)
+    }
+}
+
+impl<'a, K: 'a + Hash + Eq + Clone, V: 'a + Clone, S: BuildHasher> Extend<(&'a K, &'a V)>
+    for MapI<K, V, S>
+{
+    fn extend<T: IntoIterator<Item = (&'a K, &'a V)>>(&mut self, it: T) {
+        self.map
+            .extend(it.into_iter().map(|(k, v)| (k.clone(), v.clone())))
+    }
+}
+
+pub struct Set<V> {
+    set: rustc_hash::FxHashSet<V>,
+}
+
+impl<V> Set<V> {
+    pub fn iter(&self) -> impl Iterator<Item = &V> {
+        self.set.iter()
+    }
+}
+
+impl<V: Hash + Eq> Set<V> {
+    pub fn insert(&mut self, v: V) -> bool {
+        self.set.insert(v)
+    }
+
+    pub fn contains(&self, v: &V) -> bool {
+        self.set.contains(v)
+    }
+
+    pub fn get(&self, v: &V) -> Option<&V> {
+        self.set.get(v)
+    }
+}
+
+impl<V> Default for Set<V> {
+    fn default() -> Set<V> {
+        Set {
+            set: rustc_hash::FxHashSet::default(),
+        }
+    }
+}
+
+impl<V: Hash + Eq> Extend<V> for Set<V> {
+    fn extend<T: IntoIterator<Item = V>>(&mut self, it: T) {
+        self.set.extend(it)
+    }
+}
+
+impl<'a, V: 'a + Hash + Eq + Clone> Extend<&'a V> for Set<V> {
+    fn extend<T: IntoIterator<Item = &'a V>>(&mut self, it: T) {
+        self.set.extend(it.into_iter().cloned())
+    }
+}
+
+impl<K: Hash + Eq, V, S: BuildHasher + Default> FromIterator<(K, V)> for MapI<K, V, S> {
+    fn from_iter<I: IntoIterator<Item = (K, V)>>(it: I) -> MapI<K, V, S> {
+        MapI {
+            map: FromIterator::from_iter(it),
+        }
+    }
+}
+
+impl<K: Eq + Hash + Borrow<Q>, Q: Eq + Hash + ?Sized, V, S: BuildHasher> std::ops::Index<&Q>
+    for MapI<K, V, S>
+{
+    type Output = V;
+
+    fn index(&self, key: &Q) -> &V {
+        self.map.index(key)
+    }
+}
+
+impl<K, V, S> IntoIterator for MapI<K, V, S> {
+    type Item = (K, V);
+    type IntoIter = std::collections::hash_map::IntoIter<K, V>;
+    fn into_iter(self) -> Self::IntoIter {
+        self.map.into_iter()
+    }
+}
+
+impl<'a, K, V, S> IntoIterator for &'a MapI<K, V, S> {
+    type Item = (&'a K, &'a V);
+    type IntoIter = std::collections::hash_map::Iter<'a, K, V>;
+    fn into_iter(self) -> Self::IntoIter {
+        (&self.map).into_iter()
+    }
+}

--- a/src/type_aliases.rs
+++ b/src/type_aliases.rs
@@ -36,14 +36,14 @@ impl<K, V, S> Map<K, V, S> {
         let keys: Vec<&K> = self.map.keys().collect();
         MapIter {
             map: self,
-            order: keys.into_iter(),
+            order: shuffle(keys).into_iter(),
         }
     }
 
     pub fn keys(&self) -> impl Iterator<Item = &K> {
         let keys: Vec<&K> = self.map.keys().collect();
         MapKeys {
-            order: keys.into_iter(),
+            order: shuffle(keys).into_iter(),
             _v: std::marker::PhantomData::<&V>,
         }
     }
@@ -142,7 +142,7 @@ impl<K: Clone + Eq + Hash, V, S: BuildHasher> IntoIterator for Map<K, V, S> {
         let keys: Vec<K> = self.map.keys().map(|k| k.clone()).collect();
         MapIntoIter {
             map: self,
-            order: keys.into_iter(),
+            order: shuffle(keys).into_iter(),
         }
     }
 }
@@ -205,7 +205,7 @@ impl<V> Set<V> {
     pub fn iter(&self) -> SetIter<V> {
         let keys: Vec<&V> = self.set.iter().collect();
         SetIter {
-            order: keys.into_iter(),
+            order: shuffle(keys).into_iter(),
         }
     }
 }
@@ -251,7 +251,7 @@ impl<V> IntoIterator for Set<V> {
     fn into_iter(self) -> Self::IntoIter {
         let keys: Vec<V> = self.set.into_iter().collect();
         SetIntoIter {
-            order: keys.into_iter(),
+            order: shuffle(keys).into_iter(),
         }
     }
 }
@@ -276,4 +276,10 @@ impl<'a, V> Iterator for SetIntoIter<V> {
     fn next(&mut self) -> Option<Self::Item> {
         self.order.next()
     }
+}
+
+fn shuffle<T>(mut v: Vec<T>) -> Vec<T> {
+    use rand::seq::SliceRandom;
+    v.shuffle(&mut rand::thread_rng());
+    v
 }


### PR DESCRIPTION
This PR is _not_ meant to be merged.

This PR hacks in a hash map/set wrapper that forcefully shuffles
iteration order with the goal of provoking bugs that result from
depending on a particular iteration order. Namely, hash maps/sets
in Rust's standard library don't have a defined iteration order.
With that said, I think that in practice, their order is somewhat
stable/predictable. But in some code we're working on at Astral (that
isn't public just yet), we've noticed some non-deterministic test
failures that we *believe* might be coming from pubgrub. This PR is
a test of that theory by forcing the issue and more aggressively
shuffling iteration order.

With this PR, I have been able to find one consistently failing test:
`prop_same_on_repeated_runs`. I'm hopeful it will show up in CI too.
But the failure output looks like this for me locally:

```
---- prop_same_on_repeated_runs stdout ----
proptest: FileFailurePersistence::SourceParallel set, but failed to find lib.rs or main.rs
thread 'prop_same_on_repeated_runs' panicked at tests/proptest.rs:460:39:
assertion `left == right` failed
  left: Map { map: {648: NumberVersion(11), 327: NumberVersion(12), 164: NumberVersion(12), 350: NumberVersion(8), 531: NumberVersion(1)} }
 right: Map { map: {648: NumberVersion(11), 327: NumberVersion(7), 164: NumberVersion(7), 350: NumberVersion(10), 531: NumberVersion(12)} }
thread 'prop_same_on_repeated_runs' panicked at tests/proptest.rs:460:39:
assertion `left == right` failed
  left: Map { map: {648: NumberVersion(11), 82: NumberVersion(7), 327: NumberVersion(7), 350: NumberVersion(10), 531: NumberVersion(12)} }
 right: Map { map: {648: NumberVersion(11), 82: NumberVersion(12), 327: NumberVersion(12), 350: NumberVersion(8), 531: NumberVersion(1)} }
thread 'prop_same_on_repeated_runs' panicked at tests/proptest.rs:460:39:
assertion `left == right` failed
  left: Map { map: {648: NumberVersion(11), 327: NumberVersion(7), 41: NumberVersion(7), 350: NumberVersion(10), 531: NumberVersion(12)} }
 right: Map { map: {648: NumberVersion(11), 327: NumberVersion(12), 41: NumberVersion(12), 350: NumberVersion(8), 531: NumberVersion(1)} }
thread 'prop_same_on_repeated_runs' panicked at tests/proptest.rs:460:39:
assertion `left == right` failed
  left: Map { map: {648: NumberVersion(11), 327: NumberVersion(7), 20: NumberVersion(7), 350: NumberVersion(10), 531: NumberVersion(12)} }
 right: Map { map: {648: NumberVersion(11), 327: NumberVersion(12), 20: NumberVersion(12), 350: NumberVersion(8), 531: NumberVersion(1)} }
thread 'prop_same_on_repeated_runs' panicked at tests/proptest.rs:460:39:
assertion `left == right` failed
  left: Map { map: {648: NumberVersion(11), 10: NumberVersion(12), 327: NumberVersion(12), 350: NumberVersion(8), 531: NumberVersion(1)} }
 right: Map { map: {648: NumberVersion(11), 10: NumberVersion(7), 327: NumberVersion(7), 350: NumberVersion(10), 531: NumberVersion(12)} }
thread 'prop_same_on_repeated_runs' panicked at tests/proptest.rs:460:39:
assertion `left == right` failed
  left: Map { map: {648: NumberVersion(11), 8: NumberVersion(7), 327: NumberVersion(7), 350: NumberVersion(10), 531: NumberVersion(12)} }
 right: Map { map: {648: NumberVersion(11), 8: NumberVersion(12), 327: NumberVersion(12), 350: NumberVersion(8), 531: NumberVersion(1)} }
thread 'prop_same_on_repeated_runs' panicked at tests/proptest.rs:460:39:
assertion `left == right` failed
  left: Map { map: {648: NumberVersion(11), 327: NumberVersion(7), 7: NumberVersion(7), 350: NumberVersion(10), 531: NumberVersion(12)} }
 right: Map { map: {648: NumberVersion(11), 327: NumberVersion(12), 7: NumberVersion(12), 350: NumberVersion(8), 531: NumberVersion(1)} }
thread 'prop_same_on_repeated_runs' panicked at tests/proptest.rs:460:39:
assertion `left == right` failed
  left: Map { map: {648: NumberVersion(11), 350: NumberVersion(8), 327: NumberVersion(12), 6: NumberVersion(12), 531: NumberVersion(1)} }
 right: Map { map: {648: NumberVersion(11), 6: NumberVersion(7), 327: NumberVersion(7), 350: NumberVersion(10), 531: NumberVersion(12)} }
thread 'prop_same_on_repeated_runs' panicked at tests/proptest.rs:397:1:
Test failed: assertion failed: `(left == right)`
  left: `"Because there is no version of 327 in <0 | >0 and 327 0 depends on 7 ∅, 327 * is forbidden.\nAnd because 568 0 depends on 327, 568 0 is forbidden."`,
 right: `"Because 327 0 depends on 7 ∅ and there is no version of 327 in <0 | >0, 327 * is forbidden.\nAnd because 568 0 depends on 327, 568 0 is forbidden."` at tests/proptest.rs:462; minimal failing input: (dependency_provider, cases) = (OfflineDependencyProvider { dependencies: Map { map: {568: {NumberVersion(0): Map { map: {7: Range { segments: [(Unbounded, Unbounded)] }, 327: Range { segments: [(Unbounded, Unbounded)] }} }, NumberVersion(6): Map { map: {} }}, 327: {NumberVersion(0): Map { map: {6: Range { segments: [(Unbounded, Excluded(NumberVersion(1)))] }, 7: Range { segments: [] }} }}, 7: {NumberVersion(0): Map { map: {} }}, 6: {NumberVersion(0): Map { map: {} }, NumberVersion(4): Map { map: {} }}} } }, [(568, NumberVersion(0)), (568, NumberVersion(6))])
        successes: 0
        local rejects: 0
        global rejects: 0
```

I don't know much about pubgrub internals, so I haven't really been
able to investigate the root cause of this failure. What do you think?
