### PR TITLE
Use inline format to fix clippy lints

### DIFF
--- a/examples/branching_error_reporting.rs
+++ b/examples/branching_error_reporting.rs
@@ -55,12 +55,12 @@ fn main() {
 
     // Run the algorithm.
     match resolve(&dependency_provider, "root", (1, 0, 0)) {
-        Ok(sol) => println!("{:?}", sol),
+        Ok(sol) => println!("{sol:?}"),
         Err(PubGrubError::NoSolution(mut derivation_tree)) => {
             derivation_tree.collapse_no_versions();
             eprintln!("{}", DefaultStringReporter::report(&derivation_tree));
             std::process::exit(1);
         }
-        Err(err) => panic!("{:?}", err),
+        Err(err) => panic!("{err:?}"),
     };
 }

--- a/examples/caching_dependency_provider.rs
+++ b/examples/caching_dependency_provider.rs
@@ -89,5 +89,5 @@ fn main() {
         CachingDependencyProvider::new(remote_dependencies_provider);
 
     let solution = resolve(&caching_dependencies_provider, "root", 1u32);
-    println!("Solution: {:?}", solution);
+    println!("Solution: {solution:?}");
 }

--- a/examples/doc_interface.rs
+++ b/examples/doc_interface.rs
@@ -20,5 +20,5 @@ fn main() {
 
     // Run the algorithm.
     let solution = resolve(&dependency_provider, "root", 1u32);
-    println!("Solution: {:?}", solution);
+    println!("Solution: {solution:?}");
 }

--- a/examples/doc_interface_error.rs
+++ b/examples/doc_interface_error.rs
@@ -72,11 +72,11 @@ fn main() {
 
     // Run the algorithm.
     match resolve(&dependency_provider, "root", (1, 0, 0)) {
-        Ok(sol) => println!("{:?}", sol),
+        Ok(sol) => println!("{sol:?}"),
         Err(PubGrubError::NoSolution(mut derivation_tree)) => {
             derivation_tree.collapse_no_versions();
             eprintln!("{}", DefaultStringReporter::report(&derivation_tree));
         }
-        Err(err) => panic!("{:?}", err),
+        Err(err) => panic!("{err:?}"),
     };
 }

--- a/examples/doc_interface_semantic.rs
+++ b/examples/doc_interface_semantic.rs
@@ -63,11 +63,11 @@ fn main() {
 
     // Run the algorithm.
     match resolve(&dependency_provider, "root", (1, 0, 0)) {
-        Ok(sol) => println!("{:?}", sol),
+        Ok(sol) => println!("{sol:?}"),
         Err(PubGrubError::NoSolution(mut derivation_tree)) => {
             derivation_tree.collapse_no_versions();
             eprintln!("{}", DefaultStringReporter::report(&derivation_tree));
         }
-        Err(err) => panic!("{:?}", err),
+        Err(err) => panic!("{err:?}"),
     };
 }

--- a/examples/linear_error_reporting.rs
+++ b/examples/linear_error_reporting.rs
@@ -37,12 +37,12 @@ fn main() {
 
     // Run the algorithm.
     match resolve(&dependency_provider, "root", (1, 0, 0)) {
-        Ok(sol) => println!("{:?}", sol),
+        Ok(sol) => println!("{sol:?}"),
         Err(PubGrubError::NoSolution(mut derivation_tree)) => {
             derivation_tree.collapse_no_versions();
             eprintln!("{}", DefaultStringReporter::report(&derivation_tree));
             std::process::exit(1);
         }
-        Err(err) => panic!("{:?}", err),
+        Err(err) => panic!("{err:?}"),
     };
 }

--- a/examples/unsat_root_message_no_version.rs
+++ b/examples/unsat_root_message_no_version.rs
@@ -17,7 +17,7 @@ impl Display for Package {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Package::Root => write!(f, "root"),
-            Package::Package(name) => write!(f, "{}", name),
+            Package::Package(name) => write!(f, "{name}"),
         }
     }
 }
