### PR TITLE
Declare a minimum rust version of 1.92

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,3 +87,16 @@ jobs:
       - run: cargo +nightly build --workspace
 
       - run: cargo +nightly test --all-features --workspace
+
+  minimal-rust-version:
+    name: Minimum Rust version
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+
+      # NOTE: Keep in sync with `Cargo.toml`
+      - run: rustup toolchain install 1.92
+
+      - run: cargo +1.92 test --all-features --workspace

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,8 @@ license = "MPL-2.0"
 keywords = ["dependency", "pubgrub", "semver", "solver", "version"]
 categories = ["algorithms"]
 include = ["Cargo.toml", "LICENSE", "README.md", "src/**", "tests/**", "examples/**", "benches/**"]
+# NOTE: Keep in sync with `ci.yml`
+rust-version = "1.92"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
I picked Rust 1.92 since it's the same as the N-2 policy we have uv. Given the low volume of changes, I don't think we need a formal policy now.

Fixes https://github.com/pubgrub-rs/pubgrub/issues/197