### PR TITLE
impl: centralize use of hash sets/maps

### DIFF
--- a/src/internal/core.rs
+++ b/src/internal/core.rs
@@ -3,7 +3,6 @@
 //! Core model and functions
 //! to write a functional PubGrub algorithm.
 
-use std::collections::HashSet as Set;
 use std::error::Error;
 
 use crate::error::PubGrubError;
@@ -16,7 +15,7 @@ use crate::internal::partial_solution::{DecisionLevel, PartialSolution};
 use crate::internal::small_vec::SmallVec;
 use crate::package::Package;
 use crate::report::DerivationTree;
-use crate::type_aliases::{DependencyConstraints, Map};
+use crate::type_aliases::{DependencyConstraints, Map, Set};
 use crate::version_set::VersionSet;
 
 /// Current state of the PubGrub algorithm.
@@ -294,8 +293,8 @@ impl<P: Package, VS: VersionSet, Priority: Ord + Clone> State<P, VS, Priority> {
     }
 
     fn find_shared_ids(&self, incompat: IncompId<P, VS>) -> Set<IncompId<P, VS>> {
-        let mut all_ids = Set::new();
-        let mut shared_ids = Set::new();
+        let mut all_ids = Set::default();
+        let mut shared_ids = Set::default();
         let mut stack = vec![incompat];
         while let Some(i) = stack.pop() {
             if let Some((id1, id2)) = self.incompatibility_store[i].causes() {

--- a/src/internal/incompatibility.rs
+++ b/src/internal/incompatibility.rs
@@ -3,7 +3,6 @@
 //! An incompatibility is a set of terms for different packages
 //! that should never be satisfied all together.
 
-use std::collections::HashSet as Set;
 use std::fmt;
 
 use crate::internal::arena::{Arena, Id};
@@ -13,6 +12,7 @@ use crate::report::{
     DefaultStringReportFormatter, DerivationTree, Derived, External, ReportFormatter,
 };
 use crate::term::{self, Term};
+use crate::type_aliases::Set;
 use crate::version_set::VersionSet;
 
 /// An incompatibility is a set of terms for different packages

--- a/src/type_aliases.rs
+++ b/src/type_aliases.rs
@@ -5,6 +5,9 @@
 /// Map implementation used by the library.
 pub type Map<K, V> = rustc_hash::FxHashMap<K, V>;
 
+/// Set implementation used by the library.
+pub type Set<V> = rustc_hash::FxHashSet<V>;
+
 /// Concrete dependencies picked by the library during [resolve](crate::solver::resolve)
 /// from [DependencyConstraints].
 pub type SelectedDependencies<P, V> = Map<P, V>;


### PR DESCRIPTION
Previously, pubgrub used an alias for HashMap so that everything used
the same implementation. But it didn't do the same for HashSet, and
indeed, there were some uses of FxHashSet and std::collections::HashSet.
Like for HashMap, we standard on the use of FxHashSet for everything.
