### PR TITLE
Short-circuit equal range containment

### DIFF
--- a/version-ranges/src/lib.rs
+++ b/version-ranges/src/lib.rs
@@ -813,6 +813,14 @@ impl<V: Ord + Clone> Ranges<V> {
     /// Note that we don't know that set of all existing `V`s here, so we only check if all
     /// segments `self` are contained in a segment of `other`.
     pub fn subset_of(&self, other: &Self) -> bool {
+        // Equality is common for long accumulated ranges during PubGrub conflict resolution.
+        if self.segments.len() > 1
+            && self.segments.len() == other.segments.len()
+            && self.segments == other.segments
+        {
+            return true;
+        }
+
         let mut containing_iter = other.segments.iter();
         let mut subset_iter = self.segments.iter();
         let Some(mut containing_elem) = containing_iter.next() else {


### PR DESCRIPTION
## Summary

PubGrub conflict resolution frequently checks whether long accumulated version ranges are subsets of identical historical ranges. `Ranges::subset_of` currently walks every interval through the general containment algorithm even when the canonical segment arrays are equal.

This change short-circuits equality for multi-segment ranges before starting the general containment scan. Single-segment ranges stay on the existing path because their containment check is already cheaper than a separate equality comparison. It appears that in this workload, the length guard is an almost-perfect classifier, and equality ends up being much cheaper than containment. So we almost never do extra work due to `==` being false.

Upstreamed from [https://github.com/astral-sh/pubgrub/pull/64](https://github.com/astral-sh/pubgrub/pull/64).
