### PR TITLE
Remove dtolnay/rust-toolchain

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
-      - uses: dtolnay/rust-toolchain@stable
       - run: | 
           sudo apt-get update
           sudo apt-get install -y gcc-multilib


### PR DESCRIPTION
We don't need it anymore.