### PR TITLE
Add `State::add_incompatibility_from_dependencies` (#27)

### DIFF
--- a/src/internal/core.rs
+++ b/src/internal/core.rs
@@ -7,8 +7,8 @@ use std::collections::HashSet as Set;
 use std::sync::Arc;
 
 use crate::internal::{
-    Arena, DecisionLevel, HashArena, Id, IncompDpId, Incompatibility, PartialSolution, Relation,
-    SatisfierSearch, SmallVec,
+    Arena, DecisionLevel, HashArena, Id, IncompDpId, IncompId, Incompatibility, PartialSolution,
+    Relation, SatisfierSearch, SmallVec,
 };
 use crate::{DependencyProvider, DerivationTree, Map, NoSolutionError, VersionSet};
 
@@ -71,6 +71,23 @@ impl<DP: DependencyProvider> State<DP> {
             unit_propagation_buffer: SmallVec::Empty,
             merged_dependencies: Map::default(),
         }
+    }
+
+    /// Add the dependencies for the current version of the current package as incompatibilities.
+    pub(crate) fn add_package_version_dependencies(
+        &mut self,
+        package: Id<DP::P>,
+        version: DP::V,
+        dependencies: impl IntoIterator<Item = (DP::P, DP::VS)>,
+    ) -> Option<IncompId<DP::P, DP::VS, DP::M>> {
+        let dep_incompats =
+            self.add_incompatibility_from_dependencies(package, version.clone(), dependencies);
+        self.partial_solution.add_package_version_incompatibilities(
+            package,
+            version.clone(),
+            dep_incompats,
+            &self.incompatibility_store,
+        )
     }
 
     /// Add an incompatibility to the state.

--- a/src/internal/partial_solution.rs
+++ b/src/internal/partial_solution.rs
@@ -417,12 +417,15 @@ impl<DP: DependencyProvider> PartialSolution<DP> {
         self.has_ever_backtracked = true;
     }
 
-    /// We can add the version to the partial solution as a decision
-    /// if it doesn't produce any conflict with the new incompatibilities.
-    /// In practice I think it can only produce a conflict if one of the dependencies
-    /// (which are used to make the new incompatibilities)
-    /// is already in the partial solution with an incompatible version.
-    pub(crate) fn add_version(
+    /// Add a package version as decision if none of its dependencies conflicts with the partial
+    /// solution.
+    ///
+    /// If the resolution never backtracked before, a fast path adds the package version directly
+    /// without checking dependencies.
+    ///
+    /// Returns the incompatibility that caused the current version to be rejected, if a conflict
+    /// in the dependencies was found.
+    pub(crate) fn add_package_version_incompatibilities(
         &mut self,
         package: Id<DP::P>,
         version: DP::V,

--- a/src/solver.rs
+++ b/src/solver.rs
@@ -228,15 +228,9 @@ pub fn resolve<DP: DependencyProvider>(
             };
 
             // Add that package and version if the dependencies are not problematic.
-            let dep_incompats =
-                state.add_incompatibility_from_dependencies(p, v.clone(), dependencies);
-
-            if let Some(conflict) = state.partial_solution.add_version(
-                p,
-                v,
-                dep_incompats,
-                &state.incompatibility_store,
-            ) {
+            if let Some(conflict) =
+                state.add_package_version_dependencies(p, v.clone(), dependencies)
+            {
                 conflict_tracker.entry(p).or_default().dependencies_affected += 1;
                 for (incompat_package, _) in state.incompatibility_store[conflict].iter() {
                     if incompat_package == p {


### PR DESCRIPTION
This PR upstreams https://github.com/astral-sh/pubgrub/pull/27 since i got merge conflicts on it.

---

This wrapper avoids accessing the `incompatibility_store` directly in uv code.

Before:

```rust
let dep_incompats = self.pubgrub.add_version(
    package.clone(),
    version.clone(),
    dependencies,
);
self.pubgrub.partial_solution.add_version(
    package.clone(),
    version.clone(),
    dep_incompats,
    &self.pubgrub.incompatibility_store,
);
```

After:

```rust
self.pubgrub.add_incompatibility_from_dependencies(package.clone(), version.clone(), dependencies);
```

`add_incompatibility_from_dependencies` is one of the main methods for the custom interface to pubgrub.