### PR TITLE
Use stable order for dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,16 @@ jobs:
 
       - run: cargo test --all-features --workspace
 
+  test-i686:
+    name: Tests (32-bit)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
+      - uses: dtolnay/rust-toolchain@stable
+      - run: rustup target add i686-unknown-linux-gnu
+      - run: cargo build --workspace --target i686-unknown-linux-gnu
+      - run: cargo test --all-features --workspace --target i686-unknown-linux-gnu
+
   clippy:
     name: Clippy
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,9 @@ jobs:
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
       - uses: dtolnay/rust-toolchain@stable
+      - run: | 
+          sudo apt-get update
+          sudo apt-get install -y gcc-multilib
       - run: rustup target add i686-unknown-linux-gnu
       - run: cargo build --workspace --target i686-unknown-linux-gnu
       - run: cargo test --all-features --workspace --target i686-unknown-linux-gnu

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## 0.4.0
+
+`DependencyConstraints` is now an opaque type that retains the ordering of the dependencies across platforms. This fixes
+unstable resolutions across platform (https://github.com/pubgrub-rs/pubgrub/issues/373). `DependencyConstraints` can be
+constructed from an iterator. It is currently backed by a `Vec` internally.
+
 ## [0.3.0] - 2025-02-12 - [(diff with 0.2.1)][0.2.1-diff]
 
 PubGrub 0.3 has a more flexible interface and speeds resolution significantly. The public API is very different now, we

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ All notable changes to this project will be documented in this file.
 unstable resolutions across platform (https://github.com/pubgrub-rs/pubgrub/issues/373). `DependencyConstraints` can be
 constructed from an iterator. It is currently backed by a `Vec` internally.
 
+`SelectedDependencies` is now an opaque type that support iteration and `get()`.
+
 ## [0.3.0] - 2025-02-12 - [(diff with 0.2.1)][0.2.1-diff]
 
 PubGrub 0.3 has a more flexible interface and speeds resolution significantly. The public API is very different now, we

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -673,7 +673,7 @@ dependencies = [
 
 [[package]]
 name = "pubgrub"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "codspeed-criterion-compat",
  "env_logger",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ members = ["version-ranges"]
 
 [package]
 name = "pubgrub"
-version = "0.3.0"
+version = "0.4.0"
 authors = [
     "Matthieu Pizenberg <matthieu.pizenberg@gmail.com>",
     "Alex Tokarev <aleksator@gmail.com>",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -230,10 +230,11 @@ pub use report::{
     ReportFormatter, Reporter,
 };
 pub use solver::{
-    Dependencies, DependencyConstraints, DependencyProvider, PackageResolutionStatistics, resolve,
+    Dependencies, DependencyConstraints, DependencyProvider, PackageResolutionStatistics,
+    SelectedDependencies, resolve,
 };
 pub use term::Term;
-pub use type_aliases::{Map, SelectedDependencies, Set};
+pub use type_aliases::{Map, Set};
 pub use version::{SemanticVersion, VersionParseError};
 pub use version_ranges::Ranges;
 #[deprecated(note = "Use `Ranges` instead")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -229,9 +229,11 @@ pub use report::{
     DefaultStringReportFormatter, DefaultStringReporter, DerivationTree, Derived, External,
     ReportFormatter, Reporter,
 };
-pub use solver::{Dependencies, DependencyProvider, PackageResolutionStatistics, resolve};
+pub use solver::{
+    Dependencies, DependencyConstraints, DependencyProvider, PackageResolutionStatistics, resolve,
+};
 pub use term::Term;
-pub use type_aliases::{DependencyConstraints, Map, SelectedDependencies, Set};
+pub use type_aliases::{Map, SelectedDependencies, Set};
 pub use version::{SemanticVersion, VersionParseError};
 pub use version_ranges::Ranges;
 #[deprecated(note = "Use `Ranges` instead")]

--- a/src/solver.rs
+++ b/src/solver.rs
@@ -7,9 +7,7 @@ use std::fmt::{Debug, Display};
 use log::{debug, info};
 
 use crate::internal::{Id, Incompatibility, State};
-use crate::{
-    DependencyConstraints, Map, Package, PubGrubError, SelectedDependencies, Term, VersionSet,
-};
+use crate::{Map, Package, PubGrubError, SelectedDependencies, Term, VersionSet};
 
 /// Statistics on how often a package conflicted with other packages.
 #[derive(Debug, Default, Clone)]
@@ -244,6 +242,43 @@ pub fn resolve<DP: DependencyProvider>(
             );
             state.partial_solution.add_decision(next, v);
         }
+    }
+}
+
+/// The dependencies of a package with their version ranges.
+///
+/// There is a difference in semantics between an empty [DependencyConstraints] and
+/// [Dependencies::Unavailable](Dependencies::Unavailable):
+/// The former means the package has no dependency and it is a known fact,
+/// while the latter means they could not be fetched by the [DependencyProvider].
+#[derive(Debug, Clone)]
+pub struct DependencyConstraints<P, VS>(Vec<(P, VS)>);
+
+impl<P, VS> DependencyConstraints<P, VS> {
+    /// Iterate over each dependency in order.
+    pub fn iter(&self) -> impl Iterator<Item = &(P, VS)> {
+        self.0.iter()
+    }
+}
+
+impl<P, VS> Default for DependencyConstraints<P, VS> {
+    fn default() -> Self {
+        Self(Vec::new())
+    }
+}
+
+impl<P, VS> FromIterator<(P, VS)> for DependencyConstraints<P, VS> {
+    fn from_iter<T: IntoIterator<Item = (P, VS)>>(iter: T) -> Self {
+        Self(iter.into_iter().collect())
+    }
+}
+
+impl<P, VS> IntoIterator for DependencyConstraints<P, VS> {
+    type Item = (P, VS);
+    type IntoIter = <Vec<(P, VS)> as IntoIterator>::IntoIter;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.into_iter()
     }
 }
 

