### PR TITLE
Generic reason for custom incompatibility

### DIFF
--- a/examples/caching_dependency_provider.rs
+++ b/examples/caching_dependency_provider.rs
@@ -32,7 +32,7 @@ impl<DP: DependencyProvider<M = String>> DependencyProvider for CachingDependenc
     ) -> Result<Dependencies<DP::P, DP::VS, DP::M>, DP::Err> {
         let mut cache = self.cached_dependencies.borrow_mut();
         match cache.get_dependencies(package, version) {
-            Ok(Dependencies::Unknown(reason)) => {
+            Ok(Dependencies::Unknown(_)) => {
                 let dependencies = self.remote_dependencies.get_dependencies(package, version);
                 match dependencies {
                     Ok(Dependencies::Known(dependencies)) => {

--- a/examples/caching_dependency_provider.rs
+++ b/examples/caching_dependency_provider.rs
@@ -23,16 +23,16 @@ impl<DP: DependencyProvider> CachingDependencyProvider<DP> {
     }
 }
 
-impl<DP: DependencyProvider> DependencyProvider for CachingDependencyProvider<DP> {
+impl<DP: DependencyProvider<M = String>> DependencyProvider for CachingDependencyProvider<DP> {
     // Caches dependencies if they were already queried
     fn get_dependencies(
         &self,
         package: &DP::P,
         version: &DP::V,
-    ) -> Result<Dependencies<DP::P, DP::VS>, DP::Err> {
+    ) -> Result<Dependencies<DP::P, DP::VS, DP::M>, DP::Err> {
         let mut cache = self.cached_dependencies.borrow_mut();
         match cache.get_dependencies(package, version) {
-            Ok(Dependencies::Unknown) => {
+            Ok(Dependencies::Unknown(reason)) => {
                 let dependencies = self.remote_dependencies.get_dependencies(package, version);
                 match dependencies {
                     Ok(Dependencies::Known(dependencies)) => {
@@ -43,7 +43,7 @@ impl<DP: DependencyProvider> DependencyProvider for CachingDependencyProvider<DP
                         );
                         Ok(Dependencies::Known(dependencies))
                     }
-                    Ok(Dependencies::Unknown) => Ok(Dependencies::Unknown),
+                    Ok(Dependencies::Unknown(reason)) => Ok(Dependencies::Unknown(reason)),
                     error @ Err(_) => error,
                 }
             }
@@ -67,6 +67,7 @@ impl<DP: DependencyProvider> DependencyProvider for CachingDependencyProvider<DP
     type P = DP::P;
     type V = DP::V;
     type VS = DP::VS;
+    type M = DP::M;
 }
 
 fn main() {

--- a/src/error.rs
+++ b/src/error.rs
@@ -15,7 +15,7 @@ where
 {
     /// There is no solution for this set of dependencies.
     #[error("No solution")]
-    NoSolution(DerivationTree<DP::P, DP::VS>),
+    NoSolution(DerivationTree<DP::P, DP::VS, DP::M>),
 
     /// Error arising when the implementer of
     /// [DependencyProvider]

--- a/src/internal/core.rs
+++ b/src/internal/core.rs
@@ -43,7 +43,7 @@ pub struct State<DP: DependencyProvider> {
     pub partial_solution: PartialSolution<DP>,
 
     /// The store is the reference storage for all incompatibilities.
-    pub incompatibility_store: Arena<Incompatibility<DP::P, DP::VS>>,
+    pub incompatibility_store: Arena<Incompatibility<DP::P, DP::VS, DP::M>>,
 
     /// This is a stack of work to be done in `unit_propagation`.
     /// It can definitely be a local variable to that method, but
@@ -74,7 +74,7 @@ impl<DP: DependencyProvider> State<DP> {
     }
 
     /// Add an incompatibility to the state.
-    pub fn add_incompatibility(&mut self, incompat: Incompatibility<DP::P, DP::VS>) {
+    pub fn add_incompatibility(&mut self, incompat: Incompatibility<DP::P, DP::VS, DP::M>) {
         let id = self.incompatibility_store.alloc(incompat);
         self.merge_incompatibility(id);
     }
@@ -297,7 +297,10 @@ impl<DP: DependencyProvider> State<DP> {
 
     // Error reporting #########################################################
 
-    fn build_derivation_tree(&self, incompat: IncompDpId<DP>) -> DerivationTree<DP::P, DP::VS> {
+    fn build_derivation_tree(
+        &self,
+        incompat: IncompDpId<DP>,
+    ) -> DerivationTree<DP::P, DP::VS, DP::M> {
         let mut all_ids: Set<IncompDpId<DP>> = Set::default();
         let mut shared_ids = Set::default();
         let mut stack = vec![incompat];

--- a/src/internal/incompatibility.rs
+++ b/src/internal/incompatibility.rs
@@ -114,6 +114,7 @@ impl<P: Package, VS: VersionSet, M: Eq + Clone + Debug + Display> Incompatibilit
     }
 
     /// Create an incompatibility for a reason outside pubgrub.
+    #[allow(dead_code)] // Used by uv
     pub fn custom_term(package: P, term: Term<VS>, metadata: M) -> Self {
         let set = match &term {
             Term::Positive(r) => r.clone(),

--- a/src/internal/incompatibility.rs
+++ b/src/internal/incompatibility.rs
@@ -184,11 +184,6 @@ impl<P: Package, VS: VersionSet, M: Eq + Clone + Debug + Display> Incompatibilit
         if dep_term != other.get(p2) {
             return None;
         }
-        // The metadata must be identical to merge
-        let self_metadata = self.metadata();
-        if self_metadata != other.metadata() {
-            return None;
-        }
         return Some(Self::from_dependency(
             p1.clone(),
             self.get(p1)
@@ -304,16 +299,6 @@ impl<P: Package, VS: VersionSet, M: Eq + Clone + Debug + Display> Incompatibilit
             )),
         }
     }
-
-    fn metadata(&self) -> Option<&M> {
-        match &self.kind {
-            Kind::NotRoot(_, _)
-            | Kind::NoVersions(_, _)
-            | Kind::FromDependencyOf(_, _, _, _)
-            | Kind::DerivedFrom(_, _) => None,
-            Kind::Custom(_, _, metadata) => Some(metadata),
-        }
-    }
 }
 
 impl<'a, P: Package, VS: VersionSet + 'a, M: Eq + Clone + Debug + Display + 'a>
@@ -384,12 +369,12 @@ pub mod tests {
             let mut store = Arena::new();
             let i1 = store.alloc(Incompatibility {
                 package_terms: SmallMap::Two([("p1", t1.clone()), ("p2", t2.negate())]),
-                kind: Kind::Custom("0", Range::full(), "foo".to_string())
+                kind: Kind::<_, _, String>::FromDependencyOf("p1", Range::full(), "p2", Range::full())
             });
 
             let i2 = store.alloc(Incompatibility {
                 package_terms: SmallMap::Two([("p2", t2), ("p3", t3.clone())]),
-                kind: Kind::Custom("0", Range::full(), "bar".to_string())
+                kind: Kind::<_, _, String>::FromDependencyOf("p2", Range::full(), "p3", Range::full())
             });
 
             let mut i3 = Map::default();

--- a/src/internal/partial_solution.rs
+++ b/src/internal/partial_solution.rs
@@ -3,7 +3,7 @@
 //! A Memory acts like a structured partial solution
 //! where terms are regrouped by package in a [Map](crate::type_aliases::Map).
 
-use std::fmt::Display;
+use std::fmt::{Debug, Display};
 use std::hash::BuildHasherDefault;
 
 use priority_queue::PriorityQueue;
@@ -47,7 +47,7 @@ pub struct PartialSolution<DP: DependencyProvider> {
     /// 3. `[changed_this_decision_level..]` Containes all packages that **have** had there assignments changed since
     ///    the last time `prioritize` has bean called. The inverse is not necessarily true, some packages in the range
     ///    did not have a change. Within this range there is no sorting.
-    package_assignments: FnvIndexMap<DP::P, PackageAssignments<DP::P, DP::VS>>,
+    package_assignments: FnvIndexMap<DP::P, PackageAssignments<DP::P, DP::VS, DP::M>>,
     /// `prioritized_potential_packages` is primarily a HashMap from a package with no desition and a positive assignment
     /// to its `Priority`. But, it also maintains a max heap of packages by `Priority` order.
     prioritized_potential_packages:
@@ -77,14 +77,16 @@ impl<DP: DependencyProvider> Display for PartialSolution<DP> {
 /// that have already been made for a given package,
 /// as well as the intersection of terms by all of these.
 #[derive(Clone, Debug)]
-struct PackageAssignments<P: Package, VS: VersionSet> {
+struct PackageAssignments<P: Package, VS: VersionSet, M: Eq + Clone + Debug + Display> {
     smallest_decision_level: DecisionLevel,
     highest_decision_level: DecisionLevel,
-    dated_derivations: SmallVec<DatedDerivation<P, VS>>,
+    dated_derivations: SmallVec<DatedDerivation<P, VS, M>>,
     assignments_intersection: AssignmentsIntersection<VS>,
 }
 
-impl<P: Package, VS: VersionSet> Display for PackageAssignments<P, VS> {
+impl<P: Package, VS: VersionSet, M: Eq + Clone + Debug + Display> Display
+    for PackageAssignments<P, VS, M>
+{
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let derivations: Vec<_> = self
             .dated_derivations
@@ -103,14 +105,16 @@ impl<P: Package, VS: VersionSet> Display for PackageAssignments<P, VS> {
 }
 
 #[derive(Clone, Debug)]
-pub struct DatedDerivation<P: Package, VS: VersionSet> {
+pub struct DatedDerivation<P: Package, VS: VersionSet, M: Eq + Clone + Debug + Display> {
     global_index: u32,
     decision_level: DecisionLevel,
-    cause: IncompId<P, VS>,
+    cause: IncompId<P, VS, M>,
     accumulated_intersection: Term<VS>,
 }
 
-impl<P: Package, VS: VersionSet> Display for DatedDerivation<P, VS> {
+impl<P: Package, VS: VersionSet, M: Eq + Clone + Debug + Display> Display
+    for DatedDerivation<P, VS, M>
+{
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{:?}, cause: {:?}", self.decision_level, self.cause)
     }
@@ -134,16 +138,16 @@ impl<VS: VersionSet> Display for AssignmentsIntersection<VS> {
 }
 
 #[derive(Clone, Debug)]
-pub enum SatisfierSearch<P: Package, VS: VersionSet> {
+pub enum SatisfierSearch<P: Package, VS: VersionSet, M: Eq + Clone + Debug + Display> {
     DifferentDecisionLevels {
         previous_satisfier_level: DecisionLevel,
     },
     SameDecisionLevels {
-        satisfier_cause: IncompId<P, VS>,
+        satisfier_cause: IncompId<P, VS, M>,
     },
 }
 
-type SatisfiedMap<'i, P, VS> = SmallMap<&'i P, (Option<IncompId<P, VS>>, u32, DecisionLevel)>;
+type SatisfiedMap<'i, P, VS, M> = SmallMap<&'i P, (Option<IncompId<P, VS, M>>, u32, DecisionLevel)>;
 
 impl<DP: DependencyProvider> PartialSolution<DP> {
     /// Initialize an empty PartialSolution.
@@ -207,7 +211,7 @@ impl<DP: DependencyProvider> PartialSolution<DP> {
         &mut self,
         package: DP::P,
         cause: IncompDpId<DP>,
-        store: &Arena<Incompatibility<DP::P, DP::VS>>,
+        store: &Arena<Incompatibility<DP::P, DP::VS, DP::M>>,
     ) {
         use indexmap::map::Entry;
         let mut dated_derivation = DatedDerivation {
@@ -351,11 +355,11 @@ impl<DP: DependencyProvider> PartialSolution<DP> {
         &mut self,
         package: DP::P,
         version: DP::V,
-        new_incompatibilities: std::ops::Range<IncompId<DP::P, DP::VS>>,
-        store: &Arena<Incompatibility<DP::P, DP::VS>>,
+        new_incompatibilities: std::ops::Range<IncompId<DP::P, DP::VS, DP::M>>,
+        store: &Arena<Incompatibility<DP::P, DP::VS, DP::M>>,
     ) {
         let exact = Term::exact(version.clone());
-        let not_satisfied = |incompat: &Incompatibility<DP::P, DP::VS>| {
+        let not_satisfied = |incompat: &Incompatibility<DP::P, DP::VS, DP::M>| {
             incompat.relation(|p| {
                 if p == &package {
                     Some(&exact)
@@ -380,7 +384,7 @@ impl<DP: DependencyProvider> PartialSolution<DP> {
     }
 
     /// Check if the terms in the partial solution satisfy the incompatibility.
-    pub fn relation(&self, incompat: &Incompatibility<DP::P, DP::VS>) -> Relation<DP::P> {
+    pub fn relation(&self, incompat: &Incompatibility<DP::P, DP::VS, DP::M>) -> Relation<DP::P> {
         incompat.relation(|package| self.term_intersection_for_package(package))
     }
 
@@ -394,9 +398,9 @@ impl<DP: DependencyProvider> PartialSolution<DP> {
     /// Figure out if the satisfier and previous satisfier are of different decision levels.
     pub fn satisfier_search<'i>(
         &self,
-        incompat: &'i Incompatibility<DP::P, DP::VS>,
-        store: &Arena<Incompatibility<DP::P, DP::VS>>,
-    ) -> (&'i DP::P, SatisfierSearch<DP::P, DP::VS>) {
+        incompat: &'i Incompatibility<DP::P, DP::VS, DP::M>,
+        store: &Arena<Incompatibility<DP::P, DP::VS, DP::M>>,
+    ) -> (&'i DP::P, SatisfierSearch<DP::P, DP::VS, DP::M>) {
         let satisfied_map = Self::find_satisfier(incompat, &self.package_assignments);
         let (&satisfier_package, &(satisfier_cause, _, satisfier_decision_level)) = satisfied_map
             .iter()
@@ -431,9 +435,9 @@ impl<DP: DependencyProvider> PartialSolution<DP> {
     /// It would be nice if we could get rid of it, but I don't know if then it will be possible
     /// to return a coherent previous_satisfier_level.
     fn find_satisfier<'i>(
-        incompat: &'i Incompatibility<DP::P, DP::VS>,
-        package_assignments: &FnvIndexMap<DP::P, PackageAssignments<DP::P, DP::VS>>,
-    ) -> SatisfiedMap<'i, DP::P, DP::VS> {
+        incompat: &'i Incompatibility<DP::P, DP::VS, DP::M>,
+        package_assignments: &FnvIndexMap<DP::P, PackageAssignments<DP::P, DP::VS, DP::M>>,
+    ) -> SatisfiedMap<'i, DP::P, DP::VS, DP::M> {
         let mut satisfied = SmallMap::Empty;
         for (package, incompat_term) in incompat.iter() {
             let pa = package_assignments.get(package).expect("Must exist");
@@ -446,11 +450,11 @@ impl<DP: DependencyProvider> PartialSolution<DP> {
     /// such that incompatibility is satisfied by the partial solution up to
     /// and including that assignment plus satisfier.
     fn find_previous_satisfier<'i>(
-        incompat: &Incompatibility<DP::P, DP::VS>,
+        incompat: &Incompatibility<DP::P, DP::VS, DP::M>,
         satisfier_package: &'i DP::P,
-        mut satisfied_map: SatisfiedMap<'i, DP::P, DP::VS>,
-        package_assignments: &FnvIndexMap<DP::P, PackageAssignments<DP::P, DP::VS>>,
-        store: &Arena<Incompatibility<DP::P, DP::VS>>,
+        mut satisfied_map: SatisfiedMap<'i, DP::P, DP::VS, DP::M>,
+        package_assignments: &FnvIndexMap<DP::P, PackageAssignments<DP::P, DP::VS, DP::M>>,
+        store: &Arena<Incompatibility<DP::P, DP::VS, DP::M>>,
     ) -> DecisionLevel {
         // First, let's retrieve the previous derivations and the initial accum_term.
         let satisfier_pa = package_assignments.get(satisfier_package).unwrap();
@@ -490,12 +494,12 @@ impl<DP: DependencyProvider> PartialSolution<DP> {
     }
 }
 
-impl<P: Package, VS: VersionSet> PackageAssignments<P, VS> {
+impl<P: Package, VS: VersionSet, M: Eq + Clone + Debug + Display> PackageAssignments<P, VS, M> {
     fn satisfier(
         &self,
         package: &P,
         start_term: &Term<VS>,
-    ) -> (Option<IncompId<P, VS>>, u32, DecisionLevel) {
+    ) -> (Option<IncompId<P, VS, M>>, u32, DecisionLevel) {
         let empty = Term::empty();
         // Indicate if we found a satisfier in the list of derivations, otherwise it will be the decision.
         let idx = self

--- a/src/internal/partial_solution.rs
+++ b/src/internal/partial_solution.rs
@@ -47,6 +47,7 @@ pub struct PartialSolution<DP: DependencyProvider> {
     /// 3. `[changed_this_decision_level..]` Containes all packages that **have** had there assignments changed since
     ///    the last time `prioritize` has bean called. The inverse is not necessarily true, some packages in the range
     ///    did not have a change. Within this range there is no sorting.
+    #[allow(clippy::type_complexity)]
     package_assignments: FnvIndexMap<DP::P, PackageAssignments<DP::P, DP::VS, DP::M>>,
     /// `prioritized_potential_packages` is primarily a HashMap from a package with no desition and a positive assignment
     /// to its `Priority`. But, it also maintains a max heap of packages by `Priority` order.
@@ -396,6 +397,7 @@ impl<DP: DependencyProvider> PartialSolution<DP> {
     }
 
     /// Figure out if the satisfier and previous satisfier are of different decision levels.
+    #[allow(clippy::type_complexity)]
     pub fn satisfier_search<'i>(
         &self,
         incompat: &'i Incompatibility<DP::P, DP::VS, DP::M>,
@@ -434,6 +436,7 @@ impl<DP: DependencyProvider> PartialSolution<DP> {
     /// Question: This is possible since we added a "global_index" to every dated_derivation.
     /// It would be nice if we could get rid of it, but I don't know if then it will be possible
     /// to return a coherent previous_satisfier_level.
+    #[allow(clippy::type_complexity)]
     fn find_satisfier<'i>(
         incompat: &'i Incompatibility<DP::P, DP::VS, DP::M>,
         package_assignments: &FnvIndexMap<DP::P, PackageAssignments<DP::P, DP::VS, DP::M>>,
@@ -449,6 +452,7 @@ impl<DP: DependencyProvider> PartialSolution<DP> {
     /// Earliest assignment in the partial solution before satisfier
     /// such that incompatibility is satisfied by the partial solution up to
     /// and including that assignment plus satisfier.
+    #[allow(clippy::type_complexity)]
     fn find_previous_satisfier<'i>(
         incompat: &Incompatibility<DP::P, DP::VS, DP::M>,
         satisfier_package: &'i DP::P,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -96,7 +96,7 @@
 //!         &self,
 //!         package: &String,
 //!         version: &SemanticVersion,
-//!     ) -> Result<Dependencies<String, SemVS>, Infallible> {
+//!     ) -> Result<Dependencies<String, SemVS, Self::M>, Infallible> {
 //!         unimplemented!()
 //!     }
 //!
@@ -104,6 +104,7 @@
 //!     type P = String;
 //!     type V = SemanticVersion;
 //!     type VS = SemVS;
+//!     type M = String;
 //! }
 //! ```
 //!
@@ -162,11 +163,12 @@
 //! # use pubgrub::package::Package;
 //! # use pubgrub::version_set::VersionSet;
 //! # use pubgrub::report::DerivationTree;
+//! # use std::fmt::{Debug, Display};
 //! #
-//! pub trait Reporter<P: Package, VS: VersionSet> {
+//! pub trait Reporter<P: Package, VS: VersionSet, M: Eq + Clone + Debug + Display> {
 //!     type Output;
 //!
-//!     fn report(derivation_tree: &DerivationTree<P, VS>) -> Self::Output;
+//!     fn report(derivation_tree: &DerivationTree<P, VS, M>) -> Self::Output;
 //! }
 //! ```
 //! Implementing a [Reporter](crate::report::Reporter) may involve a lot of heuristics

--- a/src/solver.rs
+++ b/src/solver.rs
@@ -265,6 +265,7 @@ pub trait DependencyProvider {
 
     /// Retrieves the package dependencies.
     /// Return [Dependencies::Unknown] if its dependencies are unknown.
+    #[allow(clippy::type_complexity)]
     fn get_dependencies(
         &self,
         package: &Self::P,

--- a/src/solver.rs
+++ b/src/solver.rs
@@ -206,10 +206,14 @@ pub trait DependencyProvider {
     type P: Package;
 
     /// How this provider stores the versions of the packages.
+    ///
+    /// A common choice is [`SemanticVersion`][crate::version::SemanticVersion].
     type V: Debug + Display + Clone + Ord;
 
     /// How this provider stores the version requirements for the packages.
     /// The requirements must be able to process the same kind of version as this dependency provider.
+    ///
+    /// A common choice is [`Range`][crate::range::Range].
     type VS: VersionSet<V = Self::V>;
 
     /// Type for custom incompatibilities.
@@ -218,8 +222,10 @@ pub trait DependencyProvider {
     /// to be unavailable. Examples:
     /// * The version would require building the package, but builds are disabled.
     /// * The package is not available in the cache, but internet access has been disabled.
-    /// The intended use is to track them in an enum and assign them to this type. This also
-    /// supports collapsing custom incompatibilities in error messages.
+    /// * The package uses a legacy format not supported anymore.
+    ///
+    /// The intended use is to track them in an enum and assign them to this type. You can also
+    /// assign [`String`] as placeholder.
     type M: Eq + Clone + Debug + Display;
 
     /// [Decision making](https://github.com/dart-lang/pub/blob/master/doc/solver.md#decision-making)

--- a/src/solver.rs
+++ b/src/solver.rs
@@ -212,7 +212,14 @@ pub trait DependencyProvider {
     /// The requirements must be able to process the same kind of version as this dependency provider.
     type VS: VersionSet<V = Self::V>;
 
-    /// How this provider stores metadata or additional context about incompatibilities
+    /// Type for custom incompatibilities.
+    ///
+    /// There are reasons in user code outside pubgrub that can cause packages or versions
+    /// to be unavailable. Examples:
+    /// * The version would require building the package, but builds are disabled.
+    /// * The package is not available in the cache, but internet access has been disabled.
+    /// The intended use is to track them in an enum and assign them to this type. This also
+    /// supports collapsing custom incompatibilities in error messages.
     type M: Eq + Clone + Debug + Display;
 
     /// [Decision making](https://github.com/dart-lang/pub/blob/master/doc/solver.md#decision-making)

--- a/src/type_aliases.rs
+++ b/src/type_aliases.rs
@@ -22,5 +22,8 @@ pub type SelectedDependencies<DP> =
 /// while the latter means they could not be fetched by the [DependencyProvider].
 pub type DependencyConstraints<P, VS> = Map<P, VS>;
 
-pub(crate) type IncompDpId<DP> =
-    IncompId<<DP as DependencyProvider>::P, <DP as DependencyProvider>::VS>;
+pub(crate) type IncompDpId<DP> = IncompId<
+    <DP as DependencyProvider>::P,
+    <DP as DependencyProvider>::VS,
+    <DP as DependencyProvider>::M,
+>;

--- a/tests/proptest.rs
+++ b/tests/proptest.rs
@@ -4,6 +4,7 @@
 
 use std::collections::BTreeSet as Set;
 use std::convert::Infallible;
+use std::fmt::{Debug, Display};
 
 use pubgrub::error::PubGrubError;
 use pubgrub::package::Package;
@@ -31,7 +32,11 @@ struct OldestVersionsDependencyProvider<P: Package, VS: VersionSet>(
 );
 
 impl<P: Package, VS: VersionSet> DependencyProvider for OldestVersionsDependencyProvider<P, VS> {
-    fn get_dependencies(&self, p: &P, v: &VS::V) -> Result<Dependencies<P, VS>, Infallible> {
+    fn get_dependencies(
+        &self,
+        p: &P,
+        v: &VS::V,
+    ) -> Result<Dependencies<P, VS, Self::M>, Infallible> {
         self.0.get_dependencies(p, v)
     }
 
@@ -56,6 +61,7 @@ impl<P: Package, VS: VersionSet> DependencyProvider for OldestVersionsDependency
     type P = P;
     type V = VS::V;
     type VS = VS;
+    type M = String;
 }
 
 /// The same as DP but it has a timeout.
@@ -83,7 +89,7 @@ impl<DP: DependencyProvider> DependencyProvider for TimeoutDependencyProvider<DP
         &self,
         p: &DP::P,
         v: &DP::V,
-    ) -> Result<Dependencies<DP::P, DP::VS>, DP::Err> {
+    ) -> Result<Dependencies<DP::P, DP::VS, DP::M>, DP::Err> {
         self.dp.get_dependencies(p, v)
     }
 
@@ -110,6 +116,7 @@ impl<DP: DependencyProvider> DependencyProvider for TimeoutDependencyProvider<DP
     type P = DP::P;
     type V = <DP::VS as VersionSet>::V;
     type VS = DP::VS;
+    type M = DP::M;
 }
 
 fn timeout_resolve<DP: DependencyProvider>(
@@ -314,7 +321,7 @@ fn retain_versions<N: Package + Ord, VS: VersionSet>(
                 continue;
             }
             let deps = match dependency_provider.get_dependencies(n, v).unwrap() {
-                Dependencies::Unknown => panic!(),
+                Dependencies::Unknown(_) => panic!(),
                 Dependencies::Known(deps) => deps,
             };
             smaller_dependency_provider.add_dependencies(n.clone(), v.clone(), deps)
@@ -338,7 +345,7 @@ fn retain_dependencies<N: Package + Ord, VS: VersionSet>(
     for n in dependency_provider.packages() {
         for v in dependency_provider.versions(n).unwrap() {
             let deps = match dependency_provider.get_dependencies(n, v).unwrap() {
-                Dependencies::Unknown => panic!(),
+                Dependencies::Unknown(_) => panic!(),
                 Dependencies::Known(deps) => deps,
             };
             smaller_dependency_provider.add_dependencies(
@@ -368,9 +375,9 @@ fn errors_the_same_with_only_report_dependencies<N: Package + Ord>(
         return;
     };
 
-    fn recursive<N: Package + Ord, VS: VersionSet>(
+    fn recursive<N: Package + Ord, VS: VersionSet, M: Eq + Clone + Debug + Display>(
         to_retain: &mut Vec<(N, VS, N)>,
-        tree: &DerivationTree<N, VS>,
+        tree: &DerivationTree<N, VS, M>,
     ) {
         match tree {
             DerivationTree::External(External::FromDependencyOf(n1, vs1, n2, _)) => {
@@ -509,7 +516,7 @@ proptest! {
                 .get_dependencies(package, version)
                 .unwrap()
             {
-                Dependencies::Unknown => panic!(),
+                Dependencies::Unknown(_) => panic!(),
                 Dependencies::Known(d) => d.into_iter().collect(),
             };
             if !dependencies.is_empty() {

--- a/tests/sat_dependency_provider.rs
+++ b/tests/sat_dependency_provider.rs
@@ -66,7 +66,7 @@ impl<P: Package, VS: VersionSet> SatResolve<P, VS> {
         // active packages need each of there `deps` to be satisfied
         for (p, v, var) in &all_versions {
             let deps = match dp.get_dependencies(p, v).unwrap() {
-                Dependencies::Unknown => panic!(),
+                Dependencies::Unknown(_) => panic!(),
                 Dependencies::Known(d) => d,
             };
             for (p1, range) in &deps {


### PR DESCRIPTION
Restructure the incompatibility into pubgrub internal metadata and a custom external type.

The internal types are:
* not root: The root incompatibility that drives resolution
* no versions: We tried all versions and there is none remaining
* from dependency of: {A, not B} from A -> B
* derived from: {A, not C} from {A, not B} and {B, not C}
* custom: Any incompatibility that originates outside pubgrub. The idea is that users can set `M` to a custom enum of theirs. Examples:
  * The version would require building the package, but builds are disabled.
  * The package is not available in the cache, but internet access has been disabled.
  * The package has invalid metadata

I'm currently working on adapting the formatting to adapt to the uv of this. This should reduce our diff significantly.

This refactoring is relevant to collapsing custom incompatibilities, but i haven't looked into this properly yet.