### PR TITLE
ci: address security findings

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -7,12 +7,17 @@ on:
   pull_request:
   workflow_dispatch:
 
+permissions: {}
+
 jobs:
   benchmarks:
     name: Run benchmarks
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
+        with:
+          persist-credentials: false
+
       - name: Setup rust toolchain, cache and cargo-codspeed binary
         uses: moonrepo/setup-rust@ede6de059f8046a5e236c94046823e2af11ca670 # v1
         with:

--- a/.github/workflows/cargo_publish_dry_run.yml
+++ b/.github/workflows/cargo_publish_dry_run.yml
@@ -3,11 +3,13 @@
 name: Check crate publishing works
 on:
   pull_request:
-    branches: [ release ]
+    branches: [release]
   workflow_dispatch:
 
 env:
   CARGO_TERM_COLOR: always
+
+permissions: {}
 
 jobs:
   cargo_publish_dry_run:
@@ -15,6 +17,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
+        with:
+          persist-credentials: false
+
       - name: Install stable Rust
         uses: dtolnay/rust-toolchain@stable
 

--- a/.github/workflows/cargo_publish_dry_run.yml
+++ b/.github/workflows/cargo_publish_dry_run.yml
@@ -20,9 +20,6 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Install stable Rust
-        uses: dtolnay/rust-toolchain@stable
-
       - name: Get Cargo version
         id: cargo_version
         run: echo "::set-output name=version::$(cargo -V | tr -d ' ')"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,10 @@ on:
   pull_request:
   merge_group:
   push:
-    branches: [ release, dev ]
-  schedule: [ cron: "0 6 * * 4" ]
+    branches: [release, dev]
+  schedule: [cron: "0 6 * * 4"]
+
+permissions: {}
 
 env:
   CARGO_TERM_COLOR: always
@@ -15,6 +17,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
+        with:
+          persist-credentials: false
       - uses: dtolnay/rust-toolchain@stable
       - run: cargo build --workspace
       - run: cargo test --all-features --workspace
@@ -24,6 +28,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
+        with:
+          persist-credentials: false
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy
@@ -37,6 +43,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
+        with:
+          persist-credentials: false
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt
@@ -47,6 +55,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
+        with:
+          persist-credentials: false
       - uses: dtolnay/rust-toolchain@stable
       - name: Check documentation
         env:
@@ -58,6 +68,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
+        with:
+          persist-credentials: false
       - uses: dtolnay/rust-toolchain@nightly
       - run: cargo +nightly update -Zminimal-versions
       - run: cargo +nightly build --workspace

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,8 +19,9 @@ jobs:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
         with:
           persist-credentials: false
-      - uses: dtolnay/rust-toolchain@stable
+
       - run: cargo build --workspace
+
       - run: cargo test --all-features --workspace
 
   clippy:
@@ -30,9 +31,7 @@ jobs:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
         with:
           persist-credentials: false
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          components: clippy
+
       - name: Check Clippy lints
         env:
           RUSTFLAGS: -D warnings
@@ -45,9 +44,7 @@ jobs:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
         with:
           persist-credentials: false
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          components: rustfmt
+
       - run: cargo fmt --all -- --check
 
   check_documentation:
@@ -57,7 +54,7 @@ jobs:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
         with:
           persist-credentials: false
-      - uses: dtolnay/rust-toolchain@stable
+
       - name: Check documentation
         env:
           RUSTDOCFLAGS: -D warnings
@@ -70,7 +67,11 @@ jobs:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
         with:
           persist-credentials: false
-      - uses: dtolnay/rust-toolchain@nightly
+
+      - run: rustup toolchain install nightly
+
       - run: cargo +nightly update -Zminimal-versions
+
       - run: cargo +nightly build --workspace
+
       - run: cargo +nightly test --all-features --workspace

--- a/.github/workflows/deploy_documentation.yml
+++ b/.github/workflows/deploy_documentation.yml
@@ -21,8 +21,6 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: dtolnay/rust-toolchain@stable
-
       - name: Build documentation
         run: cargo doc --no-deps
 

--- a/.github/workflows/deploy_documentation.yml
+++ b/.github/workflows/deploy_documentation.yml
@@ -3,8 +3,10 @@
 name: Deploy documentation
 on:
   push:
-    branches: [ dev ]
+    branches: [dev]
   workflow_dispatch:
+
+permissions: {}
 
 env:
   CARGO_TERM_COLOR: always
@@ -12,8 +14,13 @@ env:
 jobs:
   deploy_documentation:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write # for peaceiris/actions-gh-pages
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
+        with:
+          persist-credentials: false
+
       - uses: dtolnay/rust-toolchain@stable
 
       - name: Build documentation


### PR DESCRIPTION
Hi there! This addresses a handful of low-impact findings from [zizmor](https://docs.zizmor.sh).

Key changes:

- Dropped the default permissions on all workflows to `{}` (i.e. no permissions), and have only added explicit permissions where actually needed (at the moment, just the docs workflow).
- Disabled `actions/checkout`'s implicit credential persistence everywhere.
- In a separate commit, I've removed/replaced the various usages of (unpinnable) `rust-toolchain` action with either the runner's own stable rust toolchain (which is already installed) or an explicit `rustup` invocation for a nightly toolchain where necessary.

Of these changes, I suspect the `rust-toolchain` one will merit the most attention 🙂 -- per https://github.com/dtolnay/rust-toolchain/issues/160 there's currently no great way to pin that action in a way that ensures reproducibility/hermetic CI runs, so I've opted to remove it instead. However, I've put that in a separate commit and I'm happy to remove it from the proposed changes here if you consider the unpinned action here an acceptable tradeoff!

Signed-off-by: William Woodruff <william@astral.sh>