### PR TITLE
Test cargo minimal versions on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,16 +11,16 @@ env:
 
 jobs:
   test:
-    name: Tests pass
+    name: Tests
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
-      - run: cargo build --verbose --workspace
-      - run: cargo test --all-features --workspace --verbose
+      - run: cargo build --workspace
+      - run: cargo test --all-features --workspace
 
   clippy:
-    name: No warnings from Clippy
+    name: Clippy
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -33,7 +33,7 @@ jobs:
         run: cargo clippy --workspace
 
   check_formatting:
-    name: Source code is formatted
+    name: Formatting
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -43,7 +43,7 @@ jobs:
       - run: cargo fmt --all -- --check
 
   check_documentation:
-    name: Documentation builds successfully
+    name: Docs
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -52,3 +52,13 @@ jobs:
         env:
           RUSTDOCFLAGS: -D warnings
         run: cargo doc --workspace --no-deps --document-private-items
+
+  minimal-versions:
+    name: Minimal versions
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@nightly
+      - run: cargo +nightly update -Zminimal-versions
+      - run: cargo +nightly build --workspace
+      - run: cargo +nightly test --all-features --workspace

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -81,9 +81,9 @@ checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "base64"
-version = "0.21.7"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bit-set"
@@ -730,9 +730,9 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "ron"
-version = "0.9.0-alpha.0"
+version = "0.9.0-alpha.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c0bd893640cac34097a74f0c2389ddd54c62d6a3c635fa93cafe6b6bc19be6a"
+checksum = "7644a2a539ff7fa991c8f4652373cd722d387e39229415103243914249730836"
 dependencies = [
  "base64",
  "bitflags",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ version-ranges = { version = "0.1.0", path = "version-ranges" }
 criterion = { version = "2.7.2", package = "codspeed-criterion-compat" }
 env_logger = "0.11.6"
 proptest = "1.6.0"
-ron = "=0.9.0-alpha.0"
+ron = "=0.9.0-alpha.1"
 varisat = "0.2.2"
 version-ranges = { version = "0.1.0", path = "version-ranges", features = ["proptest"] }
 

--- a/version-ranges/Cargo.toml
+++ b/version-ranges/Cargo.toml
@@ -18,4 +18,4 @@ serde = ["dep:serde", "smallvec/serde"]
 
 [dev-dependencies]
 proptest = "1.6.0"
-ron = "=0.9.0-alpha.0"
+ron = "=0.9.0-alpha.1"


### PR DESCRIPTION
With https://github.com/ron-rs/ron/pull/557, we can test out lower bounds.