### PR TITLE
 ci: remove caching steps 

### DIFF
--- a/.github/workflows/cargo_publish_dry_run.yml
+++ b/.github/workflows/cargo_publish_dry_run.yml
@@ -4,6 +4,7 @@ name: Check crate publishing works
 on:
   pull_request:
     branches: [ release ]
+  workflow_dispatch:
 
 env:
   CARGO_TERM_COLOR: always
@@ -15,10 +16,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install stable Rust
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          profile: minimal
+        uses: dtolnay/rust-toolchain
 
       - name: Get Cargo version
         id: cargo_version

--- a/.github/workflows/cargo_publish_dry_run.yml
+++ b/.github/workflows/cargo_publish_dry_run.yml
@@ -25,16 +25,5 @@ jobs:
         run: echo "::set-output name=version::$(cargo -V | tr -d ' ')"
         shell: bash
 
-      - name: Download cache
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: ${{ runner.os }}-${{ steps.cargo_version.outputs.version }}-${{ hashFiles('Cargo.toml') }}
-          restore-keys: ${{ runner.os }}-${{ steps.cargo_version.outputs.version }}
-
       - name: Run `cargo publish --dry-run`
         run: cargo publish --dry-run

--- a/.github/workflows/deploy_documentation.yml
+++ b/.github/workflows/deploy_documentation.yml
@@ -19,16 +19,6 @@ jobs:
           toolchain: nightly
           profile: minimal
 
-      - name: Download cache
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: documentation
-
       - name: Build documentation
         run: cargo +nightly doc --no-deps
 

--- a/.github/workflows/deploy_documentation.yml
+++ b/.github/workflows/deploy_documentation.yml
@@ -4,6 +4,7 @@ name: Deploy documentation
 on:
   push:
     branches: [ dev ]
+  workflow_dispatch:
 
 env:
   CARGO_TERM_COLOR: always
@@ -23,6 +24,7 @@ jobs:
         run: cargo +nightly doc --no-deps
 
       - name: Deploy documentation
+        if: ${{ github.event_name == 'branches' }}
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Pubgrub is so fast to compile that caching in CI isn't required, so i removed it. Closes #201.

I've added `workflow_dispatch` to dry run these workflows.

The timing below are from my machine, but even if CI is an order of magnitude slower i don't think we should cache:

 ```
$ hyperfine --prepare "cargo clean" "cargo publish --dry-run" "cargo +nightly doc --no-deps"
 Benchmark 1: cargo publish --dry-run
   Time (mean ± σ):      1.661 s ±  0.272 s    [User: 2.240 s, System: 0.324 s]
   Range (min … max):    1.467 s …  2.207 s    10 runs

 Benchmark 2: cargo +nightly doc --no-deps
   Time (mean ± σ):      1.230 s ±  0.020 s    [User: 2.013 s, System: 0.312 s]
   Range (min … max):    1.202 s …  1.263 s    10 runs
```