### PR TITLE
ci: raise is-terminal and tempfile dev floors so minimal-versions builds on nightly

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,15 @@ criterion = { version = "4.7.0", package = "codspeed-criterion-compat" }
 env_logger = "0.11.6"
 # Lower-bound guard for `codspeed-criterion-compat` in the minimal-versions CI job.
 cc = "1.2.40"
+# Lower-bound guards to keep the transitive `rustix` buildable in the
+# minimal-versions CI job. rustix below 0.38.6 uses the
+# `rustc_layout_scalar_valid_range_start` attribute removed from the compiler in
+# rust-lang/rust#155433, so it no longer builds on nightly (see
+# bytecodealliance/rustix#1620). `codspeed-criterion-compat -> is-terminal` pulls
+# rustix 0.37 until is-terminal 0.4.8, and `proptest -> tempfile` resolves rustix
+# 0.38.0 until tempfile 3.9 raises its floor to rustix 0.38.26.
+is-terminal = "0.4.8"
+tempfile = "3.9"
 proptest = "1.6.0"
 ron = "0.12.0"
 varisat = "0.2.2"


### PR DESCRIPTION
The `Minimal versions` CI job (`cargo +nightly update -Zminimal-versions` then build and test) is latently broken. Under minimal versions, two dev-dep paths resolve `rustix 0.37`: `codspeed-criterion-compat -> is-terminal 0.4.6` and `proptest -> tempfile`. rustix below 0.38.6 relies on the `rustc_layout_scalar_valid_range_start` attribute, which the compiler removed in rust-lang/rust#155433, so it no longer compiles on current nightly (tracked in bytecodealliance/rustix#1620). The job only still passes because it has not re-run on a post-removal nightly.

This raises two dev-dep floors so minimal versions resolves a buildable rustix. `is-terminal = "0.4.8"` moves the codspeed path off the rustix 0.37 line, and `tempfile = "3.9"` raises the proptest path to rustix 0.38.26 (the lowest tempfile floor whose rustix builds; `tempfile 3.7` and `3.8` still resolve the unbuildable rustix 0.38.0). No direct rustix floor is added, so the normal latest-versions resolution is unchanged and keeps a single rustix.

Verified locally on nightly 2026-05-12:

- with `-Zminimal-versions`, rustix resolves to a single 0.38.26 and `cargo build --workspace` plus `cargo test --all-features --workspace` pass;
- the latest-versions build is unaffected (single rustix 1.1.4, tests pass).

The astral-sh/pubgrub fork hit the same breakage; the fix there (astral-sh/pubgrub#55) was redirected here so the fork can rebase on top.
