### PR TITLE
Fix clippy

### DIFF
--- a/src/solver.rs
+++ b/src/solver.rs
@@ -148,7 +148,7 @@ pub fn resolve<DP: DependencyProvider>(
 
         info!(
             "unit_propagation: {:?} = '{}'",
-            &next, state.package_store[next]
+            next, state.package_store[next]
         );
         let satisfier_causes = state.unit_propagation(next)?;
         for (affected, incompat) in satisfier_causes {
@@ -200,7 +200,7 @@ pub fn resolve<DP: DependencyProvider>(
 
         info!(
             "DP chose: {:?} = '{}' @ {:?}",
-            &next, state.package_store[next], decision
+            next, state.package_store[next], decision
         );
 
         // Pick the next compatible version.
@@ -269,7 +269,7 @@ pub fn resolve<DP: DependencyProvider>(
             // terms and can add the decision directly.
             info!(
                 "add_decision (not first time): {:?} = '{}' @ {}",
-                &next, state.package_store[next], v
+                next, state.package_store[next], v
             );
             state.partial_solution.add_decision(next, v);
         }


### PR DESCRIPTION
Remove redundant references from the three `info!` calls flagged by the Rust 1.97.

This is an upstream port of https://github.com/astral-sh/pubgrub/pull/78