### PR TITLE
fix: unused import warning in plain cargo test

### DIFF
--- a/tests/proptest.rs
+++ b/tests/proptest.rs
@@ -11,6 +11,7 @@ use pubgrub::range::Range;
 use pubgrub::report::{DefaultStringReporter, DerivationTree, External, Reporter};
 use pubgrub::solver::{resolve, Dependencies, DependencyProvider, OfflineDependencyProvider};
 use pubgrub::type_aliases::SelectedDependencies;
+#[cfg(feature = "serde")]
 use pubgrub::version::SemanticVersion;
 use pubgrub::version_set::VersionSet;
 


### PR DESCRIPTION
Before:

```
$ cargo test
     Compiling pubgrub v0.2.1 (/home/konsti/projects/pubgrub)
  warning: unused import: `pubgrub::version::SemanticVersion`
    --> tests/proptest.rs:14:5
     |
  14 | use pubgrub::version::SemanticVersion;
     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     |
     = note: `#[warn(unused_imports)]` on by default
```