### PR TITLE
Do not use nightly in minimal-versions check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,9 +84,9 @@ jobs:
 
       - run: cargo +nightly update -Zminimal-versions
 
-      - run: cargo +nightly build --workspace
+      - run: cargo build --workspace
 
-      - run: cargo +nightly test --all-features --workspace
+      - run: cargo test --all-features --workspace
 
   minimal-rust-version:
     name: Minimum Rust version

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -206,9 +206,9 @@ checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
 
 [[package]]
 name = "codspeed"
-version = "4.4.1"
+version = "4.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b684e94583e85a5ca7e1a6454a89d76a5121240f2fb67eb564129d9bafdb9db0"
+checksum = "57af92d1db7f6871b7e82c79cd87f2501db66f36b0eab924be6ea83dd6b2f3f3"
 dependencies = [
  "anyhow",
  "cc",
@@ -224,9 +224,9 @@ dependencies = [
 
 [[package]]
 name = "codspeed-criterion-compat"
-version = "4.4.1"
+version = "4.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e65444156eb73ad7f57618188f8d4a281726d133ef55b96d1dcff89528609ab"
+checksum = "1d31ae2e9ab23c29fa13bdfa06d012524176f5c0f4e25ec262cd829d947ebc5e"
 dependencies = [
  "clap",
  "codspeed",
@@ -237,9 +237,9 @@ dependencies = [
 
 [[package]]
 name = "codspeed-criterion-compat-walltime"
-version = "4.4.1"
+version = "4.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96389aaa4bbb872ea4924dc0335b2bb181bcf28d6eedbe8fea29afcc5bde36a6"
+checksum = "cc8605e40bab5114dcb0f76268e18880082b5798dec10757b5b58d2c3bbc7a1c"
 dependencies = [
  "anes",
  "cast",
@@ -675,6 +675,7 @@ dependencies = [
 name = "pubgrub"
 version = "0.4.0"
 dependencies = [
+ "cc",
  "codspeed-criterion-compat",
  "env_logger",
  "indexmap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,8 +35,10 @@ thiserror = "2.0"
 version-ranges = { version = "0.1.0", path = "version-ranges" }
 
 [dev-dependencies]
-criterion = { version = "4.0.1", package = "codspeed-criterion-compat" }
+criterion = { version = "4.7.0", package = "codspeed-criterion-compat" }
 env_logger = "0.11.6"
+# Lower-bound guard for `codspeed-criterion-compat` in the minimal-versions CI job.
+cc = "1.2.40"
 proptest = "1.6.0"
 ron = "0.12.0"
 varisat = "0.2.2"


### PR DESCRIPTION
Old versions sometimes stop working on recent nightly, which broke the check on main. Using stable rust avoids this problem in the future.

Also bump codspeed for the associated cc bump, to work around https://github.com/CodSpeedHQ/codspeed-rust/pull/182.