### PR TITLE
Fix include patterns for version-ranges

### DIFF
--- a/version-ranges/Cargo.toml
+++ b/version-ranges/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 repository = "https://github.com/pubgrub-rs/pubgrub"
 license = "MPL-2.0"
 keywords = ["version", "pubgrub", "selector", "ranges"]
-include = ["LICENSE", "README.md", "src/**"]
+include = ["LICENSE", "README.md", "number-line-ranges.svg", "src/**"]
 
 [dependencies]
 proptest = { version = "1.6.0", optional = true }

--- a/version-ranges/Cargo.toml
+++ b/version-ranges/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 repository = "https://github.com/pubgrub-rs/pubgrub"
 license = "MPL-2.0"
 keywords = ["version", "pubgrub", "selector", "ranges"]
-include = ["ranges.png", "src"]
+include = ["LICENSE", "README.md", "src/**"]
 
 [dependencies]
 proptest = { version = "1.6.0", optional = true }


### PR DESCRIPTION
- Remove `ranges.png` because it does not exist.
- Add `LICENSE` because it needs to be distributed in the crate.
- Add `README.md` because the top-level `Cargo.toml` for the `pubgrub` crate includes it
- Change `src` to `src/**` to match the top-level `Cargo.toml` for the `pubgrub` crate, although this doesn’t currently seem to make a difference in practice.

I did not add `Changelog.md` because the top-level `Cargo.toml` for the `pubgrub` crate does not do so.

The missing license file in published `version-ranges` crates was originally fixed in https://github.com/pubgrub-rs/pubgrub/pull/267, but https://github.com/pubgrub-rs/pubgrub/pull/266 accidentally broke it by adding an `include` list that did not contain `"LICENSE"`.