### PR TITLE
Move all public symbols to the top level

### DIFF
--- a/examples/branching_error_reporting.rs
+++ b/examples/branching_error_reporting.rs
@@ -1,10 +1,9 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use pubgrub::error::PubGrubError;
-use pubgrub::range::Range;
-use pubgrub::report::{DefaultStringReporter, Reporter};
-use pubgrub::solver::{resolve, OfflineDependencyProvider};
-use pubgrub::version::SemanticVersion;
+use pubgrub::{
+    resolve, DefaultStringReporter, OfflineDependencyProvider, PubGrubError, Range, Reporter,
+    SemanticVersion,
+};
 
 type SemVS = Range<SemanticVersion>;
 

--- a/examples/caching_dependency_provider.rs
+++ b/examples/caching_dependency_provider.rs
@@ -2,8 +2,7 @@
 
 use std::cell::RefCell;
 
-use pubgrub::range::Range;
-use pubgrub::solver::{resolve, Dependencies, DependencyProvider, OfflineDependencyProvider};
+use pubgrub::{resolve, Dependencies, DependencyProvider, OfflineDependencyProvider, Range};
 
 type NumVS = Range<u32>;
 

--- a/examples/doc_interface.rs
+++ b/examples/doc_interface.rs
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use pubgrub::range::Range;
-use pubgrub::solver::{resolve, OfflineDependencyProvider};
+use pubgrub::{resolve, OfflineDependencyProvider, Range};
 
 type NumVS = Range<u32>;
 

--- a/examples/doc_interface_error.rs
+++ b/examples/doc_interface_error.rs
@@ -1,10 +1,9 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use pubgrub::error::PubGrubError;
-use pubgrub::range::Range;
-use pubgrub::report::{DefaultStringReporter, Reporter};
-use pubgrub::solver::{resolve, OfflineDependencyProvider};
-use pubgrub::version::SemanticVersion;
+use pubgrub::{
+    resolve, DefaultStringReporter, OfflineDependencyProvider, PubGrubError, Range, Reporter,
+    SemanticVersion,
+};
 
 type SemVS = Range<SemanticVersion>;
 

--- a/examples/doc_interface_semantic.rs
+++ b/examples/doc_interface_semantic.rs
@@ -1,10 +1,9 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use pubgrub::error::PubGrubError;
-use pubgrub::range::Range;
-use pubgrub::report::{DefaultStringReporter, Reporter};
-use pubgrub::solver::{resolve, OfflineDependencyProvider};
-use pubgrub::version::SemanticVersion;
+use pubgrub::{
+    resolve, DefaultStringReporter, OfflineDependencyProvider, PubGrubError, Range, Reporter,
+    SemanticVersion,
+};
 
 type SemVS = Range<SemanticVersion>;
 

--- a/examples/linear_error_reporting.rs
+++ b/examples/linear_error_reporting.rs
@@ -1,10 +1,9 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use pubgrub::error::PubGrubError;
-use pubgrub::range::Range;
-use pubgrub::report::{DefaultStringReporter, Reporter};
-use pubgrub::solver::{resolve, OfflineDependencyProvider};
-use pubgrub::version::SemanticVersion;
+use pubgrub::{
+    resolve, DefaultStringReporter, OfflineDependencyProvider, PubGrubError, Range, Reporter,
+    SemanticVersion,
+};
 
 type SemVS = Range<SemanticVersion>;
 

--- a/examples/unsat_root_message_no_version.rs
+++ b/examples/unsat_root_message_no_version.rs
@@ -1,14 +1,10 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use pubgrub::error::PubGrubError;
-use pubgrub::range::Range;
-use pubgrub::report::{Derived, Reporter};
-use pubgrub::solver::{resolve, OfflineDependencyProvider};
-use pubgrub::version::SemanticVersion;
+use pubgrub::{
+    resolve, Derived, OfflineDependencyProvider, PubGrubError, Range, Reporter, SemanticVersion,
+};
 
-use pubgrub::report::{DefaultStringReporter, External, ReportFormatter};
-use pubgrub::term::Term;
-use pubgrub::type_aliases::Map;
+use pubgrub::{DefaultStringReporter, External, Map, ReportFormatter, Term};
 use std::fmt::{self, Display};
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]

--- a/src/internal/arena.rs
+++ b/src/internal/arena.rs
@@ -1,9 +1,7 @@
-use std::{
-    fmt,
-    hash::{Hash, Hasher},
-    marker::PhantomData,
-    ops::{Index, Range},
-};
+use std::fmt;
+use std::hash::{Hash, Hasher};
+use std::marker::PhantomData;
+use std::ops::{Index, Range};
 
 /// The index of a value allocated in an arena that holds `T`s.
 ///