@@ -218,7 +218,7 @@ fn main() {
 
     // Run the algorithm
     match resolve(&dependency_provider, Package::Root, (0, 0, 0)) {
-        Ok(sol) => println!("{:?}", sol),
+        Ok(sol) => println!("{sol:?}"),
         Err(PubGrubError::NoSolution(derivation_tree)) => {
             eprintln!("No solution.\n");
 
@@ -239,6 +239,6 @@ fn main() {
             eprintln!("```");
             std::process::exit(1);
         }
-        Err(err) => panic!("{:?}", err),
+        Err(err) => panic!("{err:?}"),
     };
 }

--- a/src/internal/core.rs
+++ b/src/internal/core.rs
@@ -267,7 +267,7 @@ impl<DP: DependencyProvider> State<DP> {
                             current_incompat_changed,
                             previous_satisfier_level,
                         );
-                        log::info!("backtrack to {:?}", previous_satisfier_level);
+                        log::info!("backtrack to {previous_satisfier_level:?}");
                         satisfier_causes.push((package, current_incompat_id));
                         return Ok((package, current_incompat_id));
                     }

--- a/src/internal/incompatibility.rs
+++ b/src/internal/incompatibility.rs
@@ -491,7 +491,7 @@ pub(crate) mod tests {
                 .collect();
             let expected = BTreeMap::from([("root".to_string(), 0), ("foo".to_string(), 1)]);
 
-            assert_eq!(solution, expected, "{:?}", case);
+            assert_eq!(solution, expected, "{case:?}");
         }
     }
 }

--- a/src/internal/partial_solution.rs
+++ b/src/internal/partial_solution.rs
@@ -144,9 +144,9 @@ impl<VS: VersionSet> Display for AssignmentsIntersection<VS> {
                 version,
                 term: _,
             } => {
-                write!(f, "Decision: level {}, v = {}", decision_level, version)
+                write!(f, "Decision: level {decision_level}, v = {version}")
             }
-            Self::Derivations(term) => write!(f, "Derivations term: {}", term),
+            Self::Derivations(term) => write!(f, "Derivations term: {term}"),
         }
     }
 }
@@ -216,10 +216,7 @@ impl<DP: DependencyProvider> PartialSolution<DP> {
                     AssignmentsIntersection::Derivations(term) => {
                         debug_assert!(
                             term.contains(&version),
-                            "{:?}: {} was expected to be contained in {}",
-                            package,
-                            version,
-                            term,
+                            "{package:?}: {version} was expected to be contained in {term}",
                         )
                     }
                 },

--- a/src/report.rs
+++ b/src/report.rs
@@ -168,39 +168,34 @@ impl<P: Package, VS: VersionSet, M: Eq + Clone + Debug + Display> Display for Ex
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::NotRoot(package, version) => {
-                write!(f, "we are solving dependencies of {} {}", package, version)
+                write!(f, "we are solving dependencies of {package} {version}")
             }
             Self::NoVersions(package, set) => {
                 if set == &VS::full() {
-                    write!(f, "there is no available version for {}", package)
+                    write!(f, "there is no available version for {package}")
                 } else {
-                    write!(f, "there is no version of {} in {}", package, set)
+                    write!(f, "there is no version of {package} in {set}")
                 }
             }
             Self::Custom(package, set, metadata) => {
                 if set == &VS::full() {
-                    write!(
-                        f,
-                        "dependencies of {} are unavailable {}",
-                        package, metadata
-                    )
+                    write!(f, "dependencies of {package} are unavailable {metadata}")
                 } else {
                     write!(
                         f,
-                        "dependencies of {} at version {} are unavailable {}",
-                        package, set, metadata
+                        "dependencies of {package} at version {set} are unavailable {metadata}"
                     )
                 }
             }
             Self::FromDependencyOf(p, set_p, dep, set_dep) => {
                 if set_p == &VS::full() && set_dep == &VS::full() {
-                    write!(f, "{} depends on {}", p, dep)
+                    write!(f, "{p} depends on {dep}")
                 } else if set_p == &VS::full() {
-                    write!(f, "{} depends on {} {}", p, dep, set_dep)
+                    write!(f, "{p} depends on {dep} {set_dep}")
                 } else if set_dep == &VS::full() {
-                    write!(f, "{} {} depends on {}", p, set_p, dep)
+                    write!(f, "{p} {set_p} depends on {dep}")
                 } else {
-                    write!(f, "{} {} depends on {} {}", p, set_p, dep, set_dep)
+                    write!(f, "{p} {set_p} depends on {dep} {set_dep}")
                 }
             }
         }
