### PR TITLE
Check direct minimum versions in CI (#60)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,7 +82,7 @@ jobs:
 
       - run: rustup toolchain install nightly
 
-      - run: cargo +nightly update -Zminimal-versions
+      - run: cargo +nightly update -Zdirect-minimal-versions
 
       - run: cargo build --workspace
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ indexmap = "2.7.0"
 log = "0.4.27"
 priority-queue = "2.3.1"
 rustc-hash = "^2.1.1"
-serde = { version = "1.0", features = ["derive"], optional = true }
+serde = { version = "1.0.219", features = ["derive"], optional = true }
 thiserror = "2.0"
 version-ranges = { version = "0.1.0", path = "version-ranges" }
 


### PR DESCRIPTION
The minimal-versions job currently resolves every transitive dependency to its lowest allowed version, which [Cargo does not recommend](https://doc.rust-lang.org/cargo/reference/unstable.html#minimal-versions). This selected `rustix 0.37.0` through a development dependency and caused the job to fail on current nightly, even though PubGrub's own dependency bounds were valid.

Switch to direct minimum versions so we validate the lower bounds we declare while resolving transitive dependencies normally. Use nightly only to generate that lockfile, then build and test it with stable Rust. Align the root crate's Serde lower bound with `version-ranges` so the workspace has one consistent direct minimum.

The resulting direct-minimum dependency graph builds and passes all workspace tests with all features; the normal locked graph does as well.

This is an upstream port of https://github.com/astral-sh/pubgrub/pull/60