### PR TITLE
Allow `DependencyProvider`s to explicitly specify package conflicts

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,8 @@ version-ranges = { version = "0.1.0", path = "version-ranges", features = ["prop
 
 [features]
 serde = ["dep:serde", "version-ranges/serde"]
+experimental-conflict = []
+# default = ["experimental-conflict"]
 
 [[bench]]
 name = "backtracking"

--- a/examples/unsat_root_message_no_version.rs
+++ b/examples/unsat_root_message_no_version.rs
@@ -2,6 +2,9 @@
 
 use std::fmt::{self, Display};
 
+#[cfg(feature = "experimental-conflict")]
+use std::fmt::Write;
+
 use pubgrub::{
     DefaultStringReporter, Derived, External, Map, OfflineDependencyProvider, PubGrubError, Ranges,
     ReportFormatter, Reporter, SemanticVersion, Term, resolve,
@@ -101,6 +104,22 @@ impl ReportFormatter<Package, Ranges<SemanticVersion>, String> for CustomReportF
                 } else {
                     format!("{package} {package_set} depends on {dependency} {dependency_set}")
                 }
+            }
+            #[cfg(feature = "experimental-conflict")]
+            External::Conflict(hash_map) => {
+                let mut buf = String::new();
+                write!(buf, "packages ").unwrap();
+                for (idx, (k, v)) in hash_map.iter().enumerate() {
+                    if idx == hash_map.len() - 2 {
+                        write!(buf, "and ").unwrap();
+                    }
+                    write!(buf, "{k} in {v}").unwrap();
+                    if idx != hash_map.len() - 1 {
+                        write!(buf, ", ").unwrap();
+                    }
+                }
+                write!(buf, "conflict").unwrap();
+                buf
             }
         }
     }