@@ -289,8 +284,8 @@ impl<P: Package, VS: VersionSet, M: Eq + Clone + Debug + Display> ReportFormatte
         match terms_vec.as_slice() {
             [] => "version solving failed".into(),
             // TODO: special case when that unique package is root.
-            [(package, Term::Positive(range))] => format!("{} {} is forbidden", package, range),
-            [(package, Term::Negative(range))] => format!("{} {} is mandatory", package, range),
+            [(package, Term::Positive(range))] => format!("{package} {range} is forbidden"),
+            [(package, Term::Negative(range))] => format!("{package} {range} is mandatory"),
             [(p1, Term::Positive(r1)), (p2, Term::Negative(r2))] => self.format_external(
                 &External::<_, _, M>::FromDependencyOf(p1, r1.clone(), p2, r2.clone()),
             ),
@@ -298,7 +293,7 @@ impl<P: Package, VS: VersionSet, M: Eq + Clone + Debug + Display> ReportFormatte
                 &External::<_, _, M>::FromDependencyOf(p2, r2.clone(), p1, r1.clone()),
             ),
             slice => {
-                let str_terms: Vec<_> = slice.iter().map(|(p, t)| format!("{} {}", p, t)).collect();
+                let str_terms: Vec<_> = slice.iter().map(|(p, t)| format!("{p} {t}")).collect();
                 str_terms.join(", ") + " are incompatible"
             }
         }
@@ -605,7 +600,7 @@ impl DefaultStringReporter {
         let new_count = self.ref_count + 1;
         self.ref_count = new_count;
         if let Some(line) = self.lines.last_mut() {
-            *line = format!("{} ({})", line, new_count);
+            *line = format!("{line} ({new_count})");
         }
     }
 

--- a/src/term.rs
+++ b/src/term.rs
@@ -218,8 +218,8 @@ impl<VS: VersionSet> AsRef<Self> for Term<VS> {
 impl<VS: VersionSet + Display> Display for Term<VS> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Self::Positive(set) => write!(f, "{}", set),
-            Self::Negative(set) => write!(f, "Not ( {} )", set),
+            Self::Positive(set) => write!(f, "{set}"),
+            Self::Negative(set) => write!(f, "Not ( {set} )"),
         }
     }
 }

--- a/src/version.rs
+++ b/src/version.rs
@@ -21,7 +21,7 @@ impl serde::Serialize for SemanticVersion {
     where
         S: serde::Serializer,
     {
-        serializer.serialize_str(&format!("{}", self))
+        serializer.serialize_str(&format!("{self}"))
     }
 }
 

--- a/tests/proptest.rs
+++ b/tests/proptest.rs
@@ -601,7 +601,7 @@ fn large_case() {
     for case in std::fs::read_dir("test-examples").unwrap() {
         let case = case.unwrap().path();
         let name = case.file_name().unwrap().to_string_lossy();
-        eprint!("{} ", name);
+        eprint!("{name} ");
         let data = std::fs::read_to_string(&case).unwrap();
         let start_time = std::time::Instant::now();
         if name.ends_with("u16_NumberVersion.ron") || name.ends_with("u16_u32.ron") {


### PR DESCRIPTION
Rust 1.88 changed the uninlined format args lint to on-by-default.