### PR TITLE
 Cleanup internal imports 

### DIFF
--- a/benches/large_case.rs
+++ b/benches/large_case.rs
@@ -1,15 +1,10 @@
 // SPDX-License-Identifier: MPL-2.0
 use std::time::Duration;
 
-extern crate criterion;
-use self::criterion::*;
-
-use pubgrub::package::Package;
-use pubgrub::range::Range;
-use pubgrub::solver::{resolve, OfflineDependencyProvider};
-use pubgrub::version::SemanticVersion;
-use pubgrub::version_set::VersionSet;
+use criterion::*;
 use serde::de::Deserialize;
+
+use pubgrub::{resolve, OfflineDependencyProvider, Package, Range, SemanticVersion, VersionSet};
 
 fn bench<'a, P: Package + Deserialize<'a>, VS: VersionSet + Deserialize<'a>>(
     b: &mut Bencher,

--- a/examples/unsat_root_message_no_version.rs
+++ b/examples/unsat_root_message_no_version.rs
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use pubgrub::{
-    resolve, Derived, OfflineDependencyProvider, PubGrubError, Range, Reporter, SemanticVersion,
-};
-
-use pubgrub::{DefaultStringReporter, External, Map, ReportFormatter, Term};
 use std::fmt::{self, Display};
+
+use pubgrub::{
+    resolve, DefaultStringReporter, Derived, External, Map, OfflineDependencyProvider,
+    PubGrubError, Range, ReportFormatter, Reporter, SemanticVersion, Term,
+};
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub enum Package {

--- a/src/error.rs
+++ b/src/error.rs
@@ -4,8 +4,7 @@
 
 use thiserror::Error;
 
-use crate::report::DerivationTree;
-use crate::solver::DependencyProvider;
+use crate::{DependencyProvider, DerivationTree};
 
 /// There is no solution for this set of dependencies.
 pub type NoSolutionError<DP> = DerivationTree<

--- a/src/error.rs
+++ b/src/error.rs
@@ -20,10 +20,8 @@ pub enum PubGrubError<DP: DependencyProvider> {
     #[error("No solution")]
     NoSolution(NoSolutionError<DP>),
 
-    /// Error arising when the implementer of
-    /// [DependencyProvider]
-    /// returned an error in the method
-    /// [get_dependencies](crate::solver::DependencyProvider::get_dependencies).
+    /// Error arising when the implementer of [DependencyProvider] returned an error in the method
+    /// [get_dependencies](vecDependencyProvider::get_dependencies).
     #[error("Retrieving dependencies of {package} {version} failed")]
     ErrorRetrievingDependencies {
         /// Package whose dependencies we want.
@@ -48,15 +46,13 @@ pub enum PubGrubError<DP: DependencyProvider> {
         version: DP::V,
     },
 
-    /// Error arising when the implementer of
-    /// [DependencyProvider]
-    /// returned an error in the method
-    /// [choose_version](crate::solver::DependencyProvider::choose_version).
+    /// Error arising when the implementer of [DependencyProvider] returned an error in the method
+    /// [choose_version](DependencyProvider::choose_version).
     #[error("Decision making failed")]
     ErrorChoosingPackageVersion(#[source] DP::Err),
 
     /// Error arising when the implementer of [DependencyProvider]
-    /// returned an error in the method [should_cancel](crate::solver::DependencyProvider::should_cancel).
+    /// returned an error in the method [should_cancel](DependencyProvider::should_cancel).
     #[error("We should cancel")]
     ErrorInShouldCancel(#[source] DP::Err),
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -21,7 +21,7 @@ pub enum PubGrubError<DP: DependencyProvider> {
     NoSolution(NoSolutionError<DP>),
 
     /// Error arising when the implementer of [DependencyProvider] returned an error in the method
-    /// [get_dependencies](vecDependencyProvider::get_dependencies).
+    /// [get_dependencies](DependencyProvider::get_dependencies).
     #[error("Retrieving dependencies of {package} {version} failed")]
     ErrorRetrievingDependencies {
         /// Package whose dependencies we want.

--- a/src/internal/arena.rs
+++ b/src/internal/arena.rs
@@ -10,7 +10,7 @@ use std::ops::{Index, Range};
 /// that we actually don't need since it is phantom.
 ///
 /// <https://github.com/rust-lang/rust/issues/26925>
-pub struct Id<T> {
+pub(crate) struct Id<T> {
     raw: u32,
     _ty: PhantomData<fn() -> T>,
 }
@@ -48,7 +48,7 @@ impl<T> fmt::Debug for Id<T> {
 }
 
 impl<T> Id<T> {
-    pub fn into_raw(self) -> usize {
+    pub(crate) fn into_raw(self) -> usize {
         self.raw as usize
     }
     fn from(n: u32) -> Self {
@@ -57,7 +57,7 @@ impl<T> Id<T> {
             _ty: PhantomData,
         }
     }
-    pub fn range_to_iter(range: Range<Self>) -> impl Iterator<Item = Self> {
+    pub(crate) fn range_to_iter(range: Range<Self>) -> impl Iterator<Item = Self> {
         let start = range.start.raw;
         let end = range.end.raw;
         (start..end).map(Self::from)
@@ -71,7 +71,7 @@ impl<T> Id<T> {
 /// to have references between those items.
 /// They are all dropped at once when the arena is dropped.
 #[derive(Clone, PartialEq, Eq)]
-pub struct Arena<T> {
+pub(crate) struct Arena<T> {
     data: Vec<T>,
 }
 
@@ -91,17 +91,17 @@ impl<T> Default for Arena<T> {
 }
 
 impl<T> Arena<T> {
-    pub fn new() -> Self {
+    pub(crate) fn new() -> Self {
         Self { data: Vec::new() }
     }
 
-    pub fn alloc(&mut self, value: T) -> Id<T> {
+    pub(crate) fn alloc(&mut self, value: T) -> Id<T> {
         let raw = self.data.len();
         self.data.push(value);
         Id::from(raw as u32)
     }
 
-    pub fn alloc_iter<I: Iterator<Item = T>>(&mut self, values: I) -> Range<Id<T>> {
+    pub(crate) fn alloc_iter<I: Iterator<Item = T>>(&mut self, values: I) -> Range<Id<T>> {
         let start = Id::from(self.data.len() as u32);
         values.for_each(|v| {
             self.alloc(v);

--- a/src/internal/core.rs
+++ b/src/internal/core.rs
@@ -241,10 +241,10 @@ impl<DP: DependencyProvider> State<DP> {
 
     /// Add this incompatibility into the set of all incompatibilities.
     ///
-    /// pub(crate)collapses identical dependencies from adjacent package versions
+    /// PubGrub collapses identical dependencies from adjacent package versions
     /// into individual incompatibilities.
     /// This substantially reduces the total number of incompatibilities
-    /// and makes it much easier for pub(crate)to reason about multiple versions of packages at once.
+    /// and makes it much easier for PubGrub to reason about multiple versions of packages at once.
     ///
     /// For example, rather than representing
     /// foo 1.0.0 depends on bar ^1.0.0 and

--- a/src/internal/core.rs
+++ b/src/internal/core.rs
@@ -6,10 +6,11 @@
 use std::collections::HashSet as Set;
 use std::sync::Arc;
 
-use crate::internal::{
-    Arena, DecisionLevel, IncompDpId, Incompatibility, PartialSolution, Relation, SatisfierSearch,
-    SmallVec,
-};
+use crate::internal::arena::Arena;
+use crate::internal::incompatibility::{Incompatibility, Relation};
+use crate::internal::partial_solution::{DecisionLevel, PartialSolution};
+use crate::internal::small_vec::SmallVec;
+use crate::internal::{IncompDpId, SatisfierSearch};
 use crate::{DependencyProvider, DerivationTree, Map, NoSolutionError, VersionSet};
 
 /// Current state of the PubGrub algorithm.

--- a/src/internal/core.rs
+++ b/src/internal/core.rs
@@ -6,11 +6,10 @@
 use std::collections::HashSet as Set;
 use std::sync::Arc;
 
-use crate::internal::arena::Arena;
-use crate::internal::incompatibility::{Incompatibility, Relation};
-use crate::internal::partial_solution::{DecisionLevel, PartialSolution};
-use crate::internal::small_vec::SmallVec;
-use crate::internal::{IncompDpId, SatisfierSearch};
+use crate::internal::{
+    Arena, DecisionLevel, IncompDpId, Incompatibility, PartialSolution, Relation, SatisfierSearch,
+    SmallVec,
+};
 use crate::{DependencyProvider, DerivationTree, Map, NoSolutionError, VersionSet};
 
 /// Current state of the PubGrub algorithm.

--- a/src/internal/core.rs
+++ b/src/internal/core.rs
@@ -6,22 +6,15 @@
 use std::collections::HashSet as Set;
 use std::sync::Arc;
 
-use crate::error::NoSolutionError;
-use crate::internal::arena::Arena;
-use crate::internal::incompatibility::{Incompatibility, Relation};
-use crate::internal::partial_solution::SatisfierSearch::{
-    DifferentDecisionLevels, SameDecisionLevels,
+use crate::internal::{
+    Arena, DecisionLevel, IncompDpId, Incompatibility, PartialSolution, Relation, SatisfierSearch,
+    SmallVec,
 };
-use crate::internal::partial_solution::{DecisionLevel, PartialSolution};
-use crate::internal::small_vec::SmallVec;
-use crate::report::DerivationTree;
-use crate::solver::DependencyProvider;
-use crate::type_aliases::{IncompDpId, Map};
-use crate::version_set::VersionSet;
+use crate::{DependencyProvider, DerivationTree, Map, NoSolutionError, VersionSet};
 
 /// Current state of the PubGrub algorithm.
 #[derive(Clone)]
-pub struct State<DP: DependencyProvider> {
+pub(crate) struct State<DP: DependencyProvider> {
     root_package: DP::P,
     root_version: DP::V,
 
@@ -40,10 +33,10 @@ pub struct State<DP: DependencyProvider> {
 
     /// Partial solution.
     /// TODO: remove pub.
-    pub partial_solution: PartialSolution<DP>,
+    pub(crate) partial_solution: PartialSolution<DP>,
 
     /// The store is the reference storage for all incompatibilities.
-    pub incompatibility_store: Arena<Incompatibility<DP::P, DP::VS, DP::M>>,
+    pub(crate) incompatibility_store: Arena<Incompatibility<DP::P, DP::VS, DP::M>>,
 
     /// This is a stack of work to be done in `unit_propagation`.
     /// It can definitely be a local variable to that method, but
@@ -53,7 +46,7 @@ pub struct State<DP: DependencyProvider> {
 
 impl<DP: DependencyProvider> State<DP> {
     /// Initialization of PubGrub state.
-    pub fn init(root_package: DP::P, root_version: DP::V) -> Self {
+    pub(crate) fn init(root_package: DP::P, root_version: DP::V) -> Self {
         let mut incompatibility_store = Arena::new();
         let not_root_id = incompatibility_store.alloc(Incompatibility::not_root(
             root_package.clone(),
@@ -74,13 +67,13 @@ impl<DP: DependencyProvider> State<DP> {
     }
 
     /// Add an incompatibility to the state.
-    pub fn add_incompatibility(&mut self, incompat: Incompatibility<DP::P, DP::VS, DP::M>) {
+    pub(crate) fn add_incompatibility(&mut self, incompat: Incompatibility<DP::P, DP::VS, DP::M>) {
         let id = self.incompatibility_store.alloc(incompat);
         self.merge_incompatibility(id);
     }
 
     /// Add an incompatibility to the state.
-    pub fn add_incompatibility_from_dependencies(
+    pub(crate) fn add_incompatibility_from_dependencies(
         &mut self,
         package: DP::P,
         version: DP::V,
@@ -105,7 +98,7 @@ impl<DP: DependencyProvider> State<DP> {
 
     /// Unit propagation is the core mechanism of the solving algorithm.
     /// CF <https://github.com/dart-lang/pub/blob/master/doc/solver.md#unit-propagation>
-    pub fn unit_propagation(&mut self, package: DP::P) -> Result<(), NoSolutionError<DP>> {
+    pub(crate) fn unit_propagation(&mut self, package: DP::P) -> Result<(), NoSolutionError<DP>> {
         self.unit_propagation_buffer.clear();
         self.unit_propagation_buffer.push(package);
         while let Some(current_package) = self.unit_propagation_buffer.pop() {
@@ -202,7 +195,7 @@ impl<DP: DependencyProvider> State<DP> {
                     &self.incompatibility_store,
                 );
                 match satisfier_search_result {
-                    DifferentDecisionLevels {
+                    SatisfierSearch::DifferentDecisionLevels {
                         previous_satisfier_level,
                     } => {
                         let package = package.clone();
@@ -214,7 +207,7 @@ impl<DP: DependencyProvider> State<DP> {
                         log::info!("backtrack to {:?}", previous_satisfier_level);
                         return Ok((package, current_incompat_id));
                     }
-                    SameDecisionLevels { satisfier_cause } => {
+                    SatisfierSearch::SameDecisionLevels { satisfier_cause } => {
                         let prior_cause = Incompatibility::prior_cause(
                             current_incompat_id,
                             satisfier_cause,
@@ -248,10 +241,10 @@ impl<DP: DependencyProvider> State<DP> {
 
     /// Add this incompatibility into the set of all incompatibilities.
     ///
-    /// Pub collapses identical dependencies from adjacent package versions
+    /// pub(crate)collapses identical dependencies from adjacent package versions
     /// into individual incompatibilities.
     /// This substantially reduces the total number of incompatibilities
-    /// and makes it much easier for Pub to reason about multiple versions of packages at once.
+    /// and makes it much easier for pub(crate)to reason about multiple versions of packages at once.
     ///
     /// For example, rather than representing
     /// foo 1.0.0 depends on bar ^1.0.0 and

--- a/src/internal/incompatibility.rs
+++ b/src/internal/incompatibility.rs
@@ -6,7 +6,8 @@
 use std::fmt::{self, Debug, Display};
 use std::sync::Arc;
 
-use crate::internal::{Arena, Id, SmallMap};
+use crate::internal::arena::{Arena, Id};
+use crate::internal::small_map::SmallMap;
 use crate::{
     term, DefaultStringReportFormatter, DependencyProvider, DerivationTree, Derived, External, Map,
     Package, ReportFormatter, Set, Term, VersionSet,

--- a/src/internal/incompatibility.rs
+++ b/src/internal/incompatibility.rs
@@ -358,8 +358,8 @@ pub(crate) mod tests {
     use proptest::prelude::*;
 
     use super::*;
-    use crate::range::Range;
     use crate::term::tests::strategy as term_strat;
+    use crate::Range;
 
     proptest! {
 

--- a/src/internal/incompatibility.rs
+++ b/src/internal/incompatibility.rs
@@ -6,15 +6,11 @@
 use std::fmt::{self, Debug, Display};
 use std::sync::Arc;
 
-use crate::internal::arena::{Arena, Id};
-use crate::internal::small_map::SmallMap;
-use crate::package::Package;
-use crate::report::{
-    DefaultStringReportFormatter, DerivationTree, Derived, External, ReportFormatter,
+use crate::internal::{Arena, Id, SmallMap};
+use crate::{
+    term, DefaultStringReportFormatter, DependencyProvider, DerivationTree, Derived, External, Map,
+    Package, ReportFormatter, Set, Term, VersionSet,
 };
-use crate::term::{self, Term};
-use crate::type_aliases::{Map, Set};
-use crate::version_set::VersionSet;
 
 /// An incompatibility is a set of terms for different packages
 /// that should never be satisfied all together.
@@ -32,13 +28,19 @@ use crate::version_set::VersionSet;
 /// during conflict resolution. More about all this in
 /// [PubGrub documentation](https://github.com/dart-lang/pub/blob/master/doc/solver.md#incompatibility).
 #[derive(Debug, Clone)]
-pub struct Incompatibility<P: Package, VS: VersionSet, M: Eq + Clone + Debug + Display> {
+pub(crate) struct Incompatibility<P: Package, VS: VersionSet, M: Eq + Clone + Debug + Display> {
     package_terms: SmallMap<P, Term<VS>>,
     kind: Kind<P, VS, M>,
 }
 
 /// Type alias of unique identifiers for incompatibilities.
-pub type IncompId<P, VS, M> = Id<Incompatibility<P, VS, M>>;
+pub(crate) type IncompId<P, VS, M> = Id<Incompatibility<P, VS, M>>;
+
+pub(crate) type IncompDpId<DP> = IncompId<
+    <DP as DependencyProvider>::P,
+    <DP as DependencyProvider>::VS,
+    <DP as DependencyProvider>::M,
+>;
 
 #[derive(Debug, Clone)]
 enum Kind<P: Package, VS: VersionSet, M: Eq + Clone + Debug + Display> {
@@ -75,7 +77,7 @@ enum Kind<P: Package, VS: VersionSet, M: Eq + Clone + Debug + Display> {
 /// A Relation describes how a set of terms can be compared to an incompatibility.
 /// Typically, the set of terms comes from the partial solution.
 #[derive(Eq, PartialEq, Debug)]
-pub enum Relation<P: Package> {
+pub(crate) enum Relation<P: Package> {
     /// We say that a set of terms S satisfies an incompatibility I
     /// if S satisfies every term in I.
     Satisfied,
@@ -91,7 +93,7 @@ pub enum Relation<P: Package> {
 
 impl<P: Package, VS: VersionSet, M: Eq + Clone + Debug + Display> Incompatibility<P, VS, M> {
     /// Create the initial "not Root" incompatibility.
-    pub fn not_root(package: P, version: VS::V) -> Self {
+    pub(crate) fn not_root(package: P, version: VS::V) -> Self {
         Self {
             package_terms: SmallMap::One([(
                 package.clone(),
@@ -102,7 +104,7 @@ impl<P: Package, VS: VersionSet, M: Eq + Clone + Debug + Display> Incompatibilit
     }
 
     /// Create an incompatibility to remember that a given set does not contain any version.
-    pub fn no_versions(package: P, term: Term<VS>) -> Self {
+    pub(crate) fn no_versions(package: P, term: Term<VS>) -> Self {
         let set = match &term {
             Term::Positive(r) => r.clone(),
             Term::Negative(_) => panic!("No version should have a positive term"),
@@ -115,7 +117,7 @@ impl<P: Package, VS: VersionSet, M: Eq + Clone + Debug + Display> Incompatibilit
 
     /// Create an incompatibility for a reason outside pubgrub.
     #[allow(dead_code)] // Used by uv
-    pub fn custom_term(package: P, term: Term<VS>, metadata: M) -> Self {
+    pub(crate) fn custom_term(package: P, term: Term<VS>, metadata: M) -> Self {
         let set = match &term {
             Term::Positive(r) => r.clone(),
             Term::Negative(_) => panic!("No version should have a positive term"),
@@ -127,7 +129,7 @@ impl<P: Package, VS: VersionSet, M: Eq + Clone + Debug + Display> Incompatibilit
     }
 
     /// Create an incompatibility for a reason outside pubgrub.
-    pub fn custom_version(package: P, version: VS::V, metadata: M) -> Self {
+    pub(crate) fn custom_version(package: P, version: VS::V, metadata: M) -> Self {
         let set = VS::singleton(version);
         let term = Term::Positive(set.clone());
         Self {
@@ -137,7 +139,7 @@ impl<P: Package, VS: VersionSet, M: Eq + Clone + Debug + Display> Incompatibilit
     }
 
     /// Build an incompatibility from a given dependency.
-    pub fn from_dependency(package: P, versions: VS, dep: (P, VS)) -> Self {
+    pub(crate) fn from_dependency(package: P, versions: VS, dep: (P, VS)) -> Self {
         let (p2, set2) = dep;
         Self {
             package_terms: if set2 == VS::empty() {
@@ -152,7 +154,7 @@ impl<P: Package, VS: VersionSet, M: Eq + Clone + Debug + Display> Incompatibilit
         }
     }
 
-    pub fn as_dependency(&self) -> Option<(&P, &P)> {
+    pub(crate) fn as_dependency(&self) -> Option<(&P, &P)> {
         match &self.kind {
             Kind::FromDependencyOf(p1, _, p2, _) => Some((p1, p2)),
             _ => None,
@@ -168,7 +170,7 @@ impl<P: Package, VS: VersionSet, M: Eq + Clone + Debug + Display> Incompatibilit
     ///
     /// It is a special case of prior cause computation where the unified package
     /// is the common dependant in the two incompatibilities expressing dependencies.
-    pub fn merge_dependents(&self, other: &Self) -> Option<Self> {
+    pub(crate) fn merge_dependents(&self, other: &Self) -> Option<Self> {
         // It is almost certainly a bug to call this method without checking that self is a dependency
         debug_assert!(self.as_dependency().is_some());
         // Check that both incompatibilities are of the shape p1 depends on p2,
@@ -198,7 +200,7 @@ impl<P: Package, VS: VersionSet, M: Eq + Clone + Debug + Display> Incompatibilit
     }
 
     /// Prior cause of two incompatibilities using the rule of resolution.
-    pub fn prior_cause(
+    pub(crate) fn prior_cause(
         incompat: Id<Self>,
         satisfier_cause: Id<Self>,
         package: &P,
@@ -227,7 +229,7 @@ impl<P: Package, VS: VersionSet, M: Eq + Clone + Debug + Display> Incompatibilit
 
     /// Check if an incompatibility should mark the end of the algorithm
     /// because it satisfies the root package.
-    pub fn is_terminal(&self, root_package: &P, root_version: &VS::V) -> bool {
+    pub(crate) fn is_terminal(&self, root_package: &P, root_version: &VS::V) -> bool {
         if self.package_terms.len() == 0 {
             true
         } else if self.package_terms.len() > 1 {
@@ -239,19 +241,19 @@ impl<P: Package, VS: VersionSet, M: Eq + Clone + Debug + Display> Incompatibilit
     }
 
     /// Get the term related to a given package (if it exists).
-    pub fn get(&self, package: &P) -> Option<&Term<VS>> {
+    pub(crate) fn get(&self, package: &P) -> Option<&Term<VS>> {
         self.package_terms.get(package)
     }
 
     /// Iterate over packages.
-    pub fn iter(&self) -> impl Iterator<Item = (&P, &Term<VS>)> {
+    pub(crate) fn iter(&self) -> impl Iterator<Item = (&P, &Term<VS>)> {
         self.package_terms.iter()
     }
 
     // Reporting ###############################################################
 
     /// Retrieve parent causes if of type DerivedFrom.
-    pub fn causes(&self) -> Option<(Id<Self>, Id<Self>)> {
+    pub(crate) fn causes(&self) -> Option<(Id<Self>, Id<Self>)> {
         match self.kind {
             Kind::DerivedFrom(id1, id2) => Some((id1, id2)),
             _ => None,
@@ -259,7 +261,7 @@ impl<P: Package, VS: VersionSet, M: Eq + Clone + Debug + Display> Incompatibilit
     }
 
     /// Build a derivation tree for error reporting.
-    pub fn build_derivation_tree(
+    pub(crate) fn build_derivation_tree(
         self_id: Id<Self>,
         shared_ids: &Set<Id<Self>>,
         store: &Arena<Self>,
@@ -308,7 +310,7 @@ impl<'a, P: Package, VS: VersionSet + 'a, M: Eq + Clone + Debug + Display + 'a>
     Incompatibility<P, VS, M>
 {
     /// CF definition of Relation enum.
-    pub fn relation(&self, terms: impl Fn(&P) -> Option<&'a Term<VS>>) -> Relation<P> {
+    pub(crate) fn relation(&self, terms: impl Fn(&P) -> Option<&'a Term<VS>>) -> Relation<P> {
         let mut relation = Relation::Satisfied;
         for (package, incompat_term) in self.package_terms.iter() {
             match terms(package).map(|term| incompat_term.relation_with(term)) {
@@ -352,11 +354,12 @@ impl<P: Package, VS: VersionSet, M: Eq + Clone + Debug + Display> fmt::Display
 // TESTS #######################################################################
 
 #[cfg(test)]
-pub mod tests {
+pub(crate) mod tests {
+    use proptest::prelude::*;
+
     use super::*;
     use crate::range::Range;
     use crate::term::tests::strategy as term_strat;
-    use proptest::prelude::*;
 
     proptest! {
 

--- a/src/internal/incompatibility.rs
+++ b/src/internal/incompatibility.rs
@@ -336,7 +336,7 @@ impl<'a, P: Package, VS: VersionSet + 'a, M: Eq + Clone + Debug + Display + 'a>
     }
 }
 
-impl<P: Package, VS: VersionSet, M: Eq + Clone + Debug + Display> fmt::Display
+impl<P: Package, VS: VersionSet, M: Eq + Clone + Debug + Display> Display
     for Incompatibility<P, VS, M>
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/src/internal/incompatibility.rs
+++ b/src/internal/incompatibility.rs
@@ -6,8 +6,7 @@
 use std::fmt::{self, Debug, Display};
 use std::sync::Arc;
 
-use crate::internal::arena::{Arena, Id};
-use crate::internal::small_map::SmallMap;
+use crate::internal::{Arena, Id, SmallMap};
 use crate::{
     term, DefaultStringReportFormatter, DependencyProvider, DerivationTree, Derived, External, Map,
     Package, ReportFormatter, Set, Term, VersionSet,

--- a/src/internal/mod.rs
+++ b/src/internal/mod.rs
@@ -2,14 +2,16 @@
 
 //! Non exposed modules.
 
-pub(crate) use core::State;
-pub(crate) use incompatibility::{IncompDpId, Incompatibility};
-pub(crate) use partial_solution::SatisfierSearch;
-pub(crate) use small_vec::SmallVec;
-
 mod arena;
 mod core;
 mod incompatibility;
 mod partial_solution;
 mod small_map;
 mod small_vec;
+
+pub(crate) use arena::{Arena, Id};
+pub(crate) use core::State;
+pub(crate) use incompatibility::{IncompDpId, IncompId, Incompatibility, Relation};
+pub(crate) use partial_solution::{DecisionLevel, PartialSolution, SatisfierSearch};
+pub(crate) use small_map::SmallMap;
+pub(crate) use small_vec::SmallVec;

--- a/src/internal/mod.rs
+++ b/src/internal/mod.rs
@@ -2,9 +2,16 @@
 
 //! Non exposed modules.
 
-pub mod arena;
-pub mod core;
-pub mod incompatibility;
-pub mod partial_solution;
-pub mod small_map;
-pub mod small_vec;
+mod arena;
+mod core;
+mod incompatibility;
+mod partial_solution;
+mod small_map;
+mod small_vec;
+
+pub(crate) use arena::{Arena, Id};
+pub(crate) use core::State;
+pub(crate) use incompatibility::{IncompDpId, IncompId, Incompatibility, Relation};
+pub(crate) use partial_solution::{DecisionLevel, PartialSolution, SatisfierSearch};
+pub(crate) use small_map::SmallMap;
+pub(crate) use small_vec::SmallVec;

--- a/src/internal/mod.rs
+++ b/src/internal/mod.rs
@@ -2,16 +2,14 @@
 
 //! Non exposed modules.
 
+pub(crate) use core::State;
+pub(crate) use incompatibility::{IncompDpId, Incompatibility};
+pub(crate) use partial_solution::SatisfierSearch;
+pub(crate) use small_vec::SmallVec;
+
 mod arena;
 mod core;
 mod incompatibility;
 mod partial_solution;
 mod small_map;
 mod small_vec;
-
-pub(crate) use arena::{Arena, Id};
-pub(crate) use core::State;
-pub(crate) use incompatibility::{IncompDpId, IncompId, Incompatibility, Relation};
-pub(crate) use partial_solution::{DecisionLevel, PartialSolution, SatisfierSearch};
-pub(crate) use small_map::SmallMap;
-pub(crate) use small_vec::SmallVec;

--- a/src/internal/partial_solution.rs
+++ b/src/internal/partial_solution.rs
@@ -10,9 +10,7 @@ use priority_queue::PriorityQueue;
 use rustc_hash::FxHasher;
 
 use super::small_vec::SmallVec;
-use crate::internal::arena::Arena;
-use crate::internal::incompatibility::{IncompDpId, IncompId, Incompatibility, Relation};
-use crate::internal::small_map::SmallMap;
+use crate::internal::{Arena, IncompDpId, IncompId, Incompatibility, Relation, SmallMap};
 use crate::{DependencyProvider, Package, SelectedDependencies, Term, VersionSet};
 
 type FnvIndexMap<K, V> = indexmap::IndexMap<K, V, BuildHasherDefault<FxHasher>>;

--- a/src/internal/partial_solution.rs
+++ b/src/internal/partial_solution.rs
@@ -10,7 +10,9 @@ use priority_queue::PriorityQueue;
 use rustc_hash::FxHasher;
 
 use super::small_vec::SmallVec;
-use crate::internal::{Arena, IncompDpId, IncompId, Incompatibility, Relation, SmallMap};
+use crate::internal::arena::Arena;
+use crate::internal::incompatibility::{IncompDpId, IncompId, Incompatibility, Relation};
+use crate::internal::small_map::SmallMap;
 use crate::{DependencyProvider, Package, SelectedDependencies, Term, VersionSet};
 
 type FnvIndexMap<K, V> = indexmap::IndexMap<K, V, BuildHasherDefault<FxHasher>>;

--- a/src/internal/small_map.rs
+++ b/src/internal/small_map.rs
@@ -3,7 +3,7 @@ use std::hash::Hash;
 use crate::Map;
 
 #[derive(Debug, Clone)]
-pub enum SmallMap<K, V> {
+pub(crate) enum SmallMap<K, V> {
     Empty,
     One([(K, V); 1]),
     Two([(K, V); 2]),
@@ -11,7 +11,7 @@ pub enum SmallMap<K, V> {
 }
 
 impl<K: PartialEq + Eq + Hash, V> SmallMap<K, V> {
-    pub fn get(&self, key: &K) -> Option<&V> {
+    pub(crate) fn get(&self, key: &K) -> Option<&V> {
         match self {
             Self::Empty => None,
             Self::One([(k, v)]) if k == key => Some(v),
@@ -23,7 +23,7 @@ impl<K: PartialEq + Eq + Hash, V> SmallMap<K, V> {
         }
     }
 
-    pub fn get_mut(&mut self, key: &K) -> Option<&mut V> {
+    pub(crate) fn get_mut(&mut self, key: &K) -> Option<&mut V> {
         match self {
             Self::Empty => None,
             Self::One([(k, v)]) if k == key => Some(v),
@@ -35,7 +35,7 @@ impl<K: PartialEq + Eq + Hash, V> SmallMap<K, V> {
         }
     }
 
-    pub fn remove(&mut self, key: &K) -> Option<V> {
+    pub(crate) fn remove(&mut self, key: &K) -> Option<V> {
         let out;
         *self = match std::mem::take(self) {
             Self::Empty => {
@@ -71,7 +71,7 @@ impl<K: PartialEq + Eq + Hash, V> SmallMap<K, V> {
         out
     }
 
-    pub fn insert(&mut self, key: K, value: V) {
+    pub(crate) fn insert(&mut self, key: K, value: V) {
         *self = match std::mem::take(self) {
             Self::Empty => Self::One([(key, value)]),
             Self::One([(k, v)]) => {
@@ -109,7 +109,7 @@ impl<K: PartialEq + Eq + Hash, V> SmallMap<K, V> {
     /// let mut package_terms = package_terms.clone();
     //  let t1 = package_terms.remove(package).unwrap();
     /// ```
-    pub fn split_one(&self, key: &K) -> Option<(&V, Self)>
+    pub(crate) fn split_one(&self, key: &K) -> Option<(&V, Self)>
     where
         K: Clone,
         V: Clone,
@@ -152,7 +152,7 @@ impl<K: Clone + PartialEq + Eq + Hash, V: Clone> SmallMap<K, V> {
     /// apply the provided function to both values.
     /// If the result is None, remove that key from the merged map,
     /// otherwise add the content of the `Some(_)`.
-    pub fn merge<'a>(
+    pub(crate) fn merge<'a>(
         &'a mut self,
         map_2: impl Iterator<Item = (&'a K, &'a V)>,
         f: impl Fn(&V, &V) -> Option<V>,
@@ -180,7 +180,7 @@ impl<K, V> Default for SmallMap<K, V> {
 }
 
 impl<K, V> SmallMap<K, V> {
-    pub fn len(&self) -> usize {
+    pub(crate) fn len(&self) -> usize {
         match self {
             Self::Empty => 0,
             Self::One(_) => 1,
@@ -191,7 +191,7 @@ impl<K, V> SmallMap<K, V> {
 }
 
 impl<K: Eq + Hash + Clone, V: Clone> SmallMap<K, V> {
-    pub fn as_map(&self) -> Map<K, V> {
+    pub(crate) fn as_map(&self) -> Map<K, V> {
         match self {
             Self::Empty => Map::default(),
             Self::One([(k, v)]) => {
@@ -228,7 +228,7 @@ impl<'a, K: 'a, V: 'a> Iterator for IterSmallMap<'a, K, V> {
 }
 
 impl<K, V> SmallMap<K, V> {
-    pub fn iter(&self) -> impl Iterator<Item = (&K, &V)> {
+    pub(crate) fn iter(&self) -> impl Iterator<Item = (&K, &V)> {
         match self {
             Self::Empty => IterSmallMap::Inline([].iter()),
             Self::One(data) => IterSmallMap::Inline(data.iter()),

--- a/src/internal/small_vec.rs
+++ b/src/internal/small_vec.rs
@@ -206,8 +206,9 @@ impl<T> Iterator for SmallVecIntoIter<T> {
 
 #[cfg(test)]
 pub mod tests {
-    use super::*;
     use proptest::prelude::*;
+
+    use super::*;
 
     proptest! {
         #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -107,17 +107,17 @@
 //! ```
 //!
 //! The first method
-//! [choose_version](crate::solver::DependencyProvider::choose_version)
+//! [choose_version](DependencyProvider::choose_version)
 //! chooses a version compatible with the provided range for a package.
 //! The second method
-//! [prioritize](crate::solver::DependencyProvider::prioritize)
+//! [prioritize](DependencyProvider::prioritize)
 //! in which order different packages should be chosen.
 //! Usually prioritizing packages
 //! with the fewest number of compatible versions speeds up resolution.
 //! But in general you are free to employ whatever strategy suits you best
 //! to pick a package and a version.
 //!
-//! The third method [get_dependencies](crate::solver::DependencyProvider::get_dependencies)
+//! The third method [get_dependencies](DependencyProvider::get_dependencies)
 //! aims at retrieving the dependencies of a given package at a given version.
 //!
 //! In a real scenario, these two methods may involve reading the file system
@@ -134,10 +134,10 @@
 //! When everything goes well, the algorithm finds and returns the complete
 //! set of direct and indirect dependencies satisfying all the constraints.
 //! The packages and versions selected are returned as
-//! [SelectedDepedencies<P, V>](type_aliases::SelectedDependencies).
+//! [SelectedDependencies<P, V>](SelectedDependencies).
 //! But sometimes there is no solution because dependencies are incompatible.
-//! In such cases, [resolve(...)](solver::resolve) returns a
-//! [PubGrubError::NoSolution(derivation_tree)](error::PubGrubError::NoSolution),
+//! In such cases, [resolve(...)](resolve) returns a
+//! [PubGrubError::NoSolution(derivation_tree)](PubGrubError::NoSolution),
 //! where the provided derivation tree is a custom binary tree
 //! containing the full chain of reasons why there is no solution.
 //!
@@ -155,7 +155,7 @@
 //! such as if "a" depends on "b" and "b" depends on "c", "a" depends on "c".
 //!
 //! This crate defines a [Reporter] trait, with an associated
-//! [Output](crate::report::Reporter::Output) type and a single method.
+//! [Output](Reporter::Output) type and a single method.
 //! ```
 //! # use pubgrub::{Package, VersionSet, DerivationTree};
 //! # use std::fmt::{Debug, Display};
@@ -190,9 +190,9 @@
 //! };
 //! ```
 //! Notice that we also used
-//! [collapse_no_versions()](crate::report::DerivationTree::collapse_no_versions) above.
+//! [collapse_no_versions()](DerivationTree::collapse_no_versions) above.
 //! This method simplifies the derivation tree to get rid of the
-//! [NoVersions](crate::report::External::NoVersions)
+//! [NoVersions](External::NoVersions)
 //! external incompatibilities in the derivation tree.
 //! So instead of seeing things like this in the report:
 //! ```txt

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -220,7 +220,7 @@ mod type_aliases;
 mod version;
 mod version_set;
 
-pub use error::PubGrubError;
+pub use error::{NoSolutionError, PubGrubError};
 pub use package::Package;
 pub use range::Range;
 pub use report::{

--- a/src/range.rs
+++ b/src/range.rs
@@ -50,13 +50,14 @@
 //! If doing so regularly fixes bugs seen by users, we will bring it back into the core library.
 //! If we do not see practical bugs, or we get a formal proof that the code cannot lead to error states, then we may remove this warning.
 
-use crate::internal::small_vec::SmallVec;
-use crate::version_set::VersionSet;
 use std::borrow::Borrow;
 use std::cmp::Ordering;
 use std::fmt::{Debug, Display, Formatter};
 use std::ops::Bound::{self, Excluded, Included, Unbounded};
 use std::ops::RangeBounds;
+
+use crate::internal::SmallVec;
+use crate::VersionSet;
 
 /// A Range represents multiple intervals of a continuous range of monotone increasing
 /// values.

--- a/src/report.rs
+++ b/src/report.rs
@@ -167,9 +167,7 @@ impl<P: Package, VS: VersionSet, M: Eq + Clone + Debug + Display> DerivationTree
     }
 }
 
-impl<P: Package, VS: VersionSet, M: Eq + Clone + Debug + Display> fmt::Display
-    for External<P, VS, M>
-{
+impl<P: Package, VS: VersionSet, M: Eq + Clone + Debug + Display> Display for External<P, VS, M> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::NotRoot(package, version) => {

--- a/src/solver.rs
+++ b/src/solver.rs
@@ -65,13 +65,10 @@ use std::convert::Infallible;
 use std::error::Error;
 use std::fmt::{Debug, Display};
 
-use crate::error::PubGrubError;
-use crate::internal::core::State;
-use crate::internal::incompatibility::Incompatibility;
-use crate::package::Package;
-use crate::type_aliases::{DependencyConstraints, Map, SelectedDependencies};
-use crate::version_set::VersionSet;
 use log::{debug, info};
+
+use crate::internal::{Incompatibility, State};
+use crate::{DependencyConstraints, Map, Package, PubGrubError, SelectedDependencies, VersionSet};
 
 /// Main function of the library.
 /// Finds a set of packages satisfying dependency bounds for a given package + version pair.
@@ -253,7 +250,7 @@ pub trait DependencyProvider {
     /// The type returned from `prioritize`. The resolver does not care what type this is
     /// as long as it can pick a largest one and clone it.
     ///
-    /// [std::cmp::Reverse] can be useful if you want to pick the package with
+    /// [Reverse] can be useful if you want to pick the package with
     /// the fewest versions that match the outstanding constraint.
     type Priority: Ord + Clone;
 

--- a/src/term.rs
+++ b/src/term.rs
@@ -223,7 +223,7 @@ pub mod tests {
     use proptest::prelude::*;
 
     use super::*;
-    use crate::range::Range;
+    use crate::Range;
 
     pub fn strategy() -> impl Strategy<Value = Term<Range<u32>>> {
         prop_oneof![

--- a/src/term.rs
+++ b/src/term.rs
@@ -220,9 +220,10 @@ impl<VS: VersionSet + Display> Display for Term<VS> {
 
 #[cfg(test)]
 pub mod tests {
+    use proptest::prelude::*;
+
     use super::*;
     use crate::range::Range;
-    use proptest::prelude::*;
 
     pub fn strategy() -> impl Strategy<Value = Term<Range<u32>>> {
         prop_oneof![

--- a/src/term.rs
+++ b/src/term.rs
@@ -66,7 +66,7 @@ impl<VS: VersionSet> Term<VS> {
     pub(crate) fn contains(&self, v: &VS::V) -> bool {
         match self {
             Self::Positive(set) => set.contains(v),
-            Self::Negative(set) => !(set.contains(v)),
+            Self::Negative(set) => !set.contains(v),
         }
     }
 

--- a/src/type_aliases.rs
+++ b/src/type_aliases.rs
@@ -2,7 +2,6 @@
 
 //! Publicly exported type aliases.
 
-use crate::internal::incompatibility::IncompId;
 use crate::DependencyProvider;
 
 /// Map implementation used by the library.
@@ -22,9 +21,3 @@ pub type SelectedDependencies<DP> =
 /// the former means the package has no dependency and it is a known fact,
 /// while the latter means they could not be fetched by the [DependencyProvider].
 pub type DependencyConstraints<P, VS> = Map<P, VS>;
-
-pub(crate) type IncompDpId<DP> = IncompId<
-    <DP as DependencyProvider>::P,
-    <DP as DependencyProvider>::VS,
-    <DP as DependencyProvider>::M,
->;

--- a/src/version.rs
+++ b/src/version.rs
@@ -4,6 +4,7 @@
 
 use std::fmt::{self, Debug, Display};
 use std::str::FromStr;
+
 use thiserror::Error;
 
 /// Type for semantic versions: major.minor.patch.

--- a/tests/examples.rs
+++ b/tests/examples.rs
@@ -8,8 +8,9 @@ use pubgrub::{
 type NumVS = Range<u32>;
 type SemVS = Range<SemanticVersion>;
 
-use log::LevelFilter;
 use std::io::Write;
+
+use log::LevelFilter;
 
 fn init_log() {
     let _ = env_logger::builder()

--- a/tests/proptest.rs
+++ b/tests/proptest.rs
@@ -6,18 +6,16 @@ use std::collections::BTreeSet as Set;
 use std::convert::Infallible;
 use std::fmt::{Debug, Display};
 
-#[cfg(feature = "serde")]
-use pubgrub::SemanticVersion;
+use proptest::collection::{btree_map, btree_set, vec};
+use proptest::prelude::*;
+use proptest::sample::Index;
+use proptest::string::string_regex;
+
 use pubgrub::{
     resolve, DefaultStringReporter, Dependencies, DependencyProvider, DerivationTree, External,
     OfflineDependencyProvider, Package, PubGrubError, Range, Reporter, SelectedDependencies,
     VersionSet,
 };
-
-use proptest::collection::{btree_map, btree_set, vec};
-use proptest::prelude::*;
-use proptest::sample::Index;
-use proptest::string::string_regex;
 
 use crate::sat_dependency_provider::SatResolve;
 
@@ -134,8 +132,6 @@ fn timeout_resolve<DP: DependencyProvider>(
 }
 
 type NumVS = Range<u32>;
-#[cfg(feature = "serde")]
-type SemVS = Range<SemanticVersion>;
 
 #[test]
 #[should_panic]
@@ -609,8 +605,10 @@ fn large_case() {
                 }
             }
         } else if name.ends_with("str_SemanticVersion.ron") {
-            let dependency_provider: OfflineDependencyProvider<&str, SemVS> =
-                ron::de::from_str(&data).unwrap();
+            let dependency_provider: OfflineDependencyProvider<
+                &str,
+                Range<pubgrub::SemanticVersion>,
+            > = ron::de::from_str(&data).unwrap();
             let mut sat = SatResolve::new(&dependency_provider);
             for p in dependency_provider.packages() {
                 for v in dependency_provider.versions(p).unwrap() {

--- a/tests/proptest.rs
+++ b/tests/proptest.rs
@@ -213,7 +213,7 @@ pub fn registry_strategy<N: Package + Ord>(
                     let (a, b) = order_index(a, b, len_all_pkgid);
                     let (a, b) = if reverse_alphabetical { (b, a) } else { (a, b) };
                     let ((dep_name, _), _) = list_of_pkgid[a].to_owned();
-                    if (list_of_pkgid[b].0).0 == dep_name {
+                    if list_of_pkgid[b].0 .0 == dep_name {
                         continue;
                     }
                     let s = &crate_vers_by_name[&dep_name];
@@ -326,7 +326,7 @@ fn retain_versions<N: Package + Ord, VS: VersionSet>(
 }
 
 /// Removes dependencies from the dependency provider where the retain function returns false.
-/// Solutions are constraned by having to fulfill all the dependencies.
+/// Solutions are constrained by having to fulfill all the dependencies.
 /// If there are fewer dependencies required, there are more valid solutions.
 /// If there was a solution to a resolution in the original dependency provider,
 /// then there must still be a solution after dependencies are removed.
@@ -497,7 +497,7 @@ proptest! {
     #[test]
     fn prop_removing_a_dep_cant_break(
         (dependency_provider, cases) in registry_strategy(0u16..665),
-        indexes_to_remove in prop::collection::vec((any::<prop::sample::Index>(), any::<prop::sample::Index>(), any::<prop::sample::Index>()), 1..10)
+        indexes_to_remove in vec((any::<Index>(), any::<Index>(), any::<Index>()), 1..10)
     ) {
         let packages: Vec<_> = dependency_provider.packages().collect();
         let mut to_remove = Set::new();
@@ -537,7 +537,7 @@ proptest! {
     #[test]
     fn prop_limited_independence_of_irrelevant_alternatives(
         (dependency_provider, cases) in registry_strategy(0u16..665),
-        indexes_to_remove in prop::collection::vec(any::<prop::sample::Index>(), 1..10)
+        indexes_to_remove in vec(any::<Index>(), 1..10)
     )  {
         let all_versions: Vec<(u16, u32)> = dependency_provider
             .packages()

--- a/tests/sat_dependency_provider.rs
+++ b/tests/sat_dependency_provider.rs
@@ -6,7 +6,7 @@ use pubgrub::{
 };
 use varisat::ExtendFormula;
 
-fn sat_at_most_one(solver: &mut impl varisat::ExtendFormula, vars: &[varisat::Var]) {
+fn sat_at_most_one(solver: &mut impl ExtendFormula, vars: &[varisat::Var]) {
     if vars.len() <= 1 {
         return;
     } else if vars.len() == 2 {


### PR DESCRIPTION
Imports now only come from two modules: `crate`, which contains all public symbols, and `crate::internal`, which contains all the internal symbols. I'm surprised the split works out so cleanly. I used nightly rustfmt to group the imports.

All internal apis are now `pub(crate)`. Some of these will become public again in the uv fork.

I used my ide's lints to remove unnecessary path prefixes and cleaned some other nitpicks on the way.

No functional changes, this is a maintenance-only PR. 