### PR TITLE
Print version set on panic

### DIFF
--- a/src/term.rs
+++ b/src/term.rs
@@ -73,20 +73,22 @@ impl<VS: VersionSet> Term<VS> {
     }
 
     /// Unwrap the set contained in a positive term.
-    /// Will panic if used on a negative set.
+    ///
+    /// Panics if used on a negative set.
     pub(crate) fn unwrap_positive(&self) -> &VS {
         match self {
             Self::Positive(set) => set,
-            _ => panic!("Negative term cannot unwrap positive set"),
+            Self::Negative(set) => panic!("Negative term cannot unwrap positive set: {set:?}"),
         }
     }
 
     /// Unwrap the set contained in a negative term.
-    /// Will panic if used on a positive set.
+    ///
+    /// Panics if used on a positive set.
     pub(crate) fn unwrap_negative(&self) -> &VS {
         match self {
             Self::Negative(set) => set,
-            _ => panic!("Positive term cannot unwrap negative set"),
+            Self::Positive(set) => panic!("Positive term cannot unwrap negative set: {set:?}"),
         }
     }
 }


### PR DESCRIPTION
Improve the panic message for https://github.com/astral-sh/uv/issues/13344.

Old output:

```
Positive term cannot unwrap negative set
```

New output:

```
Positive term cannot unwrap negative set: Ranges { segments: [(Included("1.11.2"), Included("1.11.2"))] }
```

This allows identifying the package that panics.