### PR TITLE
chore: build docs on stable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,11 +47,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@nightly
+      - uses: dtolnay/rust-toolchain@stable
       - name: Check documentation
         env:
           RUSTDOCFLAGS: -D warnings
-        run: cargo +nightly doc --no-deps --document-private-items
+        run: cargo doc --no-deps --document-private-items -- -D warnings
 
   check_commit_conventions:
     name: Commit messages follow project guidelines

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Check documentation
         env:
           RUSTDOCFLAGS: -D warnings
-        run: cargo doc --no-deps --document-private-items -- -D warnings
+        run: cargo doc --no-deps --document-private-items
 
   check_commit_conventions:
     name: Commit messages follow project guidelines

--- a/.github/workflows/deploy_documentation.yml
+++ b/.github/workflows/deploy_documentation.yml
@@ -14,14 +14,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Install nightly
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: nightly
-          profile: minimal
+      - uses: dtolnay/rust-toolchain@stable
 
       - name: Build documentation
-        run: cargo +nightly doc --no-deps
+        run: cargo doc --no-deps
 
       - name: Deploy documentation
         if: ${{ github.event_name == 'branches' }}


### PR DESCRIPTION
The reasons why nightly was used  (https://github.com/pubgrub-rs/pubgrub/pull/31#issuecomment-707337018) don't apply anymore. This change removes all nightly usages in the repo, only stable remains.