### PR TITLE
feat!: no recursion and Rc for causes

### DIFF
--- a/src/internal/core.rs
+++ b/src/internal/core.rs
@@ -4,7 +4,7 @@
 //! to write a functional PubGrub algorithm.
 
 use std::error::Error;
-use std::rc::Rc;
+use std::sync::Arc;
 
 use crate::error::PubGrubError;
 use crate::internal::arena::Arena;
@@ -316,9 +316,9 @@ impl<P: Package, VS: VersionSet, Priority: Ord + Clone> State<P, VS, Priority> {
                 &self.incompatibility_store,
                 &precomputed,
             );
-            precomputed.insert(id, Rc::new(tree));
+            precomputed.insert(id, Arc::new(tree));
         }
         // Now the user can refer to the entire tree from its root.
-        Rc::into_inner(precomputed.remove(&incompat).unwrap()).unwrap()
+        Arc::into_inner(precomputed.remove(&incompat).unwrap()).unwrap()
     }
 }

--- a/src/internal/core.rs
+++ b/src/internal/core.rs
@@ -4,6 +4,7 @@
 //! to write a functional PubGrub algorithm.
 
 use std::error::Error;
+use std::rc::Rc;
 
 use crate::error::PubGrubError;
 use crate::internal::arena::Arena;
@@ -315,9 +316,9 @@ impl<P: Package, VS: VersionSet, Priority: Ord + Clone> State<P, VS, Priority> {
                 &self.incompatibility_store,
                 &precomputed,
             );
-            precomputed.insert(id, Box::new(tree));
+            precomputed.insert(id, Rc::new(tree));
         }
         // Now the user can refer to the entire tree from its root.
-        *precomputed.remove(&incompat).unwrap()
+        Rc::into_inner(precomputed.remove(&incompat).unwrap()).unwrap()
     }
 }

--- a/src/internal/core.rs
+++ b/src/internal/core.rs
@@ -288,11 +288,6 @@ impl<P: Package, VS: VersionSet, Priority: Ord + Clone> State<P, VS, Priority> {
     // Error reporting #########################################################
 
     fn build_derivation_tree(&self, incompat: IncompId<P, VS>) -> DerivationTree<P, VS> {
-        let shared_ids = self.find_shared_ids(incompat);
-        Incompatibility::build_derivation_tree(incompat, &shared_ids, &self.incompatibility_store)
-    }
-
-    fn find_shared_ids(&self, incompat: IncompId<P, VS>) -> Set<IncompId<P, VS>> {
         let mut all_ids = Set::default();
         let mut shared_ids = Set::default();
         let mut stack = vec![incompat];
@@ -307,6 +302,6 @@ impl<P: Package, VS: VersionSet, Priority: Ord + Clone> State<P, VS, Priority> {
                 }
             }
         }
-        shared_ids
+        Incompatibility::build_derivation_tree(incompat, &shared_ids, &self.incompatibility_store)
     }
 }

