### PR TITLE
Fix cargo publish dry run

### DIFF
--- a/.github/workflows/cargo_publish_dry_run.yml
+++ b/.github/workflows/cargo_publish_dry_run.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install stable Rust
-        uses: dtolnay/rust-toolchain
+        uses: dtolnay/rust-toolchain@stable
 
       - name: Get Cargo version
         id: cargo_version


### PR DESCRIPTION
Github actions are erroring with the  cargo_publish_dry_run.yml workflow, even though it's not running (https://github.com/astral-sh/pubgrub/actions/runs/8925107214). This change should fix that.