### PR TITLE
Revert "Dependabot: versioning-strategy increase-if-necessary (#340)"

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,5 @@ updates:
 
   - package-ecosystem: "cargo"
     directory: "/"
-    versioning-strategy: "increase-if-necessary"
     schedule:
       interval: "monthly"


### PR DESCRIPTION
This reverts #340, as dependabot doesn't support it:

> The property '#/updates/1/versioning-strategy' value "increase-if-necessary" did not match one of the following values: lockfile-only, auto

This imho means that we can't use dependabot with pubgrub, as the main updates with want are semver-breaking updates to our deps; lockfile updates are a secondary priority, and we shouldn't bump `Cargo.toml` for compatible updates.