### PR TITLE
Old behavior when there is no previous_satisfier

### DIFF
--- a/src/internal/partial_solution.rs
+++ b/src/internal/partial_solution.rs
@@ -485,12 +485,16 @@ impl<DP: DependencyProvider> PartialSolution<DP> {
             .get(satisfier_package)
             .expect("satisfier package not in incompat");
 
+        let start_term = accum_term.intersection(&incompat_term.negate());
+        let out = satisfier_pa.satisfier(satisfier_package, &start_term);
+
         satisfied_map.insert(
             satisfier_package,
-            satisfier_pa.satisfier(
-                satisfier_package,
-                &accum_term.intersection(&incompat_term.negate()),
-            ),
+            if accum_term.subset_of(incompat_term) {
+                (None, 0, DecisionLevel(1))
+            } else {
+                out
+            },
         );
 
         // Finally, let's identify the decision level of that previous satisfier.

--- a/tests/examples.rs
+++ b/tests/examples.rs
@@ -237,8 +237,8 @@ fn confusing_with_lots_of_holes() {
     };
     assert_eq!(
         &DefaultStringReporter::report(&derivation_tree),
-        r#"Because there is no available version for bar and foo 1 | 2 | 3 | 4 | 5 depends on bar, foo 1 | 2 | 3 | 4 | 5 is forbidden.
-And because there is no version of foo in <1 | >1, <2 | >2, <3 | >3, <4 | >4, <5 | >5 and root 1 depends on foo, root 1 is forbidden."#
+        r#"Because foo 1 | 2 | 3 | 4 | 5 depends on bar and there is no version of foo in <1 | >1, <2 | >2, <3 | >3, <4 | >4, <5 | >5, foo depends on bar.
+And because there is no available version for bar and root 1 depends on foo, root 1 is forbidden."#
     );
     derivation_tree.collapse_no_versions();
     assert_eq!(


### PR DESCRIPTION
In #79 we removed the special case described in the original PubGrub documentation as handling there not being a `previous_satisfier`. This PR brings that special case back. We believe that this special case happens when there is only one package referenced in the conflict, and that package was depended on by only one other package. Specifically under some circumstances the old code would point out that the unitary conflict has been "almost satisfied" from the very beginning of history and so backjump to beginning of the problem. (It is always technically safe to have excessive backjump. Even restarting with no decisions each time there's a conflict would still get the correct answer.) Instead after #79 they would backjump only to where the package was first depended on, triggering resolving conflict by marking the depender is unavailable.

On one hand, the post #79 code involves less backjumping and therefore less redundant decision-making and keeps the `state` free of unnecessary facts. On the other hand the old code put a fundamental conflict in the correct place in the `state` so that it will not get repeatedly removed and re-added when backjumping.

Which one is faster depends on how much optimizations we've applied to different parts of the code and the exact shape of the problem. Crates.io (without Solana) gets 14% faster. The synthetic slow_135 (based on #135) gets 19% faster. elm, "large_case", and zule have small regressions that are as likely to be noise as real. The Sudoku problem gets ~4x slower. Based on extensive testing, all of these changes are due to the algorithmic change. The second commit which reduces allocations does not have a measurable impact on performance.

By changing the order incompatibilities are discovered and combined this changes error messages. Whether for the better or worse this repo does not have sufficient testing to determine.

Some relevant back links are
- https://github.com/pubgrub-rs/pubgrub/pull/79#issuecomment-2329782596
- https://github.com/pubgrub-rs/pubgrub/pull/97#issuecomment-2330030364
- https://rust-lang.zulipchat.com/#narrow/stream/260232-t-cargo.2FPubGrub/topic/partial_solution/near/240328481
- https://rust-lang.zulipchat.com/#narrow/stream/260232-t-cargo.2FPubGrub/topic/random/near/303891131
- https://rust-lang.zulipchat.com/#narrow/stream/260232-t-cargo.2FPubGrub/topic/Progress.20report/near/465855304