### PR TITLE
feat!: associated types instead of generics for P and VS

### DIFF
--- a/benches/large_case.rs
+++ b/benches/large_case.rs
@@ -17,7 +17,7 @@ fn bench<'a, P: Package + Deserialize<'a>, VS: VersionSet + Deserialize<'a>>(
 ) where
     <VS as VersionSet>::V: Deserialize<'a>,
 {
-    let dependency_provider: OfflineDependencyProvider<P, VS> = ron::de::from_str(&case).unwrap();
+    let dependency_provider: OfflineDependencyProvider<P, VS> = ron::de::from_str(case).unwrap();
 
     b.iter(|| {
         for p in dependency_provider.packages() {

--- a/examples/caching_dependency_provider.rs
+++ b/examples/caching_dependency_provider.rs
@@ -4,7 +4,6 @@ use std::cell::RefCell;
 
 use pubgrub::range::Range;
 use pubgrub::solver::{resolve, Dependencies, DependencyProvider, OfflineDependencyProvider};
-use pubgrub::type_aliases::V;
 
 type NumVS = Range<u32>;
 
@@ -29,7 +28,7 @@ impl<DP: DependencyProvider> DependencyProvider for CachingDependencyProvider<DP
     fn get_dependencies(
         &self,
         package: &DP::P,
-        version: &V<DP>,
+        version: &DP::V,
     ) -> Result<Dependencies<DP::P, DP::VS>, DP::Err> {
         let mut cache = self.cached_dependencies.borrow_mut();
         match cache.get_dependencies(package, version) {
@@ -53,7 +52,7 @@ impl<DP: DependencyProvider> DependencyProvider for CachingDependencyProvider<DP
         }
     }
 
-    fn choose_version(&self, package: &DP::P, range: &DP::VS) -> Result<Option<V<DP>>, DP::Err> {
+    fn choose_version(&self, package: &DP::P, range: &DP::VS) -> Result<Option<DP::V>, DP::Err> {
         self.remote_dependencies.choose_version(package, range)
     }
 
@@ -66,7 +65,7 @@ impl<DP: DependencyProvider> DependencyProvider for CachingDependencyProvider<DP
     type Err = DP::Err;
 
     type P = DP::P;
-
+    type V = DP::V;
     type VS = DP::VS;
 }
 

--- a/examples/caching_dependency_provider.rs
+++ b/examples/caching_dependency_provider.rs
@@ -2,23 +2,20 @@
 
 use std::cell::RefCell;
 
-use pubgrub::package::Package;
 use pubgrub::range::Range;
 use pubgrub::solver::{resolve, Dependencies, DependencyProvider, OfflineDependencyProvider};
-use pubgrub::version_set::VersionSet;
+use pubgrub::type_aliases::V;
 
 type NumVS = Range<u32>;
 
 // An example implementing caching dependency provider that will
 // store queried dependencies in memory and check them before querying more from remote.
-struct CachingDependencyProvider<P: Package, VS: VersionSet, DP: DependencyProvider<P, VS>> {
+struct CachingDependencyProvider<DP: DependencyProvider> {
     remote_dependencies: DP,
-    cached_dependencies: RefCell<OfflineDependencyProvider<P, VS>>,
+    cached_dependencies: RefCell<OfflineDependencyProvider<DP::P, DP::VS>>,
 }
 
-impl<P: Package, VS: VersionSet, DP: DependencyProvider<P, VS>>
-    CachingDependencyProvider<P, VS, DP>
-{
+impl<DP: DependencyProvider> CachingDependencyProvider<DP> {
     pub fn new(remote_dependencies_provider: DP) -> Self {
         CachingDependencyProvider {
             remote_dependencies: remote_dependencies_provider,
@@ -27,15 +24,13 @@ impl<P: Package, VS: VersionSet, DP: DependencyProvider<P, VS>>
     }
 }
 
-impl<P: Package, VS: VersionSet, DP: DependencyProvider<P, VS>> DependencyProvider<P, VS>
-    for CachingDependencyProvider<P, VS, DP>
-{
+impl<DP: DependencyProvider> DependencyProvider for CachingDependencyProvider<DP> {
     // Caches dependencies if they were already queried
     fn get_dependencies(
         &self,
-        package: &P,
-        version: &VS::V,
-    ) -> Result<Dependencies<P, VS>, DP::Err> {
+        package: &DP::P,
+        version: &V<DP>,
+    ) -> Result<Dependencies<DP::P, DP::VS>, DP::Err> {
         let mut cache = self.cached_dependencies.borrow_mut();
         match cache.get_dependencies(package, version) {
             Ok(Dependencies::Unknown) => {
@@ -58,17 +53,21 @@ impl<P: Package, VS: VersionSet, DP: DependencyProvider<P, VS>> DependencyProvid
         }
     }
 
-    fn choose_version(&self, package: &P, range: &VS) -> Result<Option<VS::V>, DP::Err> {
+    fn choose_version(&self, package: &DP::P, range: &DP::VS) -> Result<Option<V<DP>>, DP::Err> {
         self.remote_dependencies.choose_version(package, range)
     }
 
     type Priority = DP::Priority;
 
-    fn prioritize(&self, package: &P, range: &VS) -> Self::Priority {
+    fn prioritize(&self, package: &DP::P, range: &DP::VS) -> Self::Priority {
         self.remote_dependencies.prioritize(package, range)
     }
 
     type Err = DP::Err;
+
+    type P = DP::P;
+
+    type VS = DP::VS;
 }
 
 fn main() {

--- a/src/error.rs
+++ b/src/error.rs
@@ -6,7 +6,6 @@ use thiserror::Error;
 
 use crate::report::DerivationTree;
 use crate::solver::DependencyProvider;
-use crate::type_aliases::V;
 
 /// Errors that may occur while solving dependencies.
 #[derive(Error)]
@@ -27,7 +26,7 @@ where
         /// Package whose dependencies we want.
         package: DP::P,
         /// Version of the package for which we want the dependencies.
-        version: V<DP>,
+        version: DP::V,
         /// Error raised by the implementer of
         /// [DependencyProvider].
         source: DP::Err,
@@ -43,7 +42,7 @@ where
         /// Package whose dependencies we want.
         package: DP::P,
         /// Version of the package for which we want the dependencies.
-        version: V<DP>,
+        version: DP::V,
     },
 
     /// Error arising when the implementer of

--- a/src/error.rs
+++ b/src/error.rs
@@ -50,12 +50,12 @@ where
     /// returned an error in the method
     /// [choose_version](crate::solver::DependencyProvider::choose_version).
     #[error("Decision making failed")]
-    ErrorChoosingPackageVersion(DP::Err),
+    ErrorChoosingPackageVersion(#[source] DP::Err),
 
     /// Error arising when the implementer of [DependencyProvider]
     /// returned an error in the method [should_cancel](crate::solver::DependencyProvider::should_cancel).
     #[error("We should cancel")]
-    ErrorInShouldCancel(DP::Err),
+    ErrorInShouldCancel(#[source] DP::Err),
 
     /// Something unexpected happened.
     #[error("{0}")]

--- a/src/internal/core.rs
+++ b/src/internal/core.rs
@@ -16,14 +16,14 @@ use crate::internal::partial_solution::{DecisionLevel, PartialSolution};
 use crate::internal::small_vec::SmallVec;
 use crate::report::DerivationTree;
 use crate::solver::DependencyProvider;
-use crate::type_aliases::{DependencyConstraints, IncompDpId, Map, V};
+use crate::type_aliases::{DependencyConstraints, IncompDpId, Map};
 use crate::version_set::VersionSet;
 
 /// Current state of the PubGrub algorithm.
 #[derive(Clone)]
 pub struct State<DP: DependencyProvider> {
     root_package: DP::P,
-    root_version: V<DP>,
+    root_version: DP::V,
 
     #[allow(clippy::type_complexity)]
     incompatibilities: Map<DP::P, Vec<IncompDpId<DP>>>,
@@ -53,7 +53,7 @@ pub struct State<DP: DependencyProvider> {
 
 impl<DP: DependencyProvider> State<DP> {
     /// Initialization of PubGrub state.
-    pub fn init(root_package: DP::P, root_version: V<DP>) -> Self {
+    pub fn init(root_package: DP::P, root_version: DP::V) -> Self {
         let mut incompatibility_store = Arena::new();
         let not_root_id = incompatibility_store.alloc(Incompatibility::not_root(
             root_package.clone(),
@@ -83,7 +83,7 @@ impl<DP: DependencyProvider> State<DP> {
     pub fn add_incompatibility_from_dependencies(
         &mut self,
         package: DP::P,
-        version: V<DP>,
+        version: DP::V,
         deps: &DependencyConstraints<DP::P, DP::VS>,
     ) -> std::ops::Range<IncompDpId<DP>> {
         // Create incompatibilities and allocate them in the store.

--- a/src/internal/incompatibility.rs
+++ b/src/internal/incompatibility.rs
@@ -161,7 +161,7 @@ impl<P: Package, VS: VersionSet> Incompatibility<P, VS> {
                 .unwrap()
                 .unwrap_positive()
                 .union(other.get(p1).unwrap().unwrap_positive()), // It is safe to `simplify` here
-            (&p2, dep_term.map_or(&VS::empty(), |v| v.unwrap_negative())),
+            (p2, dep_term.map_or(&VS::empty(), |v| v.unwrap_negative())),
         ));
     }
 
@@ -310,7 +310,6 @@ pub mod tests {
     use super::*;
     use crate::range::Range;
     use crate::term::tests::strategy as term_strat;
-    use crate::type_aliases::Map;
     use proptest::prelude::*;
 
     proptest! {

--- a/src/internal/partial_solution.rs
+++ b/src/internal/partial_solution.rs
@@ -15,7 +15,7 @@ use crate::internal::small_map::SmallMap;
 use crate::package::Package;
 use crate::solver::DependencyProvider;
 use crate::term::Term;
-use crate::type_aliases::{IncompDpId, SelectedDependencies, V};
+use crate::type_aliases::{IncompDpId, SelectedDependencies};
 use crate::version_set::VersionSet;
 
 use super::small_vec::SmallVec;
@@ -158,7 +158,7 @@ impl<DP: DependencyProvider> PartialSolution<DP> {
     }
 
     /// Add a decision.
-    pub fn add_decision(&mut self, package: DP::P, version: V<DP>) {
+    pub fn add_decision(&mut self, package: DP::P, version: DP::V) {
         // Check that add_decision is never used in the wrong context.
         if cfg!(debug_assertions) {
             match self.package_assignments.get_mut(&package) {
@@ -350,8 +350,8 @@ impl<DP: DependencyProvider> PartialSolution<DP> {
     pub fn add_version(
         &mut self,
         package: DP::P,
-        version: V<DP>,
-        new_incompatibilities: std::ops::Range<IncompDpId<DP>>,
+        version: DP::V,
+        new_incompatibilities: std::ops::Range<IncompId<DP::P, DP::VS>>,
         store: &Arena<Incompatibility<DP::P, DP::VS>>,
     ) {
         let exact = Term::exact(version.clone());

--- a/src/internal/small_map.rs
+++ b/src/internal/small_map.rs
@@ -220,8 +220,6 @@ impl<'a, K: 'a, V: 'a> Iterator for IterSmallMap<'a, K, V> {
 
     fn next(&mut self) -> Option<Self::Item> {
         match self {
-            // False-positive, remove when stable is >=1.76 February 24
-            #[allow(clippy::map_identity)]
             IterSmallMap::Inline(inner) => inner.next().map(|(k, v)| (k, v)),
             IterSmallMap::Map(inner) => inner.next(),
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -102,6 +102,7 @@
 //!
 //!     type Err = Infallible;
 //!     type P = String;
+//!     type V = SemanticVersion;
 //!     type VS = SemVS;
 //! }
 //! ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -82,7 +82,7 @@
 //! #
 //! type SemVS = Range<SemanticVersion>;
 //!
-//! impl DependencyProvider<String, SemVS> for MyDependencyProvider {
+//! impl DependencyProvider for MyDependencyProvider {
 //!     fn choose_version(&self, package: &String, range: &SemVS) -> Result<Option<SemanticVersion>, Infallible> {
 //!         unimplemented!()
 //!     }
@@ -101,6 +101,8 @@
 //!     }
 //!
 //!     type Err = Infallible;
+//!     type P = String;
+//!     type VS = SemVS;
 //! }
 //! ```
 //!

--- a/src/report.rs
+++ b/src/report.rs
@@ -256,7 +256,8 @@ impl DefaultStringReporter {
     ) {
         self.build_recursive_helper(derived, formatter);
         if let Some(id) = derived.shared_id {
-            if self.shared_with_ref.get(&id).is_none() {
+            #[allow(clippy::map_entry)] // `add_line_ref` not compatible with proposed fix.
+            if !self.shared_with_ref.contains_key(&id) {
                 self.add_line_ref();
                 self.shared_with_ref.insert(id, self.ref_count);
             }

--- a/src/solver.rs
+++ b/src/solver.rs
@@ -27,16 +27,9 @@
 //!
 //! The algorithm is generic and works for any type of dependency system
 //! as long as packages (P) and versions (V) implement
-//! the [Package] and [Version](crate::version::Version) traits.
+//! the [Package] and Version traits.
 //! [Package] is strictly equivalent and automatically generated
 //! for any type that implement [Clone] + [Eq] + [Hash] + [Debug] + [Display].
-//! [Version](crate::version::Version) simply states that versions are ordered,
-//! that there should be
-//! a minimal [lowest](crate::version::Version::lowest) version (like 0.0.0 in semantic versions),
-//! and that for any version, it is possible to compute
-//! what the next version closest to this one is ([bump](crate::version::Version::bump)).
-//! For semantic versions, [bump](crate::version::Version::bump) corresponds to
-//! an increment of the patch number.
 //!
 //! ## API
 //!
@@ -211,7 +204,7 @@ pub trait DependencyProvider {
     /// How this provider stores the name of the packages.
     type P: Package;
 
-    /// How this provider stores the vertions of the packages.
+    /// How this provider stores the versions of the packages.
     type V: Debug + Display + Clone + Ord;
 
     /// How this provider stores the version requirements for the packages.

--- a/src/type_aliases.rs
+++ b/src/type_aliases.rs
@@ -2,19 +2,29 @@
 
 //! Publicly exported type aliases.
 
+use crate::{
+    internal::incompatibility::IncompId, solver::DependencyProvider, version_set::VersionSet,
+};
+
 /// Map implementation used by the library.
 pub type Map<K, V> = rustc_hash::FxHashMap<K, V>;
 
 /// Set implementation used by the library.
 pub type Set<V> = rustc_hash::FxHashSet<V>;
 
+/// The version type associated with the version set associated with the dependency provider.
+pub type V<DP> = <<DP as DependencyProvider>::VS as VersionSet>::V;
+
 /// Concrete dependencies picked by the library during [resolve](crate::solver::resolve)
 /// from [DependencyConstraints].
-pub type SelectedDependencies<P, V> = Map<P, V>;
+pub type SelectedDependencies<DP> = Map<<DP as DependencyProvider>::P, V<DP>>;
 
 /// Holds information about all possible versions a given package can accept.
 /// There is a difference in semantics between an empty map
 /// inside [DependencyConstraints] and [Dependencies::Unknown](crate::solver::Dependencies::Unknown):
 /// the former means the package has no dependency and it is a known fact,
-/// while the latter means they could not be fetched by the [DependencyProvider](crate::solver::DependencyProvider).
+/// while the latter means they could not be fetched by the [DependencyProvider].
 pub type DependencyConstraints<P, VS> = Map<P, VS>;
+
+pub(crate) type IncompDpId<DP> =
+    IncompId<<DP as DependencyProvider>::P, <DP as DependencyProvider>::VS>;

--- a/src/type_aliases.rs
+++ b/src/type_aliases.rs
@@ -2,9 +2,7 @@
 
 //! Publicly exported type aliases.
 
-use crate::{
-    internal::incompatibility::IncompId, solver::DependencyProvider, version_set::VersionSet,
-};
+use crate::{internal::incompatibility::IncompId, solver::DependencyProvider};
 
 /// Map implementation used by the library.
 pub type Map<K, V> = rustc_hash::FxHashMap<K, V>;
@@ -12,12 +10,10 @@ pub type Map<K, V> = rustc_hash::FxHashMap<K, V>;
 /// Set implementation used by the library.
 pub type Set<V> = rustc_hash::FxHashSet<V>;
 
-/// The version type associated with the version set associated with the dependency provider.
-pub type V<DP> = <<DP as DependencyProvider>::VS as VersionSet>::V;
-
 /// Concrete dependencies picked by the library during [resolve](crate::solver::resolve)
 /// from [DependencyConstraints].
-pub type SelectedDependencies<DP> = Map<<DP as DependencyProvider>::P, V<DP>>;
+pub type SelectedDependencies<DP> =
+    Map<<DP as DependencyProvider>::P, <DP as DependencyProvider>::V>;
 
 /// Holds information about all possible versions a given package can accept.
 /// There is a difference in semantics between an empty map

--- a/tests/sat_dependency_provider.rs
+++ b/tests/sat_dependency_provider.rs
@@ -116,9 +116,9 @@ impl<P: Package, VS: VersionSet> SatResolve<P, VS> {
         }
     }
 
-    pub fn is_valid_solution(
+    pub fn is_valid_solution<DP: DependencyProvider<P = P, VS = VS, V = VS::V>>(
         &mut self,
-        pids: &SelectedDependencies<OfflineDependencyProvider<P, VS>>,
+        pids: &SelectedDependencies<DP>,
     ) -> bool {
         let mut assumption = vec![];
 
@@ -136,7 +136,7 @@ impl<P: Package, VS: VersionSet> SatResolve<P, VS> {
             .expect("docs say it can't error in default config")
     }
 
-    pub fn check_resolve<DP: DependencyProvider<P = P, VS = VS>>(
+    pub fn check_resolve<DP: DependencyProvider<P = P, VS = VS, V = VS::V>>(
         &mut self,
         res: &Result<SelectedDependencies<DP>, PubGrubError<DP>>,
         p: &P,
@@ -144,7 +144,7 @@ impl<P: Package, VS: VersionSet> SatResolve<P, VS> {
     ) {
         match res {
             Ok(s) => {
-                assert!(self.is_valid_solution(s));
+                assert!(self.is_valid_solution::<DP>(s));
             }
             Err(_) => {
                 assert!(!self.resolve(p, v));

--- a/tests/sat_dependency_provider.rs
+++ b/tests/sat_dependency_provider.rs
@@ -1,7 +1,5 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use std::convert::Infallible;
-
 use pubgrub::error::PubGrubError;
 use pubgrub::package::Package;
 use pubgrub::solver::{Dependencies, DependencyProvider, OfflineDependencyProvider};
@@ -118,7 +116,10 @@ impl<P: Package, VS: VersionSet> SatResolve<P, VS> {
         }
     }
 
-    pub fn is_valid_solution(&mut self, pids: &SelectedDependencies<P, VS::V>) -> bool {
+    pub fn is_valid_solution(
+        &mut self,
+        pids: &SelectedDependencies<OfflineDependencyProvider<P, VS>>,
+    ) -> bool {
         let mut assumption = vec![];
 
         for (p, vs) in &self.all_versions_by_p {
@@ -135,9 +136,9 @@ impl<P: Package, VS: VersionSet> SatResolve<P, VS> {
             .expect("docs say it can't error in default config")
     }
 
-    pub fn check_resolve(
+    pub fn check_resolve<DP: DependencyProvider<P = P, VS = VS>>(
         &mut self,
-        res: &Result<SelectedDependencies<P, VS::V>, PubGrubError<P, VS, Infallible>>,
+        res: &Result<SelectedDependencies<DP>, PubGrubError<DP>>,
         p: &P,
         v: &VS::V,
     ) {


### PR DESCRIPTION
Dependency provider was inconsistent about its types, P and VS were generics but Err and Priority were associated types. If/as we had more configuration the benefits of associated types become even more valuable. This PR goes to the breaking change of making everything consistently associated types.

This was in preparation for adding user controlled metadata for `UnavailableDependencies`. But this was sufficiently complicated to deserve its own PR before we get into the additional complications of that extension.