### PR TITLE
Switch default branch to main

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -3,7 +3,7 @@ name: Benchmarks (CodSpeed)
 on:
   push:
     branches:
-      - dev
+      - main
   pull_request:
   workflow_dispatch:
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ on:
   pull_request:
   merge_group:
   push:
-    branches: [release, dev]
+    branches: [release, main]
   schedule: [cron: "0 6 * * 4"]
 
 permissions: {}

--- a/.github/workflows/deploy_documentation.yml
+++ b/.github/workflows/deploy_documentation.yml
@@ -25,7 +25,7 @@ jobs:
         run: cargo doc --no-deps
 
       - name: Deploy documentation
-        if: ${{ github.event_name == 'branches' }}
+        if: ${{ github.ref == 'refs/heads/main' }}
         uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e # v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/deploy_documentation.yml
+++ b/.github/workflows/deploy_documentation.yml
@@ -3,7 +3,7 @@
 name: Deploy documentation
 on:
   push:
-    branches: [dev]
+    branches: [main]
   workflow_dispatch:
 
 permissions: {}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -246,7 +246,7 @@ The gist of it is:
 [0.2.1]: https://github.com/pubgrub-rs/pubgrub/releases/tag/v0.2.1
 [0.2.0]: https://github.com/pubgrub-rs/pubgrub/releases/tag/v0.2.0
 [0.1.0]: https://github.com/pubgrub-rs/pubgrub/releases/tag/v0.1.0
-[unreleased-diff]: https://github.com/pubgrub-rs/pubgrub/compare/release...dev
+[unreleased-diff]: https://github.com/pubgrub-rs/pubgrub/compare/release...main
 [0.2.1-diff]: https://github.com/pubgrub-rs/pubgrub/compare/v0.2.1...v0.3.0
 [0.2.0-diff]: https://github.com/pubgrub-rs/pubgrub/compare/v0.2.0...v0.2.1
 [0.1.0-diff]: https://github.com/pubgrub-rs/pubgrub/compare/v0.1.0...v0.2.0

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The best way to get started with PubGrub are the [guide][guide] and the
 algorithm's [introductory blog post][medium-pubgrub]. There are also some
 runnable examples in the [examples](./examples) folder. More details are
 available in the [stable API documentation][docs] and the [development API
-documentation][docs-dev] from dev branch.
+documentation][docs-dev] from the main branch.
 
 ## The PubGrub Algorithm
 


### PR DESCRIPTION
Follow the general convention of naming the default branch `main`, removing the special casing just for this repo. Update CI and benchmark triggers, documentation deployment, and development documentation references to use `main`.

Fix the documentation deployment condition to check the branch ref, allowing pushes and manual runs on `main` to publish the documentation.
