### PR TITLE
Add `Range::as_singleton`

### DIFF
--- a/src/range.rs
+++ b/src/range.rs
@@ -186,6 +186,21 @@ impl<V: Clone> Range<V> {
 }
 
 impl<V: Ord> Range<V> {
+    /// If the range includes a single version, return it.
+    /// Otherwise, returns [None].
+    pub fn as_singleton(&self) -> Option<&V> {
+        match self.segments.as_slice() {
+            [(Included(v1), Included(v2))] => {
+                if v1 == v2 {
+                    Some(v1)
+                } else {
+                    None
+                }
+            }
+            _ => None,
+        }
+    }
+
     /// Convert to something that can be used with
     /// [BTreeMap::range](std::collections::BTreeMap::range).
     /// All versions contained in self, will be in the output,


### PR DESCRIPTION
We use this method for better error messages:

https://github.com/astral-sh/uv/blob/8d721830db8ad75b8b7ef38edc0e346696c52e3d/crates/uv-resolver/src/pubgrub/report.rs#L92-L96

https://github.com/astral-sh/uv/blob/8d721830db8ad75b8b7ef38edc0e346696c52e3d/crates/uv-resolver/src/pubgrub/report.rs#L509-L520