### PR TITLE
Replace failure branch with panic

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -42,10 +42,6 @@ pub enum PubGrubError<DP: DependencyProvider> {
     /// returned an error in the method [should_cancel](DependencyProvider::should_cancel).
     #[error("We should cancel")]
     ErrorInShouldCancel(#[source] DP::Err),
-
-    /// Something unexpected happened.
-    #[error("{0}")]
-    Failure(String),
 }
 
 impl<DP: DependencyProvider> From<NoSolutionError<DP>> for PubGrubError<DP> {
@@ -78,7 +74,6 @@ where
             Self::ErrorInShouldCancel(arg0) => {
                 f.debug_tuple("ErrorInShouldCancel").field(arg0).finish()
             }
-            Self::Failure(arg0) => f.debug_tuple("Failure").field(arg0).finish(),
         }
     }
 }

--- a/src/solver.rs
+++ b/src/solver.rs
@@ -188,9 +188,10 @@ pub fn resolve<DP: DependencyProvider>(
         };
 
         if !term_intersection.contains(&v) {
-            return Err(PubGrubError::Failure(
-                "choose_package_version picked an incompatible version".into(),
-            ));
+            panic!(
+                "`choose_version` picked an incompatible version for package {}, {} is not in {}",
+                state.package_store[next], v, term_intersection
+            );
         }
 
         let is_new_dependency = added_dependencies


### PR DESCRIPTION
When the user's implementation breaks the contract about choose version, we now panic. This contract is trivial to enforce (`vs.contains(v)`), so an error variant only creates an `unreachable!()` in user code.

Fixes #239