### PR TITLE
Avoid dependency cache allocations before backtracking

### DIFF
--- a/benches/backtracking.rs
+++ b/benches/backtracking.rs
@@ -88,10 +88,31 @@ fn backtracking_ranges(c: &mut Criterion, package_count: u32, version_count: u32
     });
 }
 
+/// A large dependency tree representing the common case where every package resolves on the first
+/// attempt and PubGrub never needs to backtrack.
+fn no_backtracking(c: &mut Criterion, package_count: u32) {
+    let mut dependency_provider = OfflineDependencyProvider::<u32, Ranges<u32>>::new();
+
+    for package in 0..package_count {
+        let dependencies = [package * 2 + 1, package * 2 + 2]
+            .into_iter()
+            .filter(|dependency| *dependency < package_count)
+            .map(|dependency| (dependency, Ranges::singleton(0u32)));
+        dependency_provider.add_dependencies(package, 0u32, dependencies);
+    }
+
+    c.bench_function("no_backtracking", |b| {
+        b.iter(|| {
+            let _ = pubgrub::resolve(&dependency_provider, 0u32, 0u32);
+        })
+    });
+}
+
 fn bench_group(c: &mut Criterion) {
     backtracking_singletons(c, 100, 500);
     backtracking_disjoint_versions(c, 300, 200);
     backtracking_ranges(c, 5, 200);
+    no_backtracking(c, 1_000);
 }
 
 criterion_group!(benches, bench_group);

--- a/src/internal/partial_solution.rs
+++ b/src/internal/partial_solution.rs
@@ -176,6 +176,11 @@ impl<DP: DependencyProvider> PartialSolution<DP> {
         }
     }
 