--- a/src/internal/incompatibility.rs
+++ b/src/internal/incompatibility.rs
@@ -228,10 +228,10 @@ impl<P: Package, VS: VersionSet> Incompatibility<P, VS> {
         shared_ids: &Set<Id<Self>>,
         store: &Arena<Self>,
     ) -> DerivationTree<P, VS> {
-        match &store[self_id].kind {
+        match store[self_id].kind.clone() {
             Kind::DerivedFrom(id1, id2) => {
-                let cause1 = Self::build_derivation_tree(*id1, shared_ids, store);
-                let cause2 = Self::build_derivation_tree(*id2, shared_ids, store);
+                let cause1 = Self::build_derivation_tree(id1, shared_ids, store);
+                let cause2 = Self::build_derivation_tree(id2, shared_ids, store);
                 let derived = Derived {
                     terms: store[self_id].package_terms.as_map(),
                     shared_id: shared_ids.get(&self_id).map(|id| id.into_raw()),
@@ -241,22 +241,17 @@ impl<P: Package, VS: VersionSet> Incompatibility<P, VS> {
                 DerivationTree::Derived(derived)
             }
             Kind::NotRoot(package, version) => {
-                DerivationTree::External(External::NotRoot(package.clone(), version.clone()))
+                DerivationTree::External(External::NotRoot(package, version))
             }
             Kind::NoVersions(package, set) => {
-                DerivationTree::External(External::NoVersions(package.clone(), set.clone()))
+                DerivationTree::External(External::NoVersions(package, set))
             }
-            Kind::UnavailableDependencies(package, set) => DerivationTree::External(
-                External::UnavailableDependencies(package.clone(), set.clone()),
+            Kind::UnavailableDependencies(package, set) => {
+                DerivationTree::External(External::UnavailableDependencies(package, set))
+            }
+            Kind::FromDependencyOf(package, set, dep_package, dep_set) => DerivationTree::External(
+                External::FromDependencyOf(package, set, dep_package, dep_set),
             ),
-            Kind::FromDependencyOf(package, set, dep_package, dep_set) => {
-                DerivationTree::External(External::FromDependencyOf(
-                    package.clone(),
-                    set.clone(),
-                    dep_package.clone(),
-                    dep_set.clone(),
-                ))
-            }
         }
     }
 }

--- a/src/internal/incompatibility.rs
+++ b/src/internal/incompatibility.rs
@@ -4,6 +4,7 @@
 //! that should never be satisfied all together.
 
 use std::fmt;
+use std::rc::Rc;
 
 use crate::internal::arena::{Arena, Id};
 use crate::internal::small_map::SmallMap;
@@ -227,7 +228,7 @@ impl<P: Package, VS: VersionSet> Incompatibility<P, VS> {
         self_id: Id<Self>,
         shared_ids: &Set<Id<Self>>,
         store: &Arena<Self>,
-        precomputed: &Map<Id<Self>, Box<DerivationTree<P, VS>>>,
+        precomputed: &Map<Id<Self>, Rc<DerivationTree<P, VS>>>,
     ) -> DerivationTree<P, VS> {
         match store[self_id].kind.clone() {
             Kind::DerivedFrom(id1, id2) => {

--- a/src/internal/incompatibility.rs
+++ b/src/internal/incompatibility.rs
@@ -4,7 +4,7 @@
 //! that should never be satisfied all together.
 
 use std::fmt;
-use std::rc::Rc;
+use std::sync::Arc;
 
 use crate::internal::arena::{Arena, Id};
 use crate::internal::small_map::SmallMap;
@@ -228,7 +228,7 @@ impl<P: Package, VS: VersionSet> Incompatibility<P, VS> {
         self_id: Id<Self>,
         shared_ids: &Set<Id<Self>>,
         store: &Arena<Self>,
-        precomputed: &Map<Id<Self>, Rc<DerivationTree<P, VS>>>,
+        precomputed: &Map<Id<Self>, Arc<DerivationTree<P, VS>>>,
     ) -> DerivationTree<P, VS> {
         match store[self_id].kind.clone() {
             Kind::DerivedFrom(id1, id2) => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -220,7 +220,6 @@
 //! with a cache, you may want to know that some versions
 //! do not exist in your cache.
 
-#![allow(clippy::rc_buffer)]
 #![warn(missing_docs)]
 
 pub mod error;

--- a/src/report.rs
+++ b/src/report.rs
@@ -4,7 +4,7 @@
 //! dependency solving failed.
 
 use std::fmt;
-use std::ops::{Deref, DerefMut};
+use std::ops::Deref;
 use std::rc::Rc;
 
 use crate::package::Package;

--- a/src/report.rs
+++ b/src/report.rs
@@ -5,7 +5,7 @@
 
 use std::fmt;
 use std::ops::Deref;
-use std::rc::Rc;
+use std::sync::Arc;
 
 use crate::package::Package;
 use crate::term::Term;
@@ -65,9 +65,9 @@ pub struct Derived<P: Package, VS: VersionSet> {
     /// and refer to the explanation for the other times.
     pub shared_id: Option<usize>,
     /// First cause.
-    pub cause1: Rc<DerivationTree<P, VS>>,
+    pub cause1: Arc<DerivationTree<P, VS>>,
     /// Second cause.
-    pub cause2: Rc<DerivationTree<P, VS>>,
+    pub cause2: Arc<DerivationTree<P, VS>>,
 }
 
 impl<P: Package, VS: VersionSet> DerivationTree<P, VS> {
@@ -84,8 +84,8 @@ impl<P: Package, VS: VersionSet> DerivationTree<P, VS> {
             DerivationTree::External(_) => {}
             DerivationTree::Derived(derived) => {
                 match (
-                    Rc::make_mut(&mut derived.cause1),
-                    Rc::make_mut(&mut derived.cause2),
+                    Arc::make_mut(&mut derived.cause1),
+                    Arc::make_mut(&mut derived.cause2),
                 ) {
                     (DerivationTree::External(External::NoVersions(p, r)), ref mut cause2) => {
                         cause2.collapse_no_versions();
@@ -102,8 +102,8 @@ impl<P: Package, VS: VersionSet> DerivationTree<P, VS> {
                             .unwrap_or_else(|| self.to_owned());
                     }
                     _ => {
-                        Rc::make_mut(&mut derived.cause1).collapse_no_versions();
-                        Rc::make_mut(&mut derived.cause2).collapse_no_versions();
+                        Arc::make_mut(&mut derived.cause1).collapse_no_versions();
+                        Arc::make_mut(&mut derived.cause2).collapse_no_versions();
                     }
                 }
             }


### PR DESCRIPTION
The existing code for generating a derivation tree had two performance pathologies.

Because derivations have reused subtrees (i.e. shared IDs) they are really more like DAGs then proper trees. Nonetheless the current API ignores the sharing and built a separate (`Box`) for each of these repeated sections of the output. By using shared ownership (`Rc`) for the shared IDs we can reduce the generation time and memory use for these complicated cases.

Because we generated derivation trees recursively, the stack memory usage was `O(tree_depth)`. When dealing with complicated test cases that use larger `V`s, it is quite possible to overflow the stack. There are probably ways to reduce the constant factors to make this problem even harder to come across, and I will need to investigate them if this PR is not accepted. But this PR solved the problem by simply removing the recursion.

This is a breaking change because the switch from `Box` to `Rc` is visible in our public API.

This is split up into several commits, each of one of which should be reviewable on its own.