### PR TITLE
Fix clippy lints

### DIFF
--- a/src/internal/small_map.rs
+++ b/src/internal/small_map.rs
@@ -2,8 +2,9 @@ use std::hash::Hash;
 
 use crate::Map;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub(crate) enum SmallMap<K, V> {
+    #[default]
     Empty,
     One([(K, V); 1]),
     Two([(K, V); 2]),
@@ -170,12 +171,6 @@ impl<K: Clone + PartialEq + Eq + Hash, V: Clone> SmallMap<K, V> {
                 },
             }
         }
-    }
-}
-
-impl<K, V> Default for SmallMap<K, V> {
-    fn default() -> Self {
-        Self::Empty
     }
 }
 

--- a/src/internal/small_vec.rs
+++ b/src/internal/small_vec.rs
@@ -2,8 +2,9 @@ use std::fmt;
 use std::hash::{Hash, Hasher};
 use std::ops::Deref;
 
-#[derive(Clone)]
+#[derive(Clone, Default)]
 pub enum SmallVec<T> {
+    #[default]
     Empty,
     One([T; 1]),
     Two([T; 2]),
@@ -77,12 +78,6 @@ impl<T> SmallVec<T> {
 
     pub fn iter(&self) -> std::slice::Iter<'_, T> {
         self.as_slice().iter()
-    }
-}
-
-impl<T> Default for SmallVec<T> {
-    fn default() -> Self {
-        Self::Empty
     }
 }
 

--- a/tests/proptest.rs
+++ b/tests/proptest.rs
@@ -553,7 +553,7 @@ proptest! {
             .packages()
             .flat_map(|p| {
                 dependency_provider
-                    .versions(&p)
+                    .versions(p)
                     .unwrap()
                     .map(move |&v| (*p, v))
             })


### PR DESCRIPTION
New Rust 1.91, new clippy lints in the default set.