### PR TITLE
feat: ensure successful round-trip of RON

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -686,14 +686,15 @@ checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 
 [[package]]
 name = "ron"
-version = "0.8.1"
+version = "0.9.0-alpha.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b91f7eff05f748767f183df4320a63d6936e9c6107d97c9e6bdd9784f4289c94"
+checksum = "6c0bd893640cac34097a74f0c2389ddd54c62d6a3c635fa93cafe6b6bc19be6a"
 dependencies = [
  "base64",
  "bitflags",
  "serde",
  "serde_derive",
+ "unicode-ident",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ log = "0.4.14" # for debug logs in tests
 
 [dev-dependencies]
 proptest = "1.4.0"
-ron = "0.8.1"
+ron = "=0.9.0-alpha.0"
 varisat = "0.2.2"
 criterion = "0.5"
 env_logger = "0.11.3"

--- a/src/range.rs
+++ b/src/range.rs
@@ -862,7 +862,8 @@ pub mod tests {
 
     proptest! {
 
-        // Testing negate ----------------------------------
+        // Testing serde ----------------------------------
+
         #[cfg(feature = "serde")]
         #[test]
         fn serde_round_trip(range in strategy()) {
@@ -870,6 +871,8 @@ pub mod tests {
             let r = ron::de::from_str(&s).unwrap();
             assert_eq!(range, r);
         }
+
+        // Testing negate ----------------------------------
 
         #[test]
         fn negate_is_different(range in strategy()) {

--- a/src/range.rs
+++ b/src/range.rs
@@ -863,6 +863,13 @@ pub mod tests {
     proptest! {
 
         // Testing negate ----------------------------------
+        #[cfg(feature = "serde")]
+        #[test]
+        fn serde_round_trip(range in strategy()) {
+            let s = ron::ser::to_string(&range).unwrap();
+            let r = ron::de::from_str(&s).unwrap();
+            assert_eq!(range, r);
+        }
 
         #[test]
         fn negate_is_different(range in strategy()) {


### PR DESCRIPTION
cc https://github.com/ron-rs/ron/issues/530

When using the new format our benchmark files could not be read. Apparently this is going to be fixed in the next version of the RON dep. For now use the prerelease version.