### PR TITLE
Improve Term documentation

### DIFF
--- a/version-ranges/src/lib.rs
+++ b/version-ranges/src/lib.rs
@@ -898,7 +898,7 @@ impl<'de, V: serde::Deserialize<'de>> serde::Deserialize<'de> for Ranges<V> {
 pub fn proptest_strategy() -> impl Strategy<Value = Ranges<u32>> {
     (
         any::<bool>(),
-        prop::collection::vec(any::<(u32, bool)>(), 1..10),
+        prop::collection::vec(any::<(u32, bool)>(), 0..10),
     )
         .prop_map(|(start_unbounded, deltas)| {
             let mut start = if start_unbounded {


### PR DESCRIPTION
This PR adds better documentation for `Term`, clarifies the difference between `Positive(r)` and `Negative(r.complement())`, and adds justifications for `Term` mathematical operations.