--- a/src/internal/small_map.rs
+++ b/src/internal/small_map.rs
@@ -1,5 +1,6 @@
-use crate::type_aliases::Map;
 use std::hash::Hash;
+
+use crate::Map;
 
 #[derive(Debug, Clone)]
 pub enum SmallMap<K, V> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -157,9 +157,7 @@
 //! This crate defines a [Reporter] trait, with an associated
 //! [Output](crate::report::Reporter::Output) type and a single method.
 //! ```
-//! # use pubgrub::Package;
-//! # use pubgrub::VersionSet;
-//! # use pubgrub::DerivationTree;
+//! # use pubgrub::{Package, VersionSet, DerivationTree};
 //! # use std::fmt::{Debug, Display};
 //! #
 //! pub trait Reporter<P: Package, VS: VersionSet, M: Eq + Clone + Debug + Display> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,10 +11,10 @@
 //! # Package and Version traits
 //!
 //! All the code in this crate is manipulating packages and versions, and for this to work
-//! we defined a [Package](package::Package) trait
+//! we defined a [Package] trait
 //! that is used as bounds on most of the exposed types and functions.
 //!
-//! Package identifiers needs to implement our [Package](package::Package) trait,
+//! Package identifiers needs to implement our [Package] trait,
 //! which is automatic if the type already implements
 //! [Clone] + [Eq] + [Hash] + [Debug] + [Display](std::fmt::Display).
 //! So things like [String] will work out of the box.
@@ -22,7 +22,7 @@
 //! TODO! This is all wrong. Need to talk about VS, not Version.
 //! Our Version trait requires
 //! [Clone] + [Ord] + [Debug] + [Display](std::fmt::Display).
-//! For convenience, this library provides [SemanticVersion](version::SemanticVersion)
+//! For convenience, this library provides [SemanticVersion]
 //! that implements semantic versioning rules.
 //!
 //! # Basic example
@@ -40,15 +40,16 @@
 //!
 //! We can model that scenario with this library as follows
 //! ```
-//! # use pubgrub::solver::{OfflineDependencyProvider, resolve};
-//! # use pubgrub::range::Range;
+//! # use pubgrub::{OfflineDependencyProvider, resolve, Range};
 //!
 //! type NumVS = Range<u32>;
 //!
 //! let mut dependency_provider = OfflineDependencyProvider::<&str, NumVS>::new();
 //!
 //! dependency_provider.add_dependencies(
-//!     "root", 1u32, [("menu", Range::full()), ("icons", Range::full())],
+//!     "root",
+//!     1u32,
+//!     [("menu", Range::full()), ("icons", Range::full())],
 //! );
 //! dependency_provider.add_dependencies("menu", 1u32, [("dropdown", Range::full())]);
 //! dependency_provider.add_dependencies("dropdown", 1u32, [("icons", Range::full())]);
@@ -61,19 +62,16 @@
 //! # DependencyProvider trait
 //!
 //! In our previous example we used the
-//! [OfflineDependencyProvider](solver::OfflineDependencyProvider),
-//! which is a basic implementation of the [DependencyProvider](solver::DependencyProvider) trait.
+//! [OfflineDependencyProvider],
+//! which is a basic implementation of the [DependencyProvider] trait.
 //!
-//! But we might want to implement the [DependencyProvider](solver::DependencyProvider)
+//! But we might want to implement the [DependencyProvider]
 //! trait for our own type.
 //! Let's say that we will use [String] for packages,
-//! and [SemanticVersion](version::SemanticVersion) for versions.
+//! and [SemanticVersion] for versions.
 //! This may be done quite easily by implementing the three following functions.
 //! ```
-//! # use pubgrub::solver::{DependencyProvider, Dependencies};
-//! # use pubgrub::version::SemanticVersion;
-//! # use pubgrub::range::Range;
-//! # use pubgrub::type_aliases::{DependencyConstraints, Map};
+//! # use pubgrub::{DependencyProvider, Dependencies, SemanticVersion,Range, DependencyConstraints, Map};
 //! # use std::error::Error;
 //! # use std::borrow::Borrow;
 //! # use std::convert::Infallible;
@@ -124,10 +122,10 @@
 //!
 //! In a real scenario, these two methods may involve reading the file system
 //! or doing network request, so you may want to hold a cache in your
-//! [DependencyProvider](solver::DependencyProvider) implementation.
+//! [DependencyProvider] implementation.
 //! How exactly this could be achieved is shown in `CachingDependencyProvider`
 //! (see `examples/caching_dependency_provider.rs`).
-//! You could also use the [OfflineDependencyProvider](solver::OfflineDependencyProvider)
+//! You could also use the [OfflineDependencyProvider]
 //! type defined by the crate as guidance,
 //! but you are free to use whatever approach makes sense in your situation.
 //!
