### PR TITLE
Return `Id<DP::P>` over `&Id<DP::P>`

### DIFF
--- a/src/internal/core.rs
+++ b/src/internal/core.rs
@@ -275,7 +275,7 @@ impl<DP: DependencyProvider> State<DP> {
                     .map(|m| (past, m))
             }) {
                 let new = self.incompatibility_store.alloc(merged);
-                for (&pkg, _) in self.incompatibility_store[new].iter() {
+                for (pkg, _) in self.incompatibility_store[new].iter() {
                     self.incompatibilities
                         .entry(pkg)
                         .or_default()
@@ -287,7 +287,7 @@ impl<DP: DependencyProvider> State<DP> {
                 deps_lookup.push(id);
             }
         }
-        for (&pkg, term) in self.incompatibility_store[id].iter() {
+        for (pkg, term) in self.incompatibility_store[id].iter() {
             if cfg!(debug_assertions) {
                 assert_ne!(term, &crate::term::Term::any());
             }

--- a/src/internal/incompatibility.rs
+++ b/src/internal/incompatibility.rs
@@ -246,8 +246,10 @@ impl<P: Package, VS: VersionSet, M: Eq + Clone + Debug + Display> Incompatibilit
     }
 
     /// Iterate over packages.
-    pub(crate) fn iter(&self) -> impl Iterator<Item = (&Id<P>, &Term<VS>)> {
-        self.package_terms.iter()
+    pub(crate) fn iter(&self) -> impl Iterator<Item = (Id<P>, &Term<VS>)> {
+        self.package_terms
+            .iter()
+            .map(|(package, term)| (*package, term))
     }
 
     // Reporting ###############################################################
@@ -348,17 +350,17 @@ impl<P: Package, VS: VersionSet, M: Eq + Clone + Debug + Display> Incompatibilit
             [] => "version solving failed".into(),
             // TODO: special case when that unique package is root.
             [(package, Term::Positive(range))] => {
-                format!("{} {} is forbidden", package_store[**package], range)
+                format!("{} {} is forbidden", package_store[*package], range)
             }
             [(package, Term::Negative(range))] => {
-                format!("{} {} is mandatory", package_store[**package], range)
+                format!("{} {} is mandatory", package_store[*package], range)
             }
             [(p_pos, Term::Positive(r_pos)), (p_neg, Term::Negative(r_neg))]
             | [(p_neg, Term::Negative(r_neg)), (p_pos, Term::Positive(r_pos))] => {
                 External::<_, _, M>::FromDependencyOf(
-                    &package_store[**p_pos],
+                    &package_store[*p_pos],
                     r_pos.clone(),
-                    &package_store[**p_neg],
+                    &package_store[*p_neg],
                     r_neg.clone(),
                 )
                 .to_string()
@@ -366,7 +368,7 @@ impl<P: Package, VS: VersionSet, M: Eq + Clone + Debug + Display> Incompatibilit
             slice => {
                 let str_terms: Vec<_> = slice
                     .iter()
-                    .map(|(p, t)| format!("{} {}", package_store[**p], t))
+                    .map(|(p, t)| format!("{} {}", package_store[*p], t))
                     .collect();
                 str_terms.join(", ") + " are incompatible"
             }

--- a/src/internal/partial_solution.rs
+++ b/src/internal/partial_solution.rs
@@ -459,7 +459,7 @@ impl<DP: DependencyProvider> PartialSolution<DP> {
         package_assignments: &FnvIndexMap<Id<DP::P>, PackageAssignments<DP::P, DP::VS, DP::M>>,
     ) -> SatisfiedMap<DP::P, DP::VS, DP::M> {
         let mut satisfied = SmallMap::Empty;
-        for (&package, incompat_term) in incompat.iter() {
+        for (package, incompat_term) in incompat.iter() {
             let pa = package_assignments.get(&package).expect("Must exist");
             satisfied.insert(package, pa.satisfier(package, &incompat_term.negate()));
         }


### PR DESCRIPTION
It's more efficient to return a u32 than to return a reference, and it avoids a borrow when returning it.