### PR TITLE
test: check for unsorted iteration

### DIFF
--- a/src/range.rs
+++ b/src/range.rs
@@ -222,7 +222,17 @@ impl<V: Ord> Range<V> {
         I: Iterator<Item = &'s V> + 's,
         V: 's,
     {
+        #[cfg(debug_assertions)]
+        let mut last: Option<&V> = None;
         versions.scan(0, move |i, v| {
+            #[cfg(debug_assertions)]
+            {
+                assert!(
+                    last <= Some(v),
+                    "`contains_many` `versions` argument incorrectly sorted"
+                );
+                last = Some(v);
+            }
             while let Some(segment) = self.segments.get(*i) {
                 match within_bounds(v, segment) {
                     Ordering::Less => return Some(false),
@@ -430,8 +440,18 @@ impl<V: Ord + Clone> Range<V> {
         I: Iterator<Item = &'v V> + 'v,
         V: 'v,
     {
+        #[cfg(debug_assertions)]
+        let mut last: Option<&V> = None;
         // Return the segment index in the range for each version in the range, None otherwise
         let version_locations = versions.scan(0, move |i, v| {
+            #[cfg(debug_assertions)]
+            {
+                assert!(
+                    last <= Some(v),
+                    "`simplify` `versions` argument incorrectly sorted"
+                );
+                last = Some(v);
+            }
             while let Some(segment) = self.segments.get(*i) {
                 match within_bounds(v, segment) {
                     Ordering::Less => return Some(None),


### PR DESCRIPTION
I had a very difficult day debugging why `contains_many` did not match `contains`, turns out my input was not correctly sorted. Similarly, when debugging problems with simplify it would have been nice to easily reject "incorrectly sorted input". (Although that did not turn out to be relevant to the underlying issue.)

This should hopefully be an easy step in the right direction.