--- a/src/internal/incompatibility.rs
+++ b/src/internal/incompatibility.rs
@@ -49,11 +49,13 @@ enum Kind<P: Package, VS: VersionSet, M: Eq + Clone + Debug + Display> {
     /// This incompatibility drives the resolution, it requires that we pick the (virtual) root
     /// packages.
     NotRoot(Id<P>, VS::V),
+
     /// There are no versions in the given range for this package.
     ///
     /// This incompatibility is used when we tried all versions in a range and no version
     /// worked, so we have to backtrack
     NoVersions(Id<P>, VS),
+
     /// Incompatibility coming from the dependencies of a given package.
     ///
     /// If a@1 depends on b>=1,<2, we create an incompatibility with terms `{a 1, b <1,>=2}` with
@@ -62,10 +64,16 @@ enum Kind<P: Package, VS: VersionSet, M: Eq + Clone + Debug + Display> {
     /// We can merge multiple dependents with the same version. For example, if a@1 depends on b and
     /// a@2 depends on b, we can say instead a@1||2 depends on b.
     FromDependencyOf(Id<P>, VS, Id<P>, VS),
+
     /// Derived from two causes. Stores cause ids.
     ///
     /// For example, if a -> b and b -> c, we can derive a -> c.
     DerivedFrom(IncompId<P, VS, M>, IncompId<P, VS, M>),
+
+    /// Incompatibility coming from externally specified conflicts between packages.
+    #[cfg(feature = "experimental-conflict")]
+    Conflict(SmallMap<Id<P>, VS>),
+
     /// The package is unavailable for reasons outside pubgrub.
     ///
     /// Examples:
@@ -92,6 +100,17 @@ pub(crate) enum Relation<P: Package> {
 }
 
 impl<P: Package, VS: VersionSet, M: Eq + Clone + Debug + Display> Incompatibility<P, VS, M> {
+    #[cfg(feature = "experimental-conflict")]
+    pub(crate) fn conflict(grp: SmallMap<Id<P>, VS>) -> Self {
+        Self {
+            package_terms: grp
+                .iter()
+                .map(|(k, v)| (k.clone(), Term::Positive(v.clone())))
+                .collect(),
+            kind: Kind::Conflict(grp),
+        }
+    }
+
     /// Create the initial "not Root" incompatibility.
     pub(crate) fn not_root(package: Id<P>, version: VS::V) -> Self {
         Self {
@@ -313,6 +332,13 @@ impl<P: Package, VS: VersionSet, M: Eq + Clone + Debug + Display> Incompatibilit
                     dep_set.clone(),
                 ))
             }
+            #[cfg(feature = "experimental-conflict")]
+            Kind::Conflict(small_map) => DerivationTree::External(External::Conflict(
+                small_map
+                    .iter()
+                    .map(|(k, v)| (package_store[*k].clone(), v.clone()))
+                    .collect(),
+            )),
             Kind::Custom(package, set, metadata) => DerivationTree::External(External::Custom(
                 package_store[package].clone(),
                 set.clone(),

--- a/src/internal/small_map.rs
+++ b/src/internal/small_map.rs
@@ -211,3 +211,16 @@ impl<K, V> SmallMap<K, V> {
         }
     }
 }
+
+impl<K, V> FromIterator<(K, V)> for SmallMap<K, V>
+where
+    K: Eq + Hash,
+{
+    fn from_iter<T: IntoIterator<Item = (K, V)>>(iter: T) -> Self {
+        let mut map = Self::Empty;
+        for (k, v) in iter {
+            map.insert(k, v);
+        }
+        map
+    }
+}

--- a/src/report.rs
+++ b/src/report.rs
@@ -3,6 +3,8 @@
 //! Build a report as clear as possible as to why
 //! dependency solving failed.
 
+#[cfg(feature = "experimental-conflict")]
+use std::collections::HashMap;
 use std::fmt::{self, Debug, Display};
 use std::ops::Deref;
 use std::sync::Arc;
@@ -40,10 +42,17 @@ pub enum DerivationTree<P: Package, VS: VersionSet, M: Eq + Clone + Debug + Disp
 pub enum External<P: Package, VS: VersionSet, M: Eq + Clone + Debug + Display> {
     /// Initial incompatibility aiming at picking the root package for the first decision.
     NotRoot(P, VS::V),
+
     /// There are no versions in the given set for this package.
     NoVersions(P, VS),
+
     /// Incompatibility coming from the dependencies of a given package.
     FromDependencyOf(P, VS, P, VS),
+
+    /// Incompatibility coming from externally specified conflicts between packages.
+    #[cfg(feature = "experimental-conflict")]
+    Conflict(HashMap<P, VS>),
+
     /// The package is unusable for reasons outside pubgrub.
     Custom(P, VS, M),
 }
@@ -74,6 +83,8 @@ impl<P: Package, VS: VersionSet, M: Eq + Clone + Debug + Display> DerivationTree
                     packages.insert(p);
                     packages.insert(p2);
                 }
+                #[cfg(feature = "experimental-conflict")]
+                External::Conflict(small_map) => packages.extend(small_map.iter().map(|(k, _)| k)),
                 External::NoVersions(p, _)
                 | External::NotRoot(p, _)
                 | External::Custom(p, _, _) => {
@@ -158,6 +169,8 @@ impl<P: Package, VS: VersionSet, M: Eq + Clone + Debug + Display> DerivationTree
                     )))
                 }
             }
+            #[cfg(feature = "experimental-conflict")]
+            DerivationTree::External(External::Conflict(_)) => None,
             // Cannot be merged because the reason may not match
             DerivationTree::External(External::Custom(_, _, _)) => None,
         }
@@ -197,6 +210,20 @@ impl<P: Package, VS: VersionSet, M: Eq + Clone + Debug + Display> Display for Ex
                 } else {
                     write!(f, "{p} {set_p} depends on {dep} {set_dep}")
                 }
+            }
+            #[cfg(feature = "experimental-conflict")]
+            Self::Conflict(hash_map) => {
+                write!(f, "packages ")?;
+                for (idx, (k, v)) in hash_map.iter().enumerate() {
+                    if idx == hash_map.len() - 2 {
+                        write!(f, "and ")?;
+                    }
+                    write!(f, "{k} in {v}")?;
+                    if idx != hash_map.len() - 1 {
+                        write!(f, ", ")?;
+                    }
+                }
+                write!(f, "conflict")
             }
         }
     }

