### PR TITLE
Add `Range::is_empty()` and `Range::bounds()`

### DIFF
--- a/src/range.rs
+++ b/src/range.rs
@@ -119,6 +119,29 @@ impl<V> Range<V> {
             segments: SmallVec::one((Included(v1.into()), Excluded(v2.into()))),
         }
     }
+
+    /// Whether the set is empty, i.e. it has not ranges
+    pub fn is_empty(&self) -> bool {
+        self.segments.is_empty()
+    }
+
+    /// Return all boundary versions of this range.
+    pub fn bounds(&self) -> impl Iterator<Item = &V> {
+        self.segments.iter().flat_map(|segment| {
+            let (v1, v2) = segment;
+            let v1 = match v1 {
+                Included(v) => Some(v),
+                Excluded(v) => Some(v),
+                Unbounded => None,
+            };
+            let v2 = match v2 {
+                Included(v) => Some(v),
+                Excluded(v) => Some(v),
+                Unbounded => None,
+            };
+            v1.into_iter().chain(v2)
+        })
+    }
 }
 
 impl<V: Clone> Range<V> {


### PR DESCRIPTION
We use `Range::is_empty()` for special casing the empty version range in error messages:

https://github.com/astral-sh/uv/blob/8d721830db8ad75b8b7ef38edc0e346696c52e3d/crates/uv-resolver/src/pubgrub/report.rs#L553

https://github.com/astral-sh/uv/blob/8d721830db8ad75b8b7ef38edc0e346696c52e3d/crates/uv-resolver/src/pubgrub/report.rs#L565

We use `Range::bounds()` to check for prerelease bounds and hint the user at our prerelease rules:

https://github.com/astral-sh/uv/blob/8d721830db8ad75b8b7ef38edc0e346696c52e3d/crates/uv-resolver/src/pubgrub/report.rs#L360

Upstream port of https://github.com/astral-sh/pubgrub/pull/16