--- a/src/solver.rs
+++ b/src/solver.rs
@@ -279,7 +279,7 @@ pub fn resolve<DP: DependencyProvider>(
 /// The dependencies of a package with their version ranges.
 ///
 /// There is a difference in semantics between an empty [DependencyConstraints] and
-/// [Dependencies::Unavailable](Dependencies::Unavailable):
+/// [Dependencies::Unavailable]:
 /// The former means the package has no dependency and it is a known fact,
 /// while the latter means they could not be fetched by the [DependencyProvider].
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/src/type_aliases.rs
+++ b/src/type_aliases.rs
@@ -10,14 +10,7 @@ pub type Map<K, V> = rustc_hash::FxHashMap<K, V>;
 /// Set implementation used by the library.
 pub type Set<V> = rustc_hash::FxHashSet<V>;
 
-/// Concrete dependencies picked by the library during [resolve](crate::solver::resolve)
-/// from [DependencyConstraints].
+/// Concrete dependencies picked by the library during [resolve](crate::resolve)
+/// from [DependencyConstraints](crate::DependencyConstraints).
 pub type SelectedDependencies<DP> =
     Map<<DP as DependencyProvider>::P, <DP as DependencyProvider>::V>;
-
-/// Holds information about all possible versions a given package can accept.
-/// There is a difference in semantics between an empty map
-/// inside [DependencyConstraints] and [Dependencies::Unavailable](crate::solver::Dependencies::Unavailable):
-/// the former means the package has no dependency and it is a known fact,
-/// while the latter means they could not be fetched by the [DependencyProvider].
-pub type DependencyConstraints<P, VS> = Map<P, VS>;

--- a/src/type_aliases.rs
+++ b/src/type_aliases.rs
@@ -2,15 +2,8 @@
 
 //! Publicly exported type aliases.
 
-use crate::DependencyProvider;
-
 /// Map implementation used by the library.
 pub type Map<K, V> = rustc_hash::FxHashMap<K, V>;
 
 /// Set implementation used by the library.
 pub type Set<V> = rustc_hash::FxHashSet<V>;
-
-/// Concrete dependencies picked by the library during [resolve](crate::resolve)
-/// from [DependencyConstraints](crate::DependencyConstraints).
-pub type SelectedDependencies<DP> =
-    Map<<DP as DependencyProvider>::P, <DP as DependencyProvider>::V>;

--- a/tests/examples.rs
+++ b/tests/examples.rs
@@ -2,7 +2,7 @@
 
 use pubgrub::{
     DefaultStringReporter, Map, OfflineDependencyProvider, PubGrubError, Ranges, Reporter as _,
-    SemanticVersion, Set, resolve,
+    SelectedDependencies, SemanticVersion, Set, resolve,
 };
 
 type NumVS = Ranges<u32>;
@@ -48,7 +48,10 @@ fn no_conflict() {
     expected_solution.insert("bar", (1, 0, 0).into());
 
     // Comparing the true solution with the one computed by the algorithm.
-    assert_eq!(expected_solution, computed_solution);
+    assert_eq!(
+        SelectedDependencies::from_iter(expected_solution),
+        computed_solution
+    );
 }
 
 #[test]
@@ -84,7 +87,10 @@ fn avoiding_conflict_during_decision_making() {
     expected_solution.insert("bar", (1, 1, 0).into());
 
     // Comparing the true solution with the one computed by the algorithm.
-    assert_eq!(expected_solution, computed_solution);
+    assert_eq!(
+        SelectedDependencies::from_iter(expected_solution),
+        computed_solution
+    );
 }
 
 #[test]
@@ -118,7 +124,10 @@ fn conflict_resolution() {
     expected_solution.insert("foo", (1, 0, 0).into());
 
     // Comparing the true solution with the one computed by the algorithm.
-    assert_eq!(expected_solution, computed_solution);
+    assert_eq!(
+        SelectedDependencies::from_iter(expected_solution),
+        computed_solution
+    );
 }
 
 #[test]
@@ -177,7 +186,10 @@ fn conflict_with_partial_satisfier() {
     expected_solution.insert("target", (2, 0, 0).into());
 
     // Comparing the true solution with the one computed by the algorithm.
-    assert_eq!(expected_solution, computed_solution);
+    assert_eq!(
+        SelectedDependencies::from_iter(expected_solution),
+        computed_solution
+    );
 }
 
 #[test]
@@ -208,7 +220,10 @@ fn double_choices() {
 
     // Run the algorithm.
     let computed_solution = resolve(&dependency_provider, "a", 0u32).unwrap();
-    assert_eq!(expected_solution, computed_solution);
+    assert_eq!(
+        SelectedDependencies::from_iter(expected_solution),
+        computed_solution
+    );
 }
 
 #[test]

--- a/tests/proptest.rs
+++ b/tests/proptest.rs
@@ -130,10 +130,7 @@ fn timeout_resolve<DP: DependencyProvider>(
     dependency_provider: DP,
     name: DP::P,
     version: impl Into<DP::V>,
-) -> Result<
-    SelectedDependencies<TimeoutDependencyProvider<DP>>,
-    PubGrubError<TimeoutDependencyProvider<DP>>,
-> {
+) -> Result<SelectedDependencies<DP::P, DP::V>, PubGrubError<TimeoutDependencyProvider<DP>>> {
     resolve(
         &TimeoutDependencyProvider::new(dependency_provider, 50_000),
         name,
@@ -292,7 +289,7 @@ fn meta_test_deep_trees_from_strategy() {
             let res = resolve(&dependency_provider, name, ver);
             dis[res
                 .as_ref()
-                .map(|x| std::cmp::min(x.len(), dis.len()) - 1)
+                .map(|x| std::cmp::min(x.iter().count(), dis.len()) - 1)
                 .unwrap_or(0)] += 1;
             if dis.iter().all(|&x| x > 0) {
                 return;

--- a/tests/sat_dependency_provider.rs
+++ b/tests/sat_dependency_provider.rs
@@ -117,7 +117,7 @@ impl<P: Package, VS: VersionSet> SatResolve<P, VS> {
 
     pub fn is_valid_solution<DP: DependencyProvider<P = P, VS = VS, V = VS::V>>(
         &mut self,
-        pids: &SelectedDependencies<DP>,
+        pids: &SelectedDependencies<DP::P, DP::V>,
     ) -> bool {
         let mut assumption = vec![];
 
@@ -137,7 +137,7 @@ impl<P: Package, VS: VersionSet> SatResolve<P, VS> {
 
     pub fn check_resolve<DP: DependencyProvider<P = P, VS = VS, V = VS::V>>(
         &mut self,
-        res: &Result<SelectedDependencies<DP>, PubGrubError<DP>>,
+        res: &Result<SelectedDependencies<DP::P, DP::V>, PubGrubError<DP>>,
         p: &P,
         v: &VS::V,
     ) {

--- a/tests/sat_dependency_provider.rs
+++ b/tests/sat_dependency_provider.rs
@@ -68,10 +68,10 @@ impl<P: Package, VS: VersionSet> SatResolve<P, VS> {
                 Dependencies::Unavailable(_) => panic!(),
                 Dependencies::Available(d) => d,
             };
-            for (p1, range) in &deps {
+            for (p1, range) in deps {
                 let empty_vec = vec![];
                 let mut matches: Vec<varisat::Lit> = all_versions_by_p
-                    .get(p1)
+                    .get(&p1)
                     .unwrap_or(&empty_vec)
                     .iter()
                     .filter(|(v1, _)| range.contains(v1))

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -115,14 +115,12 @@ fn same_result_across_platforms() {
     let mut dependency_provider = UnprioritizingDependencyProvider::<_, NumVS>::new();
 
     let x = (0..1000)
-        .into_iter()
         .map(|i| (i.to_string(), Ranges::full()))
         .collect::<Vec<_>>();
     dependency_provider.add_dependencies("root".to_string(), 1u32, x);
 
     for i in 0..1000 {
         let x = (0..1000)
-            .into_iter()
             .filter(|j| *j != i)
             .map(|i| (i.to_string(), Ranges::<u32>::singleton(1u32)))
             .collect::<Vec<_>>();
@@ -134,5 +132,5 @@ fn same_result_across_platforms() {
     let ver: u32 = 1;
     let resolution = resolve(&dependency_provider, name, ver).unwrap();
     let (p, _v) = resolution.into_iter().find(|(_p, v)| *v == 2).unwrap();
-    assert_eq!(p, "712".to_string());
+    assert_eq!(p, "0".to_string());
 }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1,6 +1,10 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use pubgrub::{OfflineDependencyProvider, PubGrubError, Ranges, resolve};
+use pubgrub::{
+    Dependencies, DependencyProvider, OfflineDependencyProvider, Package,
+    PackageResolutionStatistics, PubGrubError, Ranges, VersionSet, resolve,
+};
+use std::convert::Infallible;
 
 type NumVS = Ranges<u32>;
 
@@ -49,4 +53,86 @@ fn depend_on_self() {
     assert!(resolve(&dependency_provider, "a", 0u32).is_ok());
     dependency_provider.add_dependencies("a", 66u32, [("a", Ranges::singleton(111u32))]);
     assert!(resolve(&dependency_provider, "a", 66u32).is_err());
+}
+
+/// Test the prioritization is stable across platforms.
+///
+/// https://github.com/pubgrub-rs/pubgrub/issues/373#issuecomment-3384608891
+#[test]
+fn same_result_across_platforms() {
+    struct UnprioritizingDependencyProvider<P: Package, VS: VersionSet> {
+        dependency_provider: OfflineDependencyProvider<P, VS>,
+    }
+
+    impl<P: Package, VS: VersionSet> UnprioritizingDependencyProvider<P, VS> {
+        fn new() -> Self {
+            Self {
+                dependency_provider: OfflineDependencyProvider::new(),
+            }
+        }
+
+        pub fn add_dependencies<I: IntoIterator<Item = (P, VS)>>(
+            &mut self,
+            package: P,
+            version: impl Into<VS::V>,
+            dependencies: I,
+        ) {
+            self.dependency_provider
+                .add_dependencies(package, version, dependencies);
+        }
+    }
+
+    impl<P: Package, VS: VersionSet> DependencyProvider for UnprioritizingDependencyProvider<P, VS> {
+        type P = P;
+        type V = VS::V;
+        type VS = VS;
+        type M = String;
+        type Priority = u32;
+        type Err = Infallible;
+
+        fn choose_version(&self, package: &P, range: &VS) -> Result<Option<VS::V>, Infallible> {
+            self.dependency_provider.choose_version(package, range)
+        }
+
+        fn prioritize(
+            &self,
+            _package: &Self::P,
+            _range: &Self::VS,
+            _package_statistics: &PackageResolutionStatistics,
+        ) -> Self::Priority {
+            0
+        }
+
+        fn get_dependencies(
+            &self,
+            package: &P,
+            version: &VS::V,
+        ) -> Result<Dependencies<P, VS, Self::M>, Infallible> {
+            self.dependency_provider.get_dependencies(package, version)
+        }
+    }
+
+    let mut dependency_provider = UnprioritizingDependencyProvider::<_, NumVS>::new();
+
+    let x = (0..1000)
+        .into_iter()
+        .map(|i| (i.to_string(), Ranges::full()))
+        .collect::<Vec<_>>();
+    dependency_provider.add_dependencies("root".to_string(), 1u32, x);
+
+    for i in 0..1000 {
+        let x = (0..1000)
+            .into_iter()
+            .filter(|j| *j != i)
+            .map(|i| (i.to_string(), Ranges::<u32>::singleton(1u32)))
+            .collect::<Vec<_>>();
+        dependency_provider.add_dependencies(i.to_string(), 2u32, x);
+        dependency_provider.add_dependencies(i.to_string(), 1u32, []);
+    }
+
+    let name = "root".to_string();
+    let ver: u32 = 1;
+    let resolution = resolve(&dependency_provider, name, ver).unwrap();
+    let (p, _v) = resolution.into_iter().find(|(_p, v)| *v == 2).unwrap();
+    assert_eq!(p, "712".to_string());
 }


### PR DESCRIPTION
Fixes https://github.com/pubgrub-rs/pubgrub/issues/373.

By using a `Vec` instead of an `[Fx]HashMap` for `DependencyConstraints`, the insertion order of dependencies becomes deterministic, and thereby our internal prioritization. This fixes the problem in https://github.com/pubgrub-rs/pubgrub/issues/373 where priorities, and thereby resolutions, can change depending on the platform, such as 64-bit vs 32-bit. Now, the first package in a dependency list is always prioritized.

As `DependencyConstraints` had exposed the `FxHashMap`, this is breaking change that requires pubgrub v0.4.

I made `SelectedDependencies` opaque too for good measure.