--- a/src/solver.rs
+++ b/src/solver.rs
@@ -174,7 +174,7 @@ pub fn resolve<DP: DependencyProvider>(
 
         info!(
             "unit_propagation: {:?} = '{}'",
-            &next, state.package_store[next]
+            next, state.package_store[next]
         );
         let satisfier_causes = state.unit_propagation(next)?;
         for (affected, incompat) in satisfier_causes {
@@ -226,7 +226,7 @@ pub fn resolve<DP: DependencyProvider>(
 
         info!(
             "DP chose: {:?} = '{}' @ {:?}",
-            &next, state.package_store[next], decision
+            next, state.package_store[next], decision
         );
 
         // Pick the next compatible version.
@@ -295,7 +295,7 @@ pub fn resolve<DP: DependencyProvider>(
             // terms and can add the decision directly.
             info!(
                 "add_decision (not first time): {:?} = '{}' @ {}",
-                &next, state.package_store[next], v
+                next, state.package_store[next], v
             );
             state.partial_solution.add_decision(next, v);
         }

--- a/src/solver.rs
+++ b/src/solver.rs
@@ -1,6 +1,13 @@
 // SPDX-License-Identifier: MPL-2.0
 
 use std::collections::BTreeSet as Set;
+
+#[cfg(feature = "experimental-conflict")]
+use std::collections::HashMap;
+
+#[cfg(feature = "experimental-conflict")]
+use crate::internal::SmallMap;
+
 use std::error::Error;
 use std::fmt::{Debug, Display};
 
@@ -141,6 +148,25 @@ pub fn resolve<DP: DependencyProvider>(
     let mut conflict_tracker: Map<Id<DP::P>, PackageResolutionStatistics> = Map::default();
     let mut added_dependencies: Map<Id<DP::P>, Set<DP::V>> = Map::default();
     let mut next = state.root_package;
+
+    #[cfg(feature = "experimental-conflict")]
+    {
+        let conflict = dependency_provider.init_conflict();
+
+        for grp in conflict {
+            let mut map = SmallMap::Empty;
+
+            for (k, v) in grp {
+                let id = state.package_store.alloc(k);
+                map.insert(id, v);
+            }
+
+            let incompat = Incompatibility::conflict(map);
+
+            state.add_incompatibility(incompat);
+        }
+    }
+
     loop {
         dependency_provider
             .should_cancel()
@@ -442,5 +468,13 @@ pub trait DependencyProvider {
     /// If not provided the resolver will run as long as needed.
     fn should_cancel(&self) -> Result<(), Self::Err> {
         Ok(())
+    }
+
+    /// Externally specify conflicts between specific version ranges of packages.
+    ///
+    /// This method is called once at the start of the resolution process and the resolver will learn the conflicts as internal incompatibilities.
+    #[cfg(feature = "experimental-conflict")]
+    fn init_conflict(&self) -> Vec<HashMap<Self::P, Self::VS>> {
+        vec![]
     }
 }


### PR DESCRIPTION
As mentioned by #120 and #122 , currently PubGrub does not have semantics to signify that a set of packages (of specific version ranges) cannot be simultaneously present. The PR adds a function `init_conflict` to the `DependencyProvider` trait so that they can tell the algorithm that certain combinations of packages are forbidden, at the beginning of the resolution process.

This is controlled by the `experimental-conflict` crate feature.

A considerable merit is improvement in performance, as compared to simulating conflicts with virtual packages. Before that I was using a mechanism that, say, if `foo@1.*` and `bar@2.*` conflict, we create a virtual package `baz` with versions {1.0.0, 2.0.0} and make every version of `foo` in `1.*` depend on `baz=1.0.0` and every version of `bar` in `2.*` depend on `baz=2.0.0` . The problem is that PubGrub has to try every combination of `(foo, bar)` within that range to conclude the incompatibility, and switching to directly encoding conflicts with internal `Incompatibility` brings around 100% acceleration, in my use case of a package manager for modded Minecraft, where both the conflicting packages have a few hundred of versions https://github.com/misaka10987/creeper .