@@ -156,12 +154,12 @@
 //! Derived incompatibilities are obtained during the algorithm execution by deduction,
 //! such as if "a" depends on "b" and "b" depends on "c", "a" depends on "c".
 //!
-//! This crate defines a [Reporter](crate::report::Reporter) trait, with an associated
+//! This crate defines a [Reporter] trait, with an associated
 //! [Output](crate::report::Reporter::Output) type and a single method.
 //! ```
-//! # use pubgrub::package::Package;
-//! # use pubgrub::version_set::VersionSet;
-//! # use pubgrub::report::DerivationTree;
+//! # use pubgrub::Package;
+//! # use pubgrub::VersionSet;
+//! # use pubgrub::DerivationTree;
 //! # use std::fmt::{Debug, Display};
 //! #
 //! pub trait Reporter<P: Package, VS: VersionSet, M: Eq + Clone + Debug + Display> {
@@ -170,17 +168,13 @@
 //!     fn report(derivation_tree: &DerivationTree<P, VS, M>) -> Self::Output;
 //! }
 //! ```
-//! Implementing a [Reporter](crate::report::Reporter) may involve a lot of heuristics
+//! Implementing a [Reporter] may involve a lot of heuristics
 //! to make the output human-readable and natural.
 //! For convenience, we provide a default implementation
-//! [DefaultStringReporter](crate::report::DefaultStringReporter)
-//! that outputs the report as a [String].
+//! [DefaultStringReporter] that outputs the report as a [String].
 //! You may use it as follows:
 //! ```
-//! # use pubgrub::solver::{resolve, OfflineDependencyProvider};
-//! # use pubgrub::report::{DefaultStringReporter, Reporter};
-//! # use pubgrub::error::PubGrubError;
-//! # use pubgrub::range::Range;
+//! # use pubgrub::{resolve, OfflineDependencyProvider, DefaultStringReporter, Reporter, PubGrubError, Range};
 //! #
 //! # type NumVS = Range<u32>;
 //! #
@@ -218,14 +212,27 @@
 
 #![warn(missing_docs)]
 
-pub mod error;
-pub mod package;
-pub mod range;
-pub mod report;
-pub mod solver;
-pub mod term;
-pub mod type_aliases;
-pub mod version;
-pub mod version_set;
+mod error;
+mod package;
+mod range;
+mod report;
+mod solver;
+mod term;
+mod type_aliases;
+mod version;
+mod version_set;
+
+pub use error::PubGrubError;
+pub use package::Package;
+pub use range::Range;
+pub use report::{
+    DefaultStringReportFormatter, DefaultStringReporter, DerivationTree, Derived, External,
+    ReportFormatter, Reporter,
+};
+pub use solver::{resolve, Dependencies, DependencyProvider, OfflineDependencyProvider};
+pub use term::Term;
+pub use type_aliases::{DependencyConstraints, Map, SelectedDependencies, Set};
+pub use version::{SemanticVersion, VersionParseError};
+pub use version_set::VersionSet;
 
 mod internal;

--- a/src/range.rs
+++ b/src/range.rs
@@ -50,14 +50,13 @@
 //! If doing so regularly fixes bugs seen by users, we will bring it back into the core library.
 //! If we do not see practical bugs, or we get a formal proof that the code cannot lead to error states, then we may remove this warning.
 
-use crate::{internal::small_vec::SmallVec, version_set::VersionSet};
+use crate::internal::small_vec::SmallVec;
+use crate::version_set::VersionSet;
 use std::borrow::Borrow;
 use std::cmp::Ordering;
+use std::fmt::{Debug, Display, Formatter};
+use std::ops::Bound::{self, Excluded, Included, Unbounded};
 use std::ops::RangeBounds;
-use std::{
-    fmt::{Debug, Display, Formatter},
-    ops::Bound::{self, Excluded, Included, Unbounded},
-};
 
 /// A Range represents multiple intervals of a continuous range of monotone increasing
 /// values.

--- a/src/report.rs
+++ b/src/report.rs
@@ -7,7 +7,7 @@ use std::fmt::{self, Debug, Display};
 use std::ops::Deref;
 use std::sync::Arc;
 
