### PR TITLE
Add a `Range::iter()` method

### DIFF
--- a/src/range.rs
+++ b/src/range.rs
@@ -493,6 +493,11 @@ impl<V: Ord + Clone> Range<V> {
         }
         Self { segments }.check_invariants()
     }
+
+    /// Iterate over the parts of the range.
+    pub fn iter(&self) -> impl Iterator<Item = (&Bound<V>, &Bound<V>)> {
+        self.segments.iter().map(|(start, end)| (start, end))
+    }
 }
 
 impl<T: Debug + Display + Clone + Eq + Ord> VersionSet for Range<T> {


### PR DESCRIPTION
Otherwise, it's not possible to implement custom formatting of `Range` types. This seems generally useful to expose.

Example usages:

https://github.com/astral-sh/uv/blob/8d721830db8ad75b8b7ef38edc0e346696c52e3d/crates/uv-resolver/src/pubgrub/report.rs#L97-L112

https://github.com/astral-sh/uv/blob/8d721830db8ad75b8b7ef38edc0e346696c52e3d/crates/uv-resolver/src/pubgrub/report.rs#L549-L560

https://github.com/astral-sh/uv/blob/8d721830db8ad75b8b7ef38edc0e346696c52e3d/crates/uv-resolver/src/pubgrub/report.rs#L568-L605

Upstream port of https://github.com/astral-sh/pubgrub/pull/18