### PR TITLE
Update priority queue

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,18 +21,18 @@ include = ["Cargo.toml", "LICENSE", "README.md", "src/**", "tests/**", "examples
 
 [dependencies]
 indexmap = "2.0.2"
-priority-queue = "1.1.1"
+priority-queue = "2.0.2"
 thiserror = "1.0"
 rustc-hash = "1.1.0"
 serde = { version = "1.0", features = ["derive"], optional = true }
 log = "0.4.14" # for debug logs in tests
 
 [dev-dependencies]
-proptest = "0.10.1"
-ron = "0.6"
+proptest = "1.4.0"
+ron = "0.8.1"
 varisat = "0.2.2"
 criterion = "0.5"
-env_logger = "0.9.0"
+env_logger = "0.11.3"
 
 [[bench]]
 name = "large_case"


### PR DESCRIPTION
I've been looking at duplicate dependencies in our tree and priority-queue 1 was pulling in old versions of indexmap and hashbrown, so i've updated all dependencies.