### PR TITLE
when priorities are equal do breadth first search

### DIFF
--- a/src/internal/partial_solution.rs
+++ b/src/internal/partial_solution.rs
@@ -3,6 +3,7 @@
 //! A Memory acts like a structured partial solution
 //! where terms are regrouped by package in a [Map](crate::type_aliases::Map).
 
+use std::cmp::Reverse;
 use std::fmt::{Debug, Display};
 use std::hash::BuildHasherDefault;
 
@@ -67,7 +68,7 @@ pub(crate) struct PartialSolution<DP: DependencyProvider> {
     ///
     /// The max heap allows quickly `pop`ing the highest priority package.
     prioritized_potential_packages:
-        PriorityQueue<Id<DP::P>, DP::Priority, BuildHasherDefault<FxHasher>>,
+        PriorityQueue<Id<DP::P>, (DP::Priority, Reverse<u32>), BuildHasherDefault<FxHasher>>,
     /// Whether we have never backtracked, to enable fast path optimizations.
     has_ever_backtracked: bool,
 }
@@ -330,7 +331,7 @@ impl<DP: DependencyProvider> PartialSolution<DP> {
             .filter_map(|(&p, pa)| pa.assignments_intersection.potential_package_filter(p))
             .for_each(|(p, r)| {
                 let priority = prioritizer(p, r);
-                prioritized_potential_packages.push(p, priority);
+                prioritized_potential_packages.push(p, (priority, Reverse(p.into_raw() as u32)));
             });
         self.prioritize_decision_level = self.package_assignments.len();
         prioritized_potential_packages.pop().map(|(p, _)| p)

--- a/src/internal/partial_solution.rs
+++ b/src/internal/partial_solution.rs
@@ -67,6 +67,10 @@ pub(crate) struct PartialSolution<DP: DependencyProvider> {
     /// The undecided packages order by their `Priority`.
     ///
     /// The max heap allows quickly `pop`ing the highest priority package.
+    ///
+    /// The `Reverse<u32>` is the discovery order of packages used as tiebreaker. Its order is that
+    /// of a breadth-first search.
+    #[allow(clippy::type_complexity)]
     prioritized_potential_packages:
         PriorityQueue<Id<DP::P>, (DP::Priority, Reverse<u32>), BuildHasherDefault<FxHasher>>,
     /// Whether we have never backtracked, to enable fast path optimizations.

--- a/src/solver.rs
+++ b/src/solver.rs
@@ -323,6 +323,11 @@ pub trait DependencyProvider {
     /// > since these packages will run out of versions to try more quickly.
     /// > But there's likely room for improvement in these heuristics.
     ///
+    /// The `package_conflicts_counts` argument provides access to some other heuristics that
+    /// are production users have found useful. Although the exact meaning/efficacy of those arguments may change.
+    /// 
+    /// If two packages have the same priority, PubGrub will biased toward a breadth first search.
+    /// 
     /// Note: the resolver may call this even when the range has not changed,
     /// if it is more efficient for the resolvers internal data structures.
     fn prioritize(

--- a/src/solver.rs
+++ b/src/solver.rs
@@ -325,9 +325,9 @@ pub trait DependencyProvider {
     ///
     /// The `package_conflicts_counts` argument provides access to some other heuristics that
     /// are production users have found useful. Although the exact meaning/efficacy of those arguments may change.
-    /// 
+    ///
     /// If two packages have the same priority, PubGrub will biased toward a breadth first search.
-    /// 
+    ///
     /// Note: the resolver may call this even when the range has not changed,
     /// if it is more efficient for the resolvers internal data structures.
     fn prioritize(


### PR DESCRIPTION
Now that #298 has landed, the next steps are evaluate additional heuristics on a case-by-case basis. The obvious next most important from #291 is `discovery_order`. Thinking about it, almost all users could use this as a tiebreaker, and it costs next to nothing to calculate  and the storage cost in priorities seems minimal.  Overall, the cost to adding it to the documentation and telling all of our users to add it to their boilerplate seems higher than just always including it in the priority.

Given that we would now have a reasonable default I thought about giving `prioritize` a default implementation. Unfortunately,  it would need to return a `Self::Priority`   and associated types cannot have a default value. :-(

`cargo run -r -- -m pub --with-solana --filter solana-archiver-lib -t 16` is now giving `2.52min`, a massive improvement from `7.56min` with dev. 