+    /// Returns whether the solver has backtracked at least once.
+    pub(crate) fn has_backtracked(&self) -> bool {
+        self.has_ever_backtracked
+    }
+
     pub(crate) fn display<'a>(&'a self, package_store: &'a HashArena<DP::P>) -> impl Display + 'a {
         struct PSDisplay<'a, DP: DependencyProvider>(&'a PartialSolution<DP>, &'a HashArena<DP::P>);
 
@@ -418,7 +423,7 @@ impl<DP: DependencyProvider> PartialSolution<DP> {
         new_incompatibilities: std::ops::Range<IncompId<DP::P, DP::VS, DP::M>>,
         store: &Arena<Incompatibility<DP::P, DP::VS, DP::M>>,
     ) -> Option<IncompId<DP::P, DP::VS, DP::M>> {
-        if !self.has_ever_backtracked {
+        if !self.has_backtracked() {
             // Fast path: Nothing has yet gone wrong during this resolution. This call is unlikely to be the first problem.
             // So let's live with a little bit of risk and add the decision without checking the dependencies.
             // The worst that can happen is we will have to do a full backtrack which only removes this one decision.

--- a/src/solver.rs
+++ b/src/solver.rs
@@ -52,34 +52,6 @@ impl<P, V: Ord> AddedDependencies<P, V> {
     }
 }
 
-#[cfg(test)]
-mod added_dependencies_tests {
-    use super::AddedDependencies;
-    use crate::internal::HashArena;
-
-    #[test]
-    fn deduplicates_complete_history_after_backtracking() {
-        let mut packages = HashArena::new();
-        let first = packages.alloc("first");
-        let second = packages.alloc("second");
-        let mut added = AddedDependencies::new();
-
-        assert!(added.insert(first, 1u32, false));
-        assert!(added.insert(second, 1u32, false));
-
-        // The first backtrack can revisit either package from the previous history.
-        assert!(!added.insert(first, 1u32, true));
-        assert!(!added.insert(second, 1u32, true));
-
-        // New versions are recorded once, including across later backtracks.
-        assert!(added.insert(first, 2u32, true));
-        assert!(!added.insert(first, 1u32, true));
-        assert!(!added.insert(first, 2u32, true));
-        assert!(added.insert(second, 2u32, true));
-        assert!(!added.insert(second, 2u32, true));
-    }
-}
-
 /// Statistics on how often a package conflicted with other packages.
 #[derive(Debug, Default, Clone)]
 pub struct PackageResolutionStatistics {

--- a/src/solver.rs
+++ b/src/solver.rs
@@ -8,6 +8,78 @@ use crate::internal::{Id, Incompatibility, State};
 use crate::{Map, Package, PubGrubError, Term, VersionSet};
 use log::{debug, info};
 
+/// Tracks package versions whose dependency incompatibilities have already been added.
+///
+/// Before the first backtrack, entries are stored in a compact history because decisions cannot
+/// be revisited. The history is promoted to a deduplicating map only once revisits become possible.
+struct AddedDependencies<P, V> {
+    before_first_backtrack: Vec<(Id<P>, V)>,
+    after_first_backtrack: Option<Map<Id<P>, Set<V>>>,
+}
+
+impl<P, V: Ord> AddedDependencies<P, V> {
+    fn new() -> Self {
+        Self {
+            before_first_backtrack: Vec::new(),
+            after_first_backtrack: None,
+        }
+    }
+
+    /// Records a package version and returns whether its dependency incompatibilities still need
+    /// to be added.
+    ///
+    /// `has_backtracked` must remain true after the first backtrack so that later decisions are
+    /// deduplicated against the complete pre-backtrack history.
+    fn insert(&mut self, package: Id<P>, version: V, has_backtracked: bool) -> bool {
+        if !has_backtracked {
+            // Without a backtrack, an earlier decision cannot be revisited. Keep a compact history
+            // so the common case does not allocate a map entry and tree node per package.
+            self.before_first_backtrack.push((package, version));
+            return true;
+        }
+
+        self.after_first_backtrack
+            .get_or_insert_with(|| {
+                let mut added = Map::<Id<P>, Set<V>>::default();
+                for (package, version) in std::mem::take(&mut self.before_first_backtrack) {
+                    added.entry(package).or_default().insert(version);
+                }
+                added
+            })
+            .entry(package)
+            .or_default()
+            .insert(version)
+    }
+}
+
+#[cfg(test)]
+mod added_dependencies_tests {
+    use super::AddedDependencies;
+    use crate::internal::HashArena;
+
+    #[test]
+    fn deduplicates_complete_history_after_backtracking() {
+        let mut packages = HashArena::new();
+        let first = packages.alloc("first");
+        let second = packages.alloc("second");
+        let mut added = AddedDependencies::new();
+
+        assert!(added.insert(first, 1u32, false));
+        assert!(added.insert(second, 1u32, false));
+
+        // The first backtrack can revisit either package from the previous history.
+        assert!(!added.insert(first, 1u32, true));
+        assert!(!added.insert(second, 1u32, true));
+
+        // New versions are recorded once, including across later backtracks.
+        assert!(added.insert(first, 2u32, true));
+        assert!(!added.insert(first, 1u32, true));
+        assert!(!added.insert(first, 2u32, true));
+        assert!(added.insert(second, 2u32, true));
+        assert!(!added.insert(second, 2u32, true));
+    }
+}
+
 /// Statistics on how often a package conflicted with other packages.
 #[derive(Debug, Default, Clone)]
 pub struct PackageResolutionStatistics {
@@ -139,7 +211,7 @@ pub fn resolve<DP: DependencyProvider>(
 ) -> Result<SelectedDependencies<DP::P, DP::V>, PubGrubError<DP>> {
     let mut state: State<DP> = State::init(package.clone(), version.into());
     let mut conflict_tracker: Map<Id<DP::P>, PackageResolutionStatistics> = Map::default();
-    let mut added_dependencies: Map<Id<DP::P>, Set<DP::V>> = Map::default();
+    let mut added_dependencies = AddedDependencies::new();
     let mut next = state.root_package;
     loop {
         dependency_provider
@@ -221,10 +293,8 @@ pub fn resolve<DP: DependencyProvider>(
             );
         }
 
-        let is_new_dependency = added_dependencies
-            .entry(next)
-            .or_default()
-            .insert(v.clone());
+        let is_new_dependency =
+            added_dependencies.insert(next, v.clone(), state.partial_solution.has_backtracked());
 
         if is_new_dependency {
             // Retrieve that package dependencies.


### PR DESCRIPTION
## What

Before the first backtrack, we now record resolved package versions in a compact vector instead of immediately allocating a map entry and B-tree set for each package. If the solver backtracks, we promote the complete history into the existing deduplicating map before processing the next decision, then release the vector's backing allocation. Later decisions continue to deduplicate against the complete history, preserving the guarantee that dependency incompatibilities are added at most once for each package version.

This also exposes the partial solution's existing backtrack-state check as a helper shared by the dependency cache and decision fast path, and adds a 1,000-package dependency-tree benchmark for the common case where every package resolves on the first attempt.

## Why

Before a backtrack, an earlier decision cannot be revisited, so deduplicating every package version is unnecessary. The previous map of B-tree sets nevertheless paid for hash-table entries and tree allocations throughout successful first-pass resolutions. Keeping that history contiguous avoids those per-package allocations while retaining the original map behavior once revisits become possible.

## Performance

A warmed release-mode run of the new 1,000-package no-backtracking workload, with identical allocator instrumentation enabled only around `resolve`, produced:

| Metric | `main` | This PR | Change |
| --- | ---: | ---: | ---: |
| Allocator operations | 2,628 | 1,627 | 38.1% fewer |
| Requested bytes | 1,751,144 | 1,576,380 | 10.0% fewer |
| Peak tracked live bytes | 915,232 | 808,104 | 11.7% lower |

CodSpeed classifies all existing timing benchmarks as unchanged. Because `no_backtracking` is new on this branch, it has no `main` measurement for a timing comparison; this PR therefore claims reduced allocation churn and peak memory, not a CPU-time improvement.

Upstreamed from [https://github.com/astral-sh/pubgrub/pull/72](https://github.com/astral-sh/pubgrub/pull/72).
