### PR TITLE
Reserve arena iterator capacity

### DIFF
--- a/src/internal/arena.rs
+++ b/src/internal/arena.rs
@@ -105,6 +105,7 @@ impl<T> Arena<T> {
 
     pub(crate) fn alloc_iter<I: Iterator<Item = T>>(&mut self, values: I) -> Range<Id<T>> {
         let start = Id::from(self.data.len() as u32);
+        self.data.reserve(values.size_hint().0);
         values.for_each(|v| {
             self.alloc(v);
         });
@@ -165,5 +166,37 @@ impl<T: Hash + Eq> Index<Id<T>> for HashArena<T> {
     type Output = T;
     fn index(&self, id: Id<T>) -> &T {
         &self.data[id.raw as usize]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Arena, Id};
+
+    #[test]
+    fn alloc_iter_preserves_order_and_duplicates() {
+        let mut arena = Arena::new();
+        let existing = arena.alloc("existing".to_owned());
+
+        let appended = arena.alloc_iter(
+            ["first", "duplicate", "duplicate"]
+                .into_iter()
+                .map(str::to_owned),
+        );
+
+        assert_eq!(existing.into_raw(), 0);
+        assert_eq!(arena[existing], "existing");
+        assert_eq!(appended.start.into_raw(), 1);
+        assert_eq!(appended.end.into_raw(), 4);
+        let appended_values: Vec<_> = Id::range_to_iter(appended.clone())
+            .map(|id| arena[id].as_str())
+            .collect();
+        assert_eq!(appended_values, ["first", "duplicate", "duplicate"]);
+
+        let empty = arena.alloc_iter(std::iter::empty::<String>());
+        assert_eq!(empty.start.into_raw(), 4);
+        assert_eq!(empty.end.into_raw(), 4);
+        assert_eq!(arena.data.len(), 4);
+        assert_eq!(arena[existing], "existing");
     }
 }


### PR DESCRIPTION
## What

`Arena::alloc_iter` now reserves the iterator's `size_hint` lower bound before appending its values. The lower bound is guaranteed to be available from the iterator, so this gives the backing `Vec` enough room for at least the known items while preserving normal growth if the iterator yields more. Allocation order, duplicate values, returned ID ranges, and empty iterators are unchanged.

## Why

PubGrub allocates batches of incompatibilities through this path. Appending a known-size batch one item at a time can otherwise grow the arena repeatedly as it crosses capacity boundaries. Reserving once avoids that geometric reallocation and copying without changing the allocator, build profile, or public API.

Upstreamed from [https://github.com/astral-sh/pubgrub/pull/68](https://github.com/astral-sh/pubgrub/pull/68).
