### PR TITLE
Create an arena for package names

### DIFF
--- a/src/internal/arena.rs
+++ b/src/internal/arena.rs
@@ -3,6 +3,8 @@ use std::hash::{Hash, Hasher};
 use std::marker::PhantomData;
 use std::ops::{Index, Range};
 
+type FnvIndexSet<V> = indexmap::IndexSet<V, rustc_hash::FxBuildHasher>;
+
 /// The index of a value allocated in an arena that holds `T`s.
 ///
 /// The Clone, Copy and other traits are defined manually because
@@ -122,5 +124,46 @@ impl<T> Index<Range<Id<T>>> for Arena<T> {
     type Output = [T];
     fn index(&self, id: Range<Id<T>>) -> &[T] {
         &self.data[(id.start.raw as usize)..(id.end.raw as usize)]
+    }
+}
+
+/// Yet another index-based arena. This one de-duplicates entries by hashing.
+///
+/// An arena is a kind of simple grow-only allocator, backed by a `Vec`
+/// where all items have the same lifetime, making it easier
+/// to have references between those items.
+/// In this case the `Vec` is inside a `IndexSet` allowing fast lookup by value not just index.
+/// They are all dropped at once when the arena is dropped.
+#[derive(Clone, PartialEq, Eq)]
+pub struct HashArena<T: Hash + Eq> {
+    data: FnvIndexSet<T>,
+}
+
+impl<T: Hash + Eq + fmt::Debug> fmt::Debug for HashArena<T> {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        fmt.debug_struct("Arena")
+            .field("len", &self.data.len())
+            .field("data", &self.data)
+            .finish()
+    }
+}
+
+impl<T: Hash + Eq> HashArena<T> {
+    pub fn new() -> Self {
+        HashArena {
+            data: FnvIndexSet::default(),
+        }
+    }
+
+    pub fn alloc(&mut self, value: T) -> Id<T> {
+        let (raw, _) = self.data.insert_full(value);
+        Id::from(raw as u32)
+    }
+}
+
+impl<T: Hash + Eq> Index<Id<T>> for HashArena<T> {
+    type Output = T;
+    fn index(&self, id: Id<T>) -> &T {
+        &self.data[id.raw as usize]
     }
 }