-use crate::{Package, Set, Term, VersionSet};
+use crate::{Map, Package, Set, Term, VersionSet};
 
 /// Reporter trait.
 pub trait Reporter<P: Package, VS: VersionSet, M: Eq + Clone + Debug + Display> {

--- a/src/report.rs
+++ b/src/report.rs
@@ -7,10 +7,7 @@ use std::fmt::{self, Debug, Display};
 use std::ops::Deref;
 use std::sync::Arc;
 
-use crate::package::Package;
-use crate::term::Term;
-use crate::type_aliases::{Map, Set};
-use crate::version_set::VersionSet;
+use crate::{Package, Set, Term, VersionSet};
 
 /// Reporter trait.
 pub trait Reporter<P: Package, VS: VersionSet, M: Eq + Clone + Debug + Display> {

--- a/src/solver.rs
+++ b/src/solver.rs
@@ -35,9 +35,7 @@
 //!
 //! ```
 //! # use std::convert::Infallible;
-//! # use pubgrub::solver::{resolve, OfflineDependencyProvider};
-//! # use pubgrub::error::PubGrubError;
-//! # use pubgrub::range::Range;
+//! # use pubgrub::{resolve, OfflineDependencyProvider, PubGrubError, Range};
 //! #
 //! # type NumVS = Range<u32>;
 //! #

--- a/src/term.rs
+++ b/src/term.rs
@@ -3,8 +3,9 @@
 //! A term is the fundamental unit of operation of the PubGrub algorithm.
 //! It is a positive or negative expression regarding a set of versions.
 
-use crate::version_set::VersionSet;
 use std::fmt::{self, Display};
+
+use crate::VersionSet;
 
 /// A positive or negative expression regarding a set of versions.
 ///

--- a/src/type_aliases.rs
+++ b/src/type_aliases.rs
@@ -2,7 +2,8 @@
 
 //! Publicly exported type aliases.
 
-use crate::{internal::incompatibility::IncompId, solver::DependencyProvider};
+use crate::internal::incompatibility::IncompId;
+use crate::DependencyProvider;
 
 /// Map implementation used by the library.
 pub type Map<K, V> = rustc_hash::FxHashMap<K, V>;

--- a/tests/examples.rs
+++ b/tests/examples.rs
@@ -1,11 +1,9 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use pubgrub::error::PubGrubError;
-use pubgrub::range::Range;
-use pubgrub::report::{DefaultStringReporter, Reporter as _};
-use pubgrub::solver::{resolve, OfflineDependencyProvider};
-use pubgrub::type_aliases::{Map, Set};
-use pubgrub::version::SemanticVersion;
+use pubgrub::{
+    resolve, DefaultStringReporter, Map, OfflineDependencyProvider, PubGrubError, Range,
+    Reporter as _, SemanticVersion, Set,
+};
 
 type NumVS = Range<u32>;
 type SemVS = Range<SemanticVersion>;

--- a/tests/proptest.rs
+++ b/tests/proptest.rs
@@ -6,15 +6,13 @@ use std::collections::BTreeSet as Set;
 use std::convert::Infallible;
 use std::fmt::{Debug, Display};
 
-use pubgrub::error::PubGrubError;
-use pubgrub::package::Package;
-use pubgrub::range::Range;
-use pubgrub::report::{DefaultStringReporter, DerivationTree, External, Reporter};
-use pubgrub::solver::{resolve, Dependencies, DependencyProvider, OfflineDependencyProvider};
-use pubgrub::type_aliases::SelectedDependencies;
 #[cfg(feature = "serde")]
-use pubgrub::version::SemanticVersion;
-use pubgrub::version_set::VersionSet;
+use pubgrub::SemanticVersion;
+use pubgrub::{
+    resolve, DefaultStringReporter, Dependencies, DependencyProvider, DerivationTree, External,
+    OfflineDependencyProvider, Package, PubGrubError, Range, Reporter, SelectedDependencies,
+    VersionSet,
+};
 
 use proptest::collection::{btree_map, btree_set, vec};
 use proptest::prelude::*;

--- a/tests/sat_dependency_provider.rs
+++ b/tests/sat_dependency_provider.rs
@@ -1,10 +1,9 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use pubgrub::error::PubGrubError;
-use pubgrub::package::Package;
-use pubgrub::solver::{Dependencies, DependencyProvider, OfflineDependencyProvider};
-use pubgrub::type_aliases::{Map, SelectedDependencies};
-use pubgrub::version_set::VersionSet;
+use pubgrub::{
+    Dependencies, DependencyProvider, Map, OfflineDependencyProvider, Package, PubGrubError,
+    SelectedDependencies, VersionSet,
+};
 use varisat::ExtendFormula;
 
 fn sat_at_most_one(solver: &mut impl varisat::ExtendFormula, vars: &[varisat::Var]) {

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use pubgrub::error::PubGrubError;
-use pubgrub::range::Range;
-use pubgrub::solver::{resolve, OfflineDependencyProvider};
+use pubgrub::{resolve, OfflineDependencyProvider, PubGrubError, Range};
 
 type NumVS = Range<u32>;
 


### PR DESCRIPTION
This is a prototype for moving all symbols to the top level namespace, removing the modules from the public api.

![image](https://github.com/user-attachments/assets/19efed82-353b-4608-83f6-e888d20b4f52)
