### PR TITLE
Rename dependencies type to available and unavailable

### DIFF
--- a/examples/caching_dependency_provider.rs
+++ b/examples/caching_dependency_provider.rs
@@ -32,18 +32,18 @@ impl<DP: DependencyProvider<M = String>> DependencyProvider for CachingDependenc
     ) -> Result<Dependencies<DP::P, DP::VS, DP::M>, DP::Err> {
         let mut cache = self.cached_dependencies.borrow_mut();
         match cache.get_dependencies(package, version) {
-            Ok(Dependencies::Unknown(_)) => {
+            Ok(Dependencies::Unavailable(_)) => {
                 let dependencies = self.remote_dependencies.get_dependencies(package, version);
                 match dependencies {
-                    Ok(Dependencies::Known(dependencies)) => {
+                    Ok(Dependencies::Available(dependencies)) => {
                         cache.add_dependencies(
                             package.clone(),
                             version.clone(),
                             dependencies.clone(),
                         );
-                        Ok(Dependencies::Known(dependencies))
+                        Ok(Dependencies::Available(dependencies))
                     }
-                    Ok(Dependencies::Unknown(reason)) => Ok(Dependencies::Unknown(reason)),
+                    Ok(Dependencies::Unavailable(reason)) => Ok(Dependencies::Unavailable(reason)),
                     error @ Err(_) => error,
                 }
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -121,7 +121,6 @@
 //!
 //! The third method [get_dependencies](crate::solver::DependencyProvider::get_dependencies)
 //! aims at retrieving the dependencies of a given package at a given version.
-//! Returns [None] if dependencies are unknown.
 //!
 //! In a real scenario, these two methods may involve reading the file system
 //! or doing network request, so you may want to hold a cache in your
@@ -151,7 +150,7 @@
 //! External incompatibilities have reasons that are independent
 //! of the way this algorithm is implemented such as
 //!  - dependencies: "package_a" at version 1 depends on "package_b" at version 4
-//!  - missing dependencies: dependencies of "package_a" are unknown
+//!  - missing dependencies: dependencies of "package_a" are unavailable
 //!  - absence of version: there is no version of "package_a" in the range [3.1.0  4.0.0[
 //!
 //! Derived incompatibilities are obtained during the algorithm execution by deduction,

--- a/src/type_aliases.rs
+++ b/src/type_aliases.rs
@@ -17,7 +17,7 @@ pub type SelectedDependencies<DP> =
 
 /// Holds information about all possible versions a given package can accept.
 /// There is a difference in semantics between an empty map
-/// inside [DependencyConstraints] and [Dependencies::Unknown](crate::solver::Dependencies::Unknown):
+/// inside [DependencyConstraints] and [Dependencies::Unavailable](crate::solver::Dependencies::Unavailable):
 /// the former means the package has no dependency and it is a known fact,
 /// while the latter means they could not be fetched by the [DependencyProvider].
 pub type DependencyConstraints<P, VS> = Map<P, VS>;

--- a/tests/proptest.rs
+++ b/tests/proptest.rs
@@ -322,8 +322,8 @@ fn retain_versions<N: Package + Ord, VS: VersionSet>(
                 continue;
             }
             let deps = match dependency_provider.get_dependencies(n, v).unwrap() {
-                Dependencies::Unknown(_) => panic!(),
-                Dependencies::Known(deps) => deps,
+                Dependencies::Unavailable(_) => panic!(),
+                Dependencies::Available(deps) => deps,
             };
             smaller_dependency_provider.add_dependencies(n.clone(), v.clone(), deps)
         }
@@ -346,8 +346,8 @@ fn retain_dependencies<N: Package + Ord, VS: VersionSet>(
     for n in dependency_provider.packages() {
         for v in dependency_provider.versions(n).unwrap() {
             let deps = match dependency_provider.get_dependencies(n, v).unwrap() {
-                Dependencies::Unknown(_) => panic!(),
-                Dependencies::Known(deps) => deps,
+                Dependencies::Unavailable(_) => panic!(),
+                Dependencies::Available(deps) => deps,
             };
             smaller_dependency_provider.add_dependencies(
                 n.clone(),
@@ -517,8 +517,8 @@ proptest! {
                 .get_dependencies(package, version)
                 .unwrap()
             {
-                Dependencies::Unknown(_) => panic!(),
-                Dependencies::Known(d) => d.into_iter().collect(),
+                Dependencies::Unavailable(_) => panic!(),
+                Dependencies::Available(d) => d.into_iter().collect(),
             };
             if !dependencies.is_empty() {
                 to_remove.insert((package, **version, dep_idx.get(&dependencies).0));

--- a/tests/sat_dependency_provider.rs
+++ b/tests/sat_dependency_provider.rs
@@ -66,8 +66,8 @@ impl<P: Package, VS: VersionSet> SatResolve<P, VS> {
         // active packages need each of there `deps` to be satisfied
         for (p, v, var) in &all_versions {
             let deps = match dp.get_dependencies(p, v).unwrap() {
-                Dependencies::Unknown(_) => panic!(),
-                Dependencies::Known(d) => d,
+                Dependencies::Unavailable(_) => panic!(),
+                Dependencies::Available(d) => d,
             };
             for (p1, range) in &deps {
                 let empty_vec = vec![];


### PR DESCRIPTION
In uv, dependencies are either available or unavailable. They are not unknown, but rather missing due to some brokenness: We're offline but the dep is not cached, the version list failed to deserialize, etc. (https://github.com/astral-sh/uv/blob/0b84eb01408eb0e90b5720b027359aac10708665/crates/uv-resolver/src/resolver/mod.rs#L945-L996). This change is a rename of the variants of `Dependencies` to reflect that, upstreaming the change from uv.