### PR TITLE
perf: remove more redundant scanning

### DIFF
--- a/src/internal/core.rs
+++ b/src/internal/core.rs
@@ -128,10 +128,9 @@ impl<DP: DependencyProvider> State<DP> {
                     Relation::AlmostSatisfied(package_almost) => {
                         // Add `package_almost` to the `unit_propagation_buffer` set.
                         // Putting items in `unit_propagation_buffer` more than once waste cycles,
-                        // but so does checking for duplicates.
-                        // In practice the most common pathology is adding the same package repeatedly.
-                        // So we only check if it is duplicated with the last item.
-                        if self.unit_propagation_buffer.last() != Some(&package_almost) {
+                        // but so does allocating a hash map and hashing each item.
+                        // In practice `unit_propagation_buffer` is small enough that we can just do a linear scan.
+                        if !self.unit_propagation_buffer.contains(&package_almost) {
                             self.unit_propagation_buffer.push(package_almost.clone());
                         }
                         // Add (not term) to the partial solution with incompat as cause.


### PR DESCRIPTION
Doing the stronger version of #175 because it turns out to be important to cargo crates.

While investigating https://github.com/Eh2406/pubgrub-crates-benchmark/issues/6  I took a shot in the dark and thought it might have to do with this optimization. Indeed this one change brings the time to analyze the Solana crates down from 127.25min to 90.85min a 28% improvement.