### PR TITLE
Update ron to 0.11.0 to fix nightly compilation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -730,9 +730,9 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "ron"
-version = "0.10.1"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "beceb6f7bf81c73e73aeef6dd1356d9a1b2b4909e1f0fc3e59b034f9572d7b7f"
+checksum = "db09040cc89e461f1a265139777a2bde7f8d8c67c4936f700c63ce3e2904d468"
 dependencies = [
  "base64",
  "bitflags",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ version-ranges = { version = "0.1.0", path = "version-ranges" }
 criterion = { version = "2.7.2", package = "codspeed-criterion-compat" }
 env_logger = "0.11.6"
 proptest = "1.6.0"
-ron = "0.10.1"
+ron = "0.11.0"
 varisat = "0.2.2"
 version-ranges = { version = "0.1.0", path = "version-ranges", features = ["proptest"] }
 

--- a/version-ranges/Cargo.toml
+++ b/version-ranges/Cargo.toml
@@ -18,4 +18,4 @@ serde = ["dep:serde", "smallvec/serde"]
 
 [dev-dependencies]
 proptest = "1.6.0"
-ron = "0.10.1"
+ron = "0.11.0"


### PR DESCRIPTION
See https://github.com/pubgrub-rs/pubgrub/issues/350 and https://github.com/ron-rs/ron/pull/580

Fixes https://github.com/pubgrub-rs/pubgrub/issues/350