--- a/src/internal/core.rs
+++ b/src/internal/core.rs
@@ -7,19 +7,19 @@ use std::collections::HashSet as Set;
 use std::sync::Arc;
 
 use crate::internal::{
-    Arena, DecisionLevel, IncompDpId, Incompatibility, PartialSolution, Relation, SatisfierSearch,
-    SmallVec,
+    Arena, DecisionLevel, HashArena, Id, IncompDpId, Incompatibility, PartialSolution, Relation,
+    SatisfierSearch, SmallVec,
 };
 use crate::{DependencyProvider, DerivationTree, Map, NoSolutionError, VersionSet};
 
 /// Current state of the PubGrub algorithm.
 #[derive(Clone)]
 pub(crate) struct State<DP: DependencyProvider> {
-    root_package: DP::P,
+    pub root_package: Id<DP::P>,
     root_version: DP::V,
 
     #[allow(clippy::type_complexity)]
-    incompatibilities: Map<DP::P, Vec<IncompDpId<DP>>>,
+    incompatibilities: Map<Id<DP::P>, Vec<IncompDpId<DP>>>,
 
     /// Store the ids of incompatibilities that are already contradicted.
     /// For each one keep track of the decision level when it was found to be contradicted.
@@ -29,7 +29,7 @@ pub(crate) struct State<DP: DependencyProvider> {
     /// All incompatibilities expressing dependencies,
     /// with common dependents merged.
     #[allow(clippy::type_complexity)]
-    merged_dependencies: Map<(DP::P, DP::P), SmallVec<IncompDpId<DP>>>,
+    merged_dependencies: Map<(Id<DP::P>, Id<DP::P>), SmallVec<IncompDpId<DP>>>,
 
     /// Partial solution.
     /// TODO: remove pub.
@@ -38,22 +38,27 @@ pub(crate) struct State<DP: DependencyProvider> {
     /// The store is the reference storage for all incompatibilities.
     pub(crate) incompatibility_store: Arena<Incompatibility<DP::P, DP::VS, DP::M>>,
 
+    /// The store is the reference storage for all packages.
+    pub(crate) package_store: HashArena<DP::P>,
+
     /// This is a stack of work to be done in `unit_propagation`.
     /// It can definitely be a local variable to that method, but
     /// this way we can reuse the same allocation for better performance.
-    unit_propagation_buffer: SmallVec<DP::P>,
+    unit_propagation_buffer: SmallVec<Id<DP::P>>,
 }
 
 impl<DP: DependencyProvider> State<DP> {
     /// Initialization of PubGrub state.
     pub(crate) fn init(root_package: DP::P, root_version: DP::V) -> Self {
         let mut incompatibility_store = Arena::new();
+        let mut package_store = HashArena::new();
+        let root_package = package_store.alloc(root_package);
         let not_root_id = incompatibility_store.alloc(Incompatibility::not_root(
-            root_package.clone(),
+            root_package,
             root_version.clone(),
         ));
         let mut incompatibilities = Map::default();
-        incompatibilities.insert(root_package.clone(), vec![not_root_id]);
+        incompatibilities.insert(root_package, vec![not_root_id]);
         Self {
             root_package,
             root_version,
@@ -61,6 +66,7 @@ impl<DP: DependencyProvider> State<DP> {
             contradicted_incompatibilities: Map::default(),
             partial_solution: PartialSolution::empty(),
             incompatibility_store,
+            package_store,
             unit_propagation_buffer: SmallVec::Empty,
             merged_dependencies: Map::default(),
         }
@@ -75,18 +81,19 @@ impl<DP: DependencyProvider> State<DP> {
     /// Add an incompatibility to the state.
     pub(crate) fn add_incompatibility_from_dependencies(
         &mut self,
-        package: DP::P,
+        package: Id<DP::P>,
         version: DP::V,
         deps: impl IntoIterator<Item = (DP::P, DP::VS)>,
     ) -> std::ops::Range<IncompDpId<DP>> {
         // Create incompatibilities and allocate them in the store.
         let new_incompats_id_range =
             self.incompatibility_store
-                .alloc_iter(deps.into_iter().map(|dep| {
+                .alloc_iter(deps.into_iter().map(|(dep_p, dep_vs)| {
+                    let dep_pid = self.package_store.alloc(dep_p);
                     Incompatibility::from_dependency(
-                        package.clone(),
+                        package,
                         <DP::VS as VersionSet>::singleton(version.clone()),
-                        dep,
+                        (dep_pid, dep_vs),
                     )
                 }));
         // Merge the newly created incompatibilities with the older ones.
@@ -98,7 +105,10 @@ impl<DP: DependencyProvider> State<DP> {
 
     /// Unit propagation is the core mechanism of the solving algorithm.
     /// CF <https://github.com/dart-lang/pub/blob/master/doc/solver.md#unit-propagation>
-    pub(crate) fn unit_propagation(&mut self, package: DP::P) -> Result<(), NoSolutionError<DP>> {
+    pub(crate) fn unit_propagation(
+        &mut self,
+        package: Id<DP::P>,
+    ) -> Result<(), NoSolutionError<DP>> {
         self.unit_propagation_buffer.clear();
         self.unit_propagation_buffer.push(package);
         while let Some(current_package) = self.unit_propagation_buffer.pop() {
@@ -120,7 +130,7 @@ impl<DP: DependencyProvider> State<DP> {
                     Relation::Satisfied => {
                         log::info!(
                             "Start conflict resolution because incompat satisfied:\n   {}",
-                            current_incompat
+                            current_incompat.display(&self.package_store)
                         );
                         conflict_id = Some(incompat_id);
                         break;
@@ -131,7 +141,7 @@ impl<DP: DependencyProvider> State<DP> {
                         // but so does allocating a hash map and hashing each item.
                         // In practice `unit_propagation_buffer` is small enough that we can just do a linear scan.
                         if !self.unit_propagation_buffer.contains(&package_almost) {
-                            self.unit_propagation_buffer.push(package_almost.clone());
+                            self.unit_propagation_buffer.push(package_almost);
                         }
                         // Add (not term) to the partial solution with incompat as cause.
                         self.partial_solution.add_derivation(
@@ -157,7 +167,7 @@ impl<DP: DependencyProvider> State<DP> {
                             self.build_derivation_tree(terminal_incompat_id)
                         })?;
                 self.unit_propagation_buffer.clear();
-                self.unit_propagation_buffer.push(package_almost.clone());
+                self.unit_propagation_buffer.push(package_almost);
                 // Add to the partial solution with incompat as cause.
                 self.partial_solution.add_derivation(
                     package_almost,
@@ -180,12 +190,12 @@ impl<DP: DependencyProvider> State<DP> {
     fn conflict_resolution(
         &mut self,
         incompatibility: IncompDpId<DP>,
-    ) -> Result<(DP::P, IncompDpId<DP>), IncompDpId<DP>> {
+    ) -> Result<(Id<DP::P>, IncompDpId<DP>), IncompDpId<DP>> {
         let mut current_incompat_id = incompatibility;
         let mut current_incompat_changed = false;
         loop {
             if self.incompatibility_store[current_incompat_id]
-                .is_terminal(&self.root_package, &self.root_version)
+                .is_terminal(self.root_package, &self.root_version)
             {
                 return Err(current_incompat_id);
             } else {
@@ -197,7 +207,6 @@ impl<DP: DependencyProvider> State<DP> {
                     SatisfierSearch::DifferentDecisionLevels {
                         previous_satisfier_level,
                     } => {
-                        let package = package.clone();
                         self.backtrack(
                             current_incompat_id,
                             current_incompat_changed,
@@ -213,7 +222,7 @@ impl<DP: DependencyProvider> State<DP> {
                             package,
                             &self.incompatibility_store,
                         );
-                        log::info!("prior cause: {}", prior_cause);
+                        log::info!("prior cause: {}", prior_cause.display(&self.package_store));
                         current_incompat_id = self.incompatibility_store.alloc(prior_cause);
                         current_incompat_changed = true;
                     }
@@ -256,19 +265,16 @@ impl<DP: DependencyProvider> State<DP> {
     fn merge_incompatibility(&mut self, mut id: IncompDpId<DP>) {
         if let Some((p1, p2)) = self.incompatibility_store[id].as_dependency() {
             // If we are a dependency, there's a good chance we can be merged with a previous dependency
-            let deps_lookup = self
-                .merged_dependencies
-                .entry((p1.clone(), p2.clone()))
-                .or_default();
+            let deps_lookup = self.merged_dependencies.entry((p1, p2)).or_default();
             if let Some((past, merged)) = deps_lookup.as_mut_slice().iter_mut().find_map(|past| {
                 self.incompatibility_store[id]
                     .merge_dependents(&self.incompatibility_store[*past])
                     .map(|m| (past, m))
             }) {
                 let new = self.incompatibility_store.alloc(merged);
-                for (pkg, _) in self.incompatibility_store[new].iter() {
+                for (&pkg, _) in self.incompatibility_store[new].iter() {
                     self.incompatibilities
-                        .entry(pkg.clone())
+                        .entry(pkg)
                         .or_default()
                         .retain(|id| id != past);
                 }
@@ -278,14 +284,11 @@ impl<DP: DependencyProvider> State<DP> {
                 deps_lookup.push(id);
             }
         }
-        for (pkg, term) in self.incompatibility_store[id].iter() {
+        for (&pkg, term) in self.incompatibility_store[id].iter() {
             if cfg!(debug_assertions) {
                 assert_ne!(term, &crate::term::Term::any());
             }
-            self.incompatibilities
-                .entry(pkg.clone())
-                .or_default()
-                .push(id);
+            self.incompatibilities.entry(pkg).or_default().push(id);
         }
     }
 
@@ -320,6 +323,7 @@ impl<DP: DependencyProvider> State<DP> {
                 id,
                 &shared_ids,
                 &self.incompatibility_store,
+                &self.package_store,
                 &precomputed,
             );
             precomputed.insert(id, Arc::new(tree));

--- a/src/internal/incompatibility.rs
+++ b/src/internal/incompatibility.rs
@@ -3,13 +3,13 @@
 //! An incompatibility is a set of terms for different packages
 //! that should never be satisfied all together.
 
-use std::fmt::{self, Debug, Display};
+use std::fmt::{Debug, Display};
 use std::sync::Arc;
 
-use crate::internal::{Arena, Id, SmallMap};
+use crate::internal::{Arena, HashArena, Id, SmallMap};
 use crate::{
-    term, DefaultStringReportFormatter, DependencyProvider, DerivationTree, Derived, External, Map,
-    Package, ReportFormatter, Set, Term, VersionSet,
+    term, DependencyProvider, DerivationTree, Derived, External, Map, Package, Set, Term,
+    VersionSet,
 };
 
 /// An incompatibility is a set of terms for different packages
@@ -29,7 +29,7 @@ use crate::{
 /// [PubGrub documentation](https://github.com/dart-lang/pub/blob/master/doc/solver.md#incompatibility).
 #[derive(Debug, Clone)]
 pub(crate) struct Incompatibility<P: Package, VS: VersionSet, M: Eq + Clone + Debug + Display> {
-    package_terms: SmallMap<P, Term<VS>>,
+    package_terms: SmallMap<Id<P>, Term<VS>>,
     kind: Kind<P, VS, M>,
 }
 
@@ -48,12 +48,12 @@ enum Kind<P: Package, VS: VersionSet, M: Eq + Clone + Debug + Display> {
     ///
     /// This incompatibility drives the resolution, it requires that we pick the (virtual) root
     /// packages.
-    NotRoot(P, VS::V),
+    NotRoot(Id<P>, VS::V),
     /// There are no versions in the given range for this package.
     ///
     /// This incompatibility is used when we tried all versions in a range and no version
     /// worked, so we have to backtrack
-    NoVersions(P, VS),
+    NoVersions(Id<P>, VS),
     /// Incompatibility coming from the dependencies of a given package.
     ///
     /// If a@1 depends on b>=1,<2, we create an incompatibility with terms `{a 1, b <1,>=2}` with
@@ -61,7 +61,7 @@ enum Kind<P: Package, VS: VersionSet, M: Eq + Clone + Debug + Display> {
     ///
     /// We can merge multiple dependents with the same version. For example, if a@1 depends on b and
     /// a@2 depends on b, we can say instead a@1||2 depends on b.
-    FromDependencyOf(P, VS, P, VS),
+    FromDependencyOf(Id<P>, VS, Id<P>, VS),
     /// Derived from two causes. Stores cause ids.
     ///
     /// For example, if a -> b and b -> c, we can derive a -> c.
@@ -71,7 +71,7 @@ enum Kind<P: Package, VS: VersionSet, M: Eq + Clone + Debug + Display> {
     /// Examples:
     /// * The version would require building the package, but builds are disabled.
     /// * The package is not available in the cache, but internet access has been disabled.
-    Custom(P, VS, M),
+    Custom(Id<P>, VS, M),
 }
 
 /// A Relation describes how a set of terms can be compared to an incompatibility.
@@ -83,20 +83,20 @@ pub(crate) enum Relation<P: Package> {
     Satisfied,
     /// We say that S contradicts I
     /// if S contradicts at least one term in I.
-    Contradicted(P),
+    Contradicted(Id<P>),
     /// If S satisfies all but one of I's terms and is inconclusive for the remaining term,
     /// we say S "almost satisfies" I and we call the remaining term the "unsatisfied term".
-    AlmostSatisfied(P),
+    AlmostSatisfied(Id<P>),
     /// Otherwise, we say that their relation is inconclusive.
     Inconclusive,
 }
 
 impl<P: Package, VS: VersionSet, M: Eq + Clone + Debug + Display> Incompatibility<P, VS, M> {
     /// Create the initial "not Root" incompatibility.
-    pub(crate) fn not_root(package: P, version: VS::V) -> Self {
+    pub(crate) fn not_root(package: Id<P>, version: VS::V) -> Self {
         Self {
             package_terms: SmallMap::One([(
-                package.clone(),
+                package,
                 Term::Negative(VS::singleton(version.clone())),
             )]),
             kind: Kind::NotRoot(package, version),
@@ -104,59 +104,59 @@ impl<P: Package, VS: VersionSet, M: Eq + Clone + Debug + Display> Incompatibilit
     }
 
     /// Create an incompatibility to remember that a given set does not contain any version.
-    pub(crate) fn no_versions(package: P, term: Term<VS>) -> Self {
+    pub(crate) fn no_versions(package: Id<P>, term: Term<VS>) -> Self {
         let set = match &term {
             Term::Positive(r) => r.clone(),
             Term::Negative(_) => panic!("No version should have a positive term"),
         };
         Self {
-            package_terms: SmallMap::One([(package.clone(), term)]),
+            package_terms: SmallMap::One([(package, term)]),
             kind: Kind::NoVersions(package, set),
         }
     }
 
     /// Create an incompatibility for a reason outside pubgrub.
     #[allow(dead_code)] // Used by uv
-    pub(crate) fn custom_term(package: P, term: Term<VS>, metadata: M) -> Self {
+    pub(crate) fn custom_term(package: Id<P>, term: Term<VS>, metadata: M) -> Self {
         let set = match &term {
             Term::Positive(r) => r.clone(),
             Term::Negative(_) => panic!("No version should have a positive term"),
         };
         Self {
-            package_terms: SmallMap::One([(package.clone(), term)]),
+            package_terms: SmallMap::One([(package, term)]),
             kind: Kind::Custom(package, set, metadata),
         }
     }
 
     /// Create an incompatibility for a reason outside pubgrub.
-    pub(crate) fn custom_version(package: P, version: VS::V, metadata: M) -> Self {
+    pub(crate) fn custom_version(package: Id<P>, version: VS::V, metadata: M) -> Self {
         let set = VS::singleton(version);
         let term = Term::Positive(set.clone());
         Self {
-            package_terms: SmallMap::One([(package.clone(), term)]),
+            package_terms: SmallMap::One([(package, term)]),
             kind: Kind::Custom(package, set, metadata),
         }
     }
 
     /// Build an incompatibility from a given dependency.
-    pub(crate) fn from_dependency(package: P, versions: VS, dep: (P, VS)) -> Self {
+    pub(crate) fn from_dependency(package: Id<P>, versions: VS, dep: (Id<P>, VS)) -> Self {
         let (p2, set2) = dep;
         Self {
             package_terms: if set2 == VS::empty() {
-                SmallMap::One([(package.clone(), Term::Positive(versions.clone()))])
+                SmallMap::One([(package, Term::Positive(versions.clone()))])
             } else {
                 SmallMap::Two([
-                    (package.clone(), Term::Positive(versions.clone())),
-                    (p2.clone(), Term::Negative(set2.clone())),
+                    (package, Term::Positive(versions.clone())),
+                    (p2, Term::Negative(set2.clone())),
                 ])
             },
             kind: Kind::FromDependencyOf(package, versions, p2, set2),
         }
     }
 
-    pub(crate) fn as_dependency(&self) -> Option<(&P, &P)> {
+    pub(crate) fn as_dependency(&self) -> Option<(Id<P>, Id<P>)> {
         match &self.kind {
-            Kind::FromDependencyOf(p1, _, p2, _) => Some((p1, p2)),
+            Kind::FromDependencyOf(p1, _, p2, _) => Some((*p1, *p2)),
             _ => None,
         }
     }
@@ -186,40 +186,40 @@ impl<P: Package, VS: VersionSet, M: Eq + Clone + Debug + Display> Incompatibilit
         if dep_term != other.get(p2) {
             return None;
         }
-        return Some(Self::from_dependency(
-            p1.clone(),
+        Some(Self::from_dependency(
+            p1,
             self.get(p1)
                 .unwrap()
                 .unwrap_positive()
                 .union(other.get(p1).unwrap().unwrap_positive()), // It is safe to `simplify` here
             (
-                p2.clone(),
+                p2,
                 dep_term.map_or(VS::empty(), |v| v.unwrap_negative().clone()),
             ),
-        ));
+        ))
     }
 
     /// Prior cause of two incompatibilities using the rule of resolution.
     pub(crate) fn prior_cause(
         incompat: Id<Self>,
         satisfier_cause: Id<Self>,
-        package: &P,
+        package: Id<P>,
         incompatibility_store: &Arena<Self>,
     ) -> Self {
         let kind = Kind::DerivedFrom(incompat, satisfier_cause);
         // Optimization to avoid cloning and dropping t1
         let (t1, mut package_terms) = incompatibility_store[incompat]
             .package_terms
-            .split_one(package)
+            .split_one(&package)
             .unwrap();
         let satisfier_cause_terms = &incompatibility_store[satisfier_cause].package_terms;
         package_terms.merge(
-            satisfier_cause_terms.iter().filter(|(p, _)| p != &package),
+            satisfier_cause_terms.iter().filter(|(p, _)| p != &&package),
             |t1, t2| Some(t1.intersection(t2)),
         );
-        let term = t1.union(satisfier_cause_terms.get(package).unwrap());
+        let term = t1.union(satisfier_cause_terms.get(&package).unwrap());
         if term != Term::any() {
-            package_terms.insert(package.clone(), term);
+            package_terms.insert(package, term);
         }
         Self {
             package_terms,
@@ -229,24 +229,24 @@ impl<P: Package, VS: VersionSet, M: Eq + Clone + Debug + Display> Incompatibilit
 
     /// Check if an incompatibility should mark the end of the algorithm
     /// because it satisfies the root package.
-    pub(crate) fn is_terminal(&self, root_package: &P, root_version: &VS::V) -> bool {
+    pub(crate) fn is_terminal(&self, root_package: Id<P>, root_version: &VS::V) -> bool {
         if self.package_terms.len() == 0 {
             true
         } else if self.package_terms.len() > 1 {
             false
         } else {
             let (package, term) = self.package_terms.iter().next().unwrap();
-            (package == root_package) && term.contains(root_version)
+            (package == &root_package) && term.contains(root_version)
         }
     }
 
     /// Get the term related to a given package (if it exists).
-    pub(crate) fn get(&self, package: &P) -> Option<&Term<VS>> {
-        self.package_terms.get(package)
+    pub(crate) fn get(&self, package: Id<P>) -> Option<&Term<VS>> {
+        self.package_terms.get(&package)
     }
 
     /// Iterate over packages.
-    pub(crate) fn iter(&self) -> impl Iterator<Item = (&P, &Term<VS>)> {
+    pub(crate) fn iter(&self) -> impl Iterator<Item = (&Id<P>, &Term<VS>)> {
         self.package_terms.iter()
     }
 
@@ -265,12 +265,17 @@ impl<P: Package, VS: VersionSet, M: Eq + Clone + Debug + Display> Incompatibilit
         self_id: Id<Self>,
         shared_ids: &Set<Id<Self>>,
         store: &Arena<Self>,
+        package_store: &HashArena<P>,
         precomputed: &Map<Id<Self>, Arc<DerivationTree<P, VS, M>>>,
     ) -> DerivationTree<P, VS, M> {
         match store[self_id].kind.clone() {
             Kind::DerivedFrom(id1, id2) => {
-                let derived = Derived {
-                    terms: store[self_id].package_terms.as_map(),
+                let derived: Derived<P, VS, M> = Derived {
+                    terms: store[self_id]
+                        .package_terms
+                        .iter()
+                        .map(|(&a, b)| (package_store[a].clone(), b.clone()))
+                        .collect(),
                     shared_id: shared_ids.get(&self_id).map(|id| id.into_raw()),
                     cause1: precomputed
                         .get(&id1)
@@ -284,21 +289,22 @@ impl<P: Package, VS: VersionSet, M: Eq + Clone + Debug + Display> Incompatibilit
                 DerivationTree::Derived(derived)
             }
             Kind::NotRoot(package, version) => {
-                DerivationTree::External(External::NotRoot(package, version))
+                DerivationTree::External(External::NotRoot(package_store[package].clone(), version))
             }
-            Kind::NoVersions(package, set) => {
-                DerivationTree::External(External::NoVersions(package.clone(), set.clone()))
-            }
+            Kind::NoVersions(package, set) => DerivationTree::External(External::NoVersions(
+                package_store[package].clone(),
+                set.clone(),
+            )),
             Kind::FromDependencyOf(package, set, dep_package, dep_set) => {
                 DerivationTree::External(External::FromDependencyOf(
-                    package.clone(),
+                    package_store[package].clone(),
                     set.clone(),
-                    dep_package.clone(),
+                    package_store[dep_package].clone(),
                     dep_set.clone(),
                 ))
             }
             Kind::Custom(package, set, metadata) => DerivationTree::External(External::Custom(
-                package.clone(),
+                package_store[package].clone(),
                 set.clone(),
                 metadata.clone(),
             )),
@@ -310,13 +316,13 @@ impl<'a, P: Package, VS: VersionSet + 'a, M: Eq + Clone + Debug + Display + 'a>
     Incompatibility<P, VS, M>
 {
     /// CF definition of Relation enum.
-    pub(crate) fn relation(&self, terms: impl Fn(&P) -> Option<&'a Term<VS>>) -> Relation<P> {
+    pub(crate) fn relation(&self, terms: impl Fn(Id<P>) -> Option<&'a Term<VS>>) -> Relation<P> {
         let mut relation = Relation::Satisfied;
-        for (package, incompat_term) in self.package_terms.iter() {
+        for (&package, incompat_term) in self.package_terms.iter() {
             match terms(package).map(|term| incompat_term.relation_with(term)) {
                 Some(term::Relation::Satisfied) => {}
                 Some(term::Relation::Contradicted) => {
-                    return Relation::Contradicted(package.clone());
+                    return Relation::Contradicted(package);
                 }
                 None | Some(term::Relation::Inconclusive) => {
                     // If a package is not present, the intersection is the same as [Term::any].
@@ -325,7 +331,7 @@ impl<'a, P: Package, VS: VersionSet + 'a, M: Eq + Clone + Debug + Display + 'a>
                     // but we systematically remove those from incompatibilities
                     // so we're safe on that front.
                     if relation == Relation::Satisfied {
-                        relation = Relation::AlmostSatisfied(package.clone());
+                        relation = Relation::AlmostSatisfied(package);
                     } else {
                         return Relation::Inconclusive;
                     }
@@ -336,18 +342,35 @@ impl<'a, P: Package, VS: VersionSet + 'a, M: Eq + Clone + Debug + Display + 'a>
     }
 }
 
-impl<P: Package, VS: VersionSet, M: Eq + Clone + Debug + Display> Display
-    for Incompatibility<P, VS, M>
-{
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "{}",
-            ReportFormatter::<P, VS, M>::format_terms(
-                &DefaultStringReportFormatter,
-                &self.package_terms.as_map()
-            )
-        )
+impl<P: Package, VS: VersionSet, M: Eq + Clone + Debug + Display> Incompatibility<P, VS, M> {
+    pub fn display<'a>(&'a self, package_store: &'a HashArena<P>) -> impl Display + 'a {
+        match self.iter().collect::<Vec<_>>().as_slice() {
+            [] => "version solving failed".into(),
+            // TODO: special case when that unique package is root.
+            [(package, Term::Positive(range))] => {
+                format!("{} {} is forbidden", package_store[**package], range)
+            }
+            [(package, Term::Negative(range))] => {
+                format!("{} {} is mandatory", package_store[**package], range)
+            }
+            [(p_pos, Term::Positive(r_pos)), (p_neg, Term::Negative(r_neg))]
+            | [(p_neg, Term::Negative(r_neg)), (p_pos, Term::Positive(r_pos))] => {
+                External::<_, _, M>::FromDependencyOf(
+                    &package_store[**p_pos],
+                    r_pos.clone(),
+                    &package_store[**p_neg],
+                    r_neg.clone(),
+                )
+                .to_string()
+            }
+            slice => {
+                let str_terms: Vec<_> = slice
+                    .iter()
+                    .map(|(p, t)| format!("{} {}", package_store[**p], t))
+                    .collect();
+                str_terms.join(", ") + " are incompatible"
+            }
+        }
     }
 }
 
@@ -373,22 +396,26 @@ pub(crate) mod tests {
         #[test]
         fn rule_of_resolution(t1 in term_strat(), t2 in term_strat(), t3 in term_strat()) {
             let mut store = Arena::new();
+            let mut package_store = HashArena::new();
+            let p1 = package_store.alloc("p1");
+            let p2 = package_store.alloc("p2");
+            let p3 = package_store.alloc("p3");
             let i1 = store.alloc(Incompatibility {
-                package_terms: SmallMap::Two([("p1", t1.clone()), ("p2", t2.negate())]),
-                kind: Kind::<_, _, String>::FromDependencyOf("p1", Ranges::full(), "p2", Ranges::full())
+                package_terms: SmallMap::Two([(p1, t1.clone()), (p2, t2.negate())]),
+                kind: Kind::<_, _, String>::FromDependencyOf(p1, Ranges::full(), p2, Ranges::full())
             });
 
             let i2 = store.alloc(Incompatibility {
-                package_terms: SmallMap::Two([("p2", t2), ("p3", t3.clone())]),
-                kind: Kind::<_, _, String>::FromDependencyOf("p2", Ranges::full(), "p3", Ranges::full())
+                package_terms: SmallMap::Two([(p2, t2), (p3, t3.clone())]),
+                kind: Kind::<_, _, String>::FromDependencyOf(p2, Ranges::full(), p3, Ranges::full())
             });
 
             let mut i3 = Map::default();
-            i3.insert("p1", t1);
-            i3.insert("p3", t3);
+            i3.insert(p1, t1);
+            i3.insert(p3, t3);
 
-            let i_resolution = Incompatibility::prior_cause(i1, i2, &"p2", &store);
-            assert_eq!(i_resolution.package_terms.as_map(), i3);
+            let i_resolution = Incompatibility::prior_cause(i1, i2, p2, &store);
+            assert_eq!(i_resolution.package_terms.iter().map(|(&k, v)|(k, v.clone())).collect::<Map<_, _>>(), i3);
         }
 
     }

--- a/src/internal/mod.rs
+++ b/src/internal/mod.rs
@@ -9,7 +9,7 @@ mod partial_solution;
 mod small_map;
 mod small_vec;
 
-pub(crate) use arena::{Arena, Id};
+pub(crate) use arena::{Arena, HashArena, Id};
 pub(crate) use core::State;
 pub(crate) use incompatibility::{IncompDpId, IncompId, Incompatibility, Relation};
 pub(crate) use partial_solution::{DecisionLevel, PartialSolution, SatisfierSearch};

--- a/src/internal/small_map.rs
+++ b/src/internal/small_map.rs
@@ -190,27 +190,6 @@ impl<K, V> SmallMap<K, V> {
     }
 }
 
-impl<K: Eq + Hash + Clone, V: Clone> SmallMap<K, V> {
-    pub(crate) fn as_map(&self) -> Map<K, V> {
-        match self {
-            Self::Empty => Map::default(),
-            Self::One([(k, v)]) => {
-                let mut map = Map::with_capacity_and_hasher(1, Default::default());
-                map.insert(k.clone(), v.clone());
-                map
-            }
-            Self::Two(data) => {
-                let mut map = Map::with_capacity_and_hasher(2, Default::default());
-                for (k, v) in data {
-                    map.insert(k.clone(), v.clone());
-                }
-                map
-            }
-            Self::Flexible(data) => data.clone(),
-        }
-    }
-}
-
 enum IterSmallMap<'a, K, V> {
     Inline(std::slice::Iter<'a, (K, V)>),
     Map(std::collections::hash_map::Iter<'a, K, V>),

--- a/src/solver.rs
+++ b/src/solver.rs
@@ -65,7 +65,7 @@ use std::fmt::{Debug, Display};
 
 use log::{debug, info};
 
-use crate::internal::{Incompatibility, State};
+use crate::internal::{Id, Incompatibility, State};
 use crate::{DependencyConstraints, Map, Package, PubGrubError, SelectedDependencies, VersionSet};
 
 /// Main function of the library.
@@ -76,44 +76,59 @@ pub fn resolve<DP: DependencyProvider>(
     version: impl Into<DP::V>,
 ) -> Result<SelectedDependencies<DP>, PubGrubError<DP>> {
     let mut state: State<DP> = State::init(package.clone(), version.into());
-    let mut added_dependencies: Map<DP::P, Set<DP::V>> = Map::default();
-    let mut next = package;
+    let mut added_dependencies: Map<Id<DP::P>, Set<DP::V>> = Map::default();
+    let mut next = state.root_package;
     loop {
         dependency_provider
             .should_cancel()
-            .map_err(PubGrubError::ErrorInShouldCancel)?;
+            .map_err(|err| PubGrubError::ErrorInShouldCancel(err))?;
 
-        info!("unit_propagation: {}", &next);
+        info!(
+            "unit_propagation: {:?} = '{}'",
+            &next, state.package_store[next]
+        );
         state.unit_propagation(next)?;
 
         debug!(
             "Partial solution after unit propagation: {}",
-            state.partial_solution
+            state.partial_solution.display(&state.package_store)
         );
 
-        let Some(highest_priority_pkg) = state
-            .partial_solution
-            .pick_highest_priority_pkg(|p, r| dependency_provider.prioritize(p, r))
+        let Some(highest_priority_pkg) =
+            state.partial_solution.pick_highest_priority_pkg(|p, r| {
+                dependency_provider.prioritize(&state.package_store[p], r)
+            })
         else {
-            return Ok(state.partial_solution.extract_solution());
+            return Ok(state
+                .partial_solution
+                .extract_solution()
+                .map(|(p, v)| (state.package_store[p].clone(), v))
+                .collect());
         };
         next = highest_priority_pkg;
 
         let term_intersection = state
             .partial_solution
-            .term_intersection_for_package(&next)
+            .term_intersection_for_package(next)
             .ok_or_else(|| {
                 PubGrubError::Failure("a package was chosen but we don't have a term.".into())
             })?;
         let decision = dependency_provider
-            .choose_version(&next, term_intersection.unwrap_positive())
+            .choose_version(
+                &state.package_store[next],
+                term_intersection.unwrap_positive(),
+            )
             .map_err(PubGrubError::ErrorChoosingPackageVersion)?;
-        info!("DP chose: {} @ {:?}", next, decision);
+
+        info!(
+            "DP chose: {:?} = '{}' @ {:?}",
+            &next, state.package_store[next], decision
+        );
 
         // Pick the next compatible version.
         let v = match decision {
             None => {
-                let inc = Incompatibility::no_versions(next.clone(), term_intersection.clone());
+                let inc = Incompatibility::no_versions(next, term_intersection.clone());
                 state.add_incompatibility(inc);
                 continue;
             }
@@ -127,25 +142,25 @@ pub fn resolve<DP: DependencyProvider>(
         }
 
         let is_new_dependency = added_dependencies
-            .entry(next.clone())
+            .entry(next)
             .or_default()
             .insert(v.clone());
 
         if is_new_dependency {
             // Retrieve that package dependencies.
-            let p = &next;
-            let dependencies = dependency_provider.get_dependencies(p, &v).map_err(|err| {
-                PubGrubError::ErrorRetrievingDependencies {
-                    package: p.clone(),
+            let p = next;
+            let dependencies = dependency_provider
+                .get_dependencies(&state.package_store[p], &v)
+                .map_err(|err| PubGrubError::ErrorRetrievingDependencies {
+                    package: state.package_store[p].clone(),
                     version: v.clone(),
                     source: err,
-                }
-            })?;
+                })?;
 
             let dependencies = match dependencies {
                 Dependencies::Unavailable(reason) => {
                     state.add_incompatibility(Incompatibility::custom_version(
-                        p.clone(),
+                        p,
                         v.clone(),
                         reason,
                     ));
@@ -156,19 +171,19 @@ pub fn resolve<DP: DependencyProvider>(
 
             // Add that package and version if the dependencies are not problematic.
             let dep_incompats =
-                state.add_incompatibility_from_dependencies(p.clone(), v.clone(), dependencies);
+                state.add_incompatibility_from_dependencies(p, v.clone(), dependencies);
 
-            state.partial_solution.add_version(
-                p.clone(),
-                v.clone(),
-                dep_incompats,
-                &state.incompatibility_store,
-            );
+            state
+                .partial_solution
+                .add_version(p, v, dep_incompats, &state.incompatibility_store);
         } else {
             // `dep_incompats` are already in `incompatibilities` so we know there are not satisfied
             // terms and can add the decision directly.
-            info!("add_decision (not first time): {} @ {}", &next, v);
-            state.partial_solution.add_decision(next.clone(), v);
+            info!(
+                "add_decision (not first time): {:?} = '{}' @ {}",
+                &next, state.package_store[next], v
+            );
+            state.partial_solution.add_decision(next, v);
         }
     }
 }


### PR DESCRIPTION
We have long known that resolution time is proportional to `P::Clone`. Most real-world resolution problems contain at least one `String` in there `P`. If performance is anywhere on the priority list then `P::Clone` should not allocate. Thanks to our library being generic this is easy for users to achieve and control. `P` can be a wrapper around `Rc<P>` and it does not allocate, or using various interning strategies use `&str` for even faster clone, or by using hashconsing (or any de-duplicating interning strategy) `P` can be a wrapper around `usize`. So for our benchmarks we used `P=u32` because it was the simplest type that met our trait pounds OR `P=&str` because it was similar to what was easily available to a user. Now that we have production users, we see that there `P` tends to have a more expensive clone. (`Rc` for the cargo benchmarks, `Arc` for the uv use case, `String` for gleam and elm.)

It also turns out that resolution time is proportional to `P::Hash`. As `P` ends up being the key in a large number of hash tables. The hottest of these tables tends to be `PartialSolution::package_assignments`. Only the hashconsing (or its relatives) strategy allows a user to provide very fast `P::Hash` where `P` has a string in it. None of our production users are using this approach. So the performance of our internal benchmarks that use `&str` are far more realistic than the ones that use `u32`.

Luckily we can provide a hashconsing like wrapper around `P` for our users. We already have an arena such that if two IDs are equal then the data they point at must be equal, we just need to make the inverse true that if the data is equal then any IDs for that data will be equal. This arena instead of allocating by just pushing new items to a `Vec` (and returning the new index) would return a previous ID if the value had already been added and do the normal thing otherwise. This does not involve a lot of code by using the indexmap crate, which is already one of our dependencies.

This is a pessimization four benchmarks that use `u32`, or for any (theoretical) users who are already using hashconsing. Unfortunately rust does not have specialization, and even if it did there is no trait bound for "`Hash` is cheap". Based on the (hilariously out of date named) `large_case_u16_NumberVersion` this is a ~9.5% regression, similarly ~10.5% for the synthetic `slow_135_0_u16_NumberVersion`. A sudoku problem, which is not synthetic but also not the intended use case, sees a similar regression.

Real-world benchmarks see significant improvements. `elm_str_SemanticVersion` 10.2%, `zuse_str_SemanticVersion` 19.9%, [all of crates.io](https://rust-lang.zulipchat.com/#narrow/stream/260232-t-cargo.2FPubGrub/topic/Progress.20report/near/453185146) 14% without lock files and 11% with.

I'd love to hear the impact on `uv` benchmarks, but I expect them to be in a similar range. Perhaps infinitesimally bigger because they are already collecting this data for their implementation of prioritize which can now just be `Id<P>::as_raw()`.

There is potential follow-up work because `Map<Id<P` (especially when densely filled) can be replaced with a `Vec` decreasing the size and removing the calculation of `Hash` for `Id`. But it's a lot of code for a much smaller when so I left it out for now.

Unfortunately bunch of log and panic messages now refer to `Id(1)` instead of the name of that package. Similarly they use Debug instead of display. This is hard to fix because the relevant `impls` do not have access to the arena in which the actual package name is stored.