### PR TITLE
Dependabot: versioning-strategy increase-if-necessary

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,5 +12,6 @@ updates:
 
   - package-ecosystem: "cargo"
     directory: "/"
+    versioning-strategy: "increase-if-necessary"
     schedule:
       interval: "monthly"


### PR DESCRIPTION
PubGrub is a library, so we should widen the range where possible to not force users to upgrade versions.