### PR TITLE
Add dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      artifacts:
+        # Group upload/download artifact updates, the versions are dependent
+        patterns:
+          - "actions/*-artifact"
+
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
Weekly updates for dependabot and cargo dependencies as PRs. This is the same configuration we are using in uv minus the automatic label: Feel to edit the interval if you prefer something else.