### PR TITLE
Fix a clippy lint: `impl Default for Arena`

### DIFF
--- a/src/internal/arena.rs
+++ b/src/internal/arena.rs
@@ -86,9 +86,15 @@ impl<T: fmt::Debug> fmt::Debug for Arena<T> {
     }
 }
 
+impl<T> Default for Arena<T> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl<T> Arena<T> {
-    pub fn new() -> Arena<T> {
-        Arena { data: Vec::new() }
+    pub fn new() -> Self {
+        Self { data: Vec::new() }
     }
 
     pub fn alloc(&mut self, value: T) -> Id<T> {


### PR DESCRIPTION
This showed up as a clippy warning (parameterless new but no default) when removing `#![allow(clippy::all)]` on our `main`, though surprisingly this doesn't happen on upstream `dev`. I think it's a good change either way.