### PR TITLE
Update rustc-hash bound to 2.0.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ indexmap = "2.7.0"
 # for debug logs in tests
 log = "0.4.22"
 priority-queue = "2.1.1"
-rustc-hash = ">=1.0.0, <3.0.0"
+rustc-hash = "^2.0.0"
 serde = { version = "1.0", features = ["derive"], optional = true }
 thiserror = "2.0"
 version-ranges = { version = "0.1.0", path = "version-ranges" }


### PR DESCRIPTION
We don't actually support v1 anymore, we need the `FxBuildHasher` introduced in v2.

We still can't build with minimal versions due to https://github.com/ron-rs/ron/issues/556