### PR TITLE
Track outdated priorities in a set

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -42,10 +42,6 @@ pub enum PubGrubError<DP: DependencyProvider> {
     /// returned an error in the method [should_cancel](DependencyProvider::should_cancel).
     #[error("We should cancel")]
     ErrorInShouldCancel(#[source] DP::Err),
-
-    /// Something unexpected happened.
-    #[error("{0}")]
-    Failure(String),
 }
 
 impl<DP: DependencyProvider> From<NoSolutionError<DP>> for PubGrubError<DP> {
@@ -78,7 +74,6 @@ where
             Self::ErrorInShouldCancel(arg0) => {
                 f.debug_tuple("ErrorInShouldCancel").field(arg0).finish()
             }
-            Self::Failure(arg0) => f.debug_tuple("Failure").field(arg0).finish(),
         }
     }
 }

--- a/src/solver.rs
+++ b/src/solver.rs
@@ -188,9 +188,10 @@ pub fn resolve<DP: DependencyProvider>(
         };
 
         if !term_intersection.contains(&v) {
-            return Err(PubGrubError::Failure(
-                "choose_package_version picked an incompatible version".into(),
-            ));
+            panic!(
+                "`choose_version` picked an incompatible version for package {}, {} is not in {}",
+                state.package_store[next], v, term_intersection
+            );
         }
 
         let is_new_dependency = added_dependencies


### PR DESCRIPTION
pubgrub currently assumes that package priorities can only change when the derivations of a package change. In tracks the decision level range where derivations changed, and only updates decisions in this level.

This assumption is incorrect for uv, where the priority doesn't depend on the range, but on specifiers and discovery order per package name, not per `DP::P`, which contains virtual packages, too. This change enables more flexible priority updating for uv now and for pubgrub generally in the future.

Instead of updating all package priorities in a decision level range, we directly track the set of packages that need to be updated because we changed their derivations. This enables adding pushing priority updates from uv in our fork.

Currently, packages that are removed from prioritization, those that need to be changed and those that are added are all treated the same way, there might be some optimization by telling them apart.

This branch is based on https://github.com/pubgrub-rs/pubgrub/compare/dev...Eh2406:pubgrub:stop-prioritize.

Half of https://github.com/pubgrub-rs/pubgrub/issues/239, incidentally