### PR TITLE
Add `Range::is_empty()`

### DIFF
--- a/src/range.rs
+++ b/src/range.rs
@@ -119,6 +119,11 @@ impl<V> Range<V> {
             segments: SmallVec::one((Included(v1.into()), Excluded(v2.into()))),
         }
     }
+
+    /// Whether the set is empty, i.e. it has not ranges
+    pub fn is_empty(&self) -> bool {
+        self.segments.is_empty()
+    }
 }
 
 impl<V: Clone> Range<V> {


### PR DESCRIPTION
We use `Range::is_empty()` for special casing the empty version range in error messages. This mirrors std, which has `is_empty` methods on all of its collections: https://doc.rust-lang.org/nightly/std/?search=is_empty

Example usages:

https://github.com/astral-sh/uv/blob/8d721830db8ad75b8b7ef38edc0e346696c52e3d/crates/uv-resolver/src/pubgrub/report.rs#L553

https://github.com/astral-sh/uv/blob/8d721830db8ad75b8b7ef38edc0e346696c52e3d/crates/uv-resolver/src/pubgrub/report.rs#L565