### PR TITLE
feat: allow depending on self

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -33,19 +33,6 @@ pub enum PubGrubError<DP: DependencyProvider> {
         source: DP::Err,
     },
 
-    /// Error arising when the implementer of
-    /// [DependencyProvider]
-    /// returned a dependency on the requested package.
-    /// This technically means that the package directly depends on itself,
-    /// and is clearly some kind of mistake.
-    #[error("{package} {version} depends on itself")]
-    SelfDependency {
-        /// Package whose dependencies we want.
-        package: DP::P,
-        /// Version of the package for which we want the dependencies.
-        version: DP::V,
-    },
-
     /// Error arising when the implementer of [DependencyProvider] returned an error in the method
     /// [choose_version](DependencyProvider::choose_version).
     #[error("Decision making failed")]
@@ -83,11 +70,6 @@ where
                 .field("package", package)
                 .field("version", version)
                 .field("source", source)
-                .finish(),
-            Self::SelfDependency { package, version } => f
-                .debug_struct("SelfDependency")
-                .field("package", package)
-                .field("version", version)
                 .finish(),
             Self::ErrorChoosingPackageVersion(arg0) => f
                 .debug_tuple("ErrorChoosingPackageVersion")

--- a/src/solver.rs
+++ b/src/solver.rs
@@ -153,12 +153,6 @@ pub fn resolve<DP: DependencyProvider>(
                     ));
                     continue;
                 }
-                Dependencies::Available(x) if x.contains_key(p) => {
-                    return Err(PubGrubError::SelfDependency {
-                        package: p.clone(),
-                        version: v,
-                    });
-                }
                 Dependencies::Available(x) => x,
             };
 

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -43,11 +43,10 @@ fn should_always_find_a_satisfier() {
 }
 
 #[test]
-fn cannot_depend_on_self() {
+fn depend_on_self() {
     let mut dependency_provider = OfflineDependencyProvider::<_, NumVS>::new();
     dependency_provider.add_dependencies("a", 0u32, [("a", Range::full())]);
-    assert!(matches!(
-        resolve(&dependency_provider, "a", 0u32),
-        Err(PubGrubError::SelfDependency { .. })
-    ));
+    assert!(resolve(&dependency_provider, "a", 0u32).is_ok());
+    dependency_provider.add_dependencies("a", 66u32, [("a", Range::singleton(111u32))]);
+    assert!(resolve(&dependency_provider, "a", 66u32).is_err());
 }


### PR DESCRIPTION
In general PubGrub allows cyclical imports. It is totally okay for `A` to depend on `B` which depends on `A`. We have a special exception for `A` depending on `A`. This is extra code and kind of inconsistent.

The argument for the error message was to force the user to choose one of the two reasonable semantics:
- Self dependencies are okay, but meaningless. In which case the dependency provider should filter them out.
- Self dependencies are not okay. In which case the dependency provider should return `Unavailable` with a reason.

I believe that the UV fork of this project removed this code to implement the "self dependencies are okay" semantics.

In Cargo we (currently) take a somewhat inconsistent position. We treat the self dependency as okay for dependency resolution, but then error later due to the cyclical import. I would like to maintain bug for bug compatibility as long as possible to avoid tying upgrading to PubGrub to other breaking changes. The easiest way to implement this "it's not a problem for resolution but the edge does exist for cycle checking" is for PubGrub to simply not error. (Although if we decide not to merge this I have other options.)