### PR TITLE
Add cold annotations

### DIFF
--- a/src/internal/core.rs
+++ b/src/internal/core.rs
@@ -79,6 +79,7 @@ impl<DP: DependencyProvider> State<DP> {
     }
 
     /// Add an incompatibility to the state.
+    #[cold]
     pub(crate) fn add_incompatibility_from_dependencies(
         &mut self,
         package: Id<DP::P>,
@@ -105,6 +106,7 @@ impl<DP: DependencyProvider> State<DP> {
 
     /// Unit propagation is the core mechanism of the solving algorithm.
     /// CF <https://github.com/dart-lang/pub/blob/master/doc/solver.md#unit-propagation>
+    #[cold]
     pub(crate) fn unit_propagation(
         &mut self,
         package: Id<DP::P>,
@@ -187,6 +189,7 @@ impl<DP: DependencyProvider> State<DP> {
     /// Return the root cause or the terminal incompatibility.
     /// CF <https://github.com/dart-lang/pub/blob/master/doc/solver.md#unit-propagation>
     #[allow(clippy::type_complexity)]
+    #[cold]
     fn conflict_resolution(
         &mut self,
         incompatibility: IncompDpId<DP>,

--- a/src/internal/partial_solution.rs
+++ b/src/internal/partial_solution.rs
@@ -267,6 +267,7 @@ impl<DP: DependencyProvider> PartialSolution<DP> {
         }
     }
 
+    #[cold]
     pub(crate) fn pick_highest_priority_pkg(
         &mut self,
         prioritizer: impl Fn(Id<DP::P>, &DP::VS) -> DP::Priority,

--- a/src/solver.rs
+++ b/src/solver.rs
@@ -70,6 +70,7 @@ use crate::{DependencyConstraints, Map, Package, PubGrubError, SelectedDependenc
 
 /// Main function of the library.
 /// Finds a set of packages satisfying dependency bounds for a given package + version pair.
+#[cold]
 pub fn resolve<DP: DependencyProvider>(
     dependency_provider: &DP,
     package: DP::P,


### PR DESCRIPTION
This PR add `#[cold]` annotations to specific functions to hint the compiler that they should not be inlined, so that other more critical functions like iterators has better chance to be inlined.