### PR TITLE
Avoid cloning dependency version sets

### DIFF
--- a/src/internal/incompatibility.rs
+++ b/src/internal/incompatibility.rs
@@ -57,11 +57,11 @@ enum Kind<P: Package, VS: VersionSet, M: Eq + Clone + Debug + Display> {
     /// Incompatibility coming from the dependencies of a given package.
     ///
     /// If a@1 depends on b>=1,<2, we create an incompatibility with terms `{a 1, b <1,>=2}` with
-    /// kind `FromDependencyOf(a, 1, b, >=1,<2)`.
+    /// kind `FromDependencyOf(a, b)`. The version sets are stored in the incompatibility terms.
     ///
     /// We can merge multiple dependents with the same version. For example, if a@1 depends on b and
     /// a@2 depends on b, we can say instead a@1||2 depends on b.
-    FromDependencyOf(Id<P>, VS, Id<P>, VS),
+    FromDependencyOf(Id<P>, Id<P>),
     /// Derived from two causes. Stores cause ids.
     ///
     /// For example, if a -> b and b -> c, we can derive a -> c.
@@ -143,20 +143,38 @@ impl<P: Package, VS: VersionSet, M: Eq + Clone + Debug + Display> Incompatibilit
         let (p2, set2) = dep;
         Self {
             package_terms: if set2 == VS::empty() {
-                SmallMap::One([(package, Term::Positive(versions.clone()))])
+                SmallMap::One([(package, Term::Positive(versions))])
             } else {
                 SmallMap::Two([
-                    (package, Term::Positive(versions.clone())),
-                    (p2, Term::Negative(set2.clone())),
+                    (package, Term::Positive(versions)),
+                    (p2, Term::Negative(set2)),
                 ])
             },
-            kind: Kind::FromDependencyOf(package, versions, p2, set2),
+            kind: Kind::FromDependencyOf(package, p2),
         }
+    }
+
+    fn dependency_terms(&self, p1: Id<P>, p2: Id<P>) -> (&VS, Option<&VS>) {
+        let mut terms = self.package_terms.iter();
+        let versions = match terms.next() {
+            Some((term_package, Term::Positive(versions))) if *term_package == p1 => versions,
+            _ => panic!("dependency incompatibility must start with its positive term"),
+        };
+        let dependency_versions = match terms.next() {
+            None => None,
+            Some((term_package, Term::Negative(versions))) if *term_package == p2 => Some(versions),
+            _ => panic!("dependency incompatibility must end with its negative term"),
+        };
+        assert!(
+            terms.next().is_none(),
+            "dependency incompatibility must contain at most two terms"
+        );
+        (versions, dependency_versions)
     }
 
     pub(crate) fn as_dependency(&self) -> Option<(Id<P>, Id<P>)> {
         match &self.kind {
-            Kind::FromDependencyOf(p1, _, p2, _) => Some((*p1, *p2)),
+            Kind::FromDependencyOf(p1, p2) => Some((*p1, *p2)),
             _ => None,
         }
     }
@@ -305,12 +323,14 @@ impl<P: Package, VS: VersionSet, M: Eq + Clone + Debug + Display> Incompatibilit
                 package_store[package].clone(),
                 set.clone(),
             )),
-            Kind::FromDependencyOf(package, set, dep_package, dep_set) => {
+            Kind::FromDependencyOf(package, dep_package) => {
+                let (package_versions, dependency_versions) =
+                    store[self_id].dependency_terms(package, dep_package);
                 DerivationTree::External(External::FromDependencyOf(
                     package_store[package].clone(),
-                    set.clone(),
+                    package_versions.clone(),
                     package_store[dep_package].clone(),
-                    dep_set.clone(),
+                    dependency_versions.cloned().unwrap_or_else(VS::empty),
                 ))
             }
             Kind::Custom(package, set, metadata) => DerivationTree::External(External::Custom(
@@ -395,11 +415,51 @@ pub(crate) mod tests {
     use proptest::prelude::*;
     use std::cmp::Reverse;
     use std::collections::BTreeMap;
+    use std::fmt::{self, Formatter};
 
     use super::*;
     use crate::internal::State;
     use crate::term::tests::strategy as term_strat;
     use crate::{OfflineDependencyProvider, Ranges};
+
+    #[derive(Debug, Eq, PartialEq)]
+    struct PanicOnCloneRanges(Ranges<usize>);
+
+    impl Clone for PanicOnCloneRanges {
+        fn clone(&self) -> Self {
+            panic!("version set was cloned")
+        }
+    }
+
+    impl Display for PanicOnCloneRanges {
+        fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+            Display::fmt(&self.0, f)
+        }
+    }
+
+    impl VersionSet for PanicOnCloneRanges {
+        type V = usize;
+
+        fn empty() -> Self {
+            Self(Ranges::empty())
+        }
+
+        fn singleton(v: Self::V) -> Self {
+            Self(Ranges::singleton(v))
+        }
+
+        fn complement(&self) -> Self {
+            Self(self.0.complement())
+        }
+
+        fn intersection(&self, other: &Self) -> Self {
+            Self(self.0.intersection(&other.0))
+        }
+
+        fn contains(&self, v: &Self::V) -> bool {
+            self.0.contains(v)
+        }
+    }
 
     proptest! {
 
@@ -419,12 +479,12 @@ pub(crate) mod tests {
             let p3 = package_store.alloc("p3");
             let i1 = store.alloc(Incompatibility {
                 package_terms: SmallMap::Two([(p1, t1.clone()), (p2, t2.negate())]),
-                kind: Kind::<_, _, String>::FromDependencyOf(p1, Ranges::full(), p2, Ranges::full())
+                kind: Kind::<_, _, String>::FromDependencyOf(p1, p2)
             });
 
             let i2 = store.alloc(Incompatibility {
                 package_terms: SmallMap::Two([(p2, t2), (p3, t3.clone())]),
-                kind: Kind::<_, _, String>::FromDependencyOf(p2, Ranges::full(), p3, Ranges::full())
+                kind: Kind::<_, _, String>::FromDependencyOf(p2, p3)
             });
 
             let mut i3 = Map::default();
@@ -435,6 +495,123 @@ pub(crate) mod tests {
             assert_eq!(i_resolution.package_terms.iter().map(|(&k, v)|(k, v.clone())).collect::<Map<_, _>>(), i3);
         }
 
+    }
+
+    #[test]
+    fn from_dependency_does_not_clone_version_sets() {
+        let mut package_store = HashArena::new();
+        let package = package_store.alloc("package".to_string());
+        let dependency = package_store.alloc("dependency".to_string());
+
+        for dependency_versions in [
+            PanicOnCloneRanges(Ranges::singleton(2usize)),
+            PanicOnCloneRanges(Ranges::empty()),
+        ] {
+            let _: Incompatibility<String, PanicOnCloneRanges, String> =
+                Incompatibility::from_dependency(
+                    package,
+                    PanicOnCloneRanges(Ranges::singleton(1usize)),
+                    (dependency, dependency_versions),
+                );
+        }
+    }
+
+    fn assert_dependency_tree(
+        package_store: &HashArena<String>,
+        incompatibility: Incompatibility<String, Ranges<usize>, String>,
+        expected_versions: &Ranges<usize>,
+        expected_dependency: &str,
+        expected_dependency_versions: &Ranges<usize>,
+    ) {
+        let mut store = Arena::new();
+        let id = store.alloc(incompatibility);
+        let tree = Incompatibility::build_derivation_tree(
+            id,
+            &Set::default(),
+            &store,
+            package_store,
+            &Map::default(),
+        );
+        let DerivationTree::External(External::FromDependencyOf(
+            actual_package,
+            actual_versions,
+            actual_dependency,
+            actual_dependency_versions,
+        )) = tree
+        else {
+            panic!("expected a dependency external")
+        };
+        assert_eq!(actual_package, "package");
+        assert_eq!(&actual_versions, expected_versions);
+        assert_eq!(actual_dependency, expected_dependency);
+        assert_eq!(&actual_dependency_versions, expected_dependency_versions);
+    }
+
+    #[test]
+    fn dependency_derivation_trees_reconstruct_ranges() {
+        let mut package_store = HashArena::new();
+        let package = package_store.alloc("package".to_string());
+        let dependency = package_store.alloc("dependency".to_string());
+        let versions = Ranges::between(1usize, 4usize);
+        let other_versions = Ranges::singleton(4usize);
+        let dependency_versions = Ranges::between(7usize, 10usize);
+
+        assert_dependency_tree(
+            &package_store,
+            Incompatibility::from_dependency(
+                package,
+                versions.clone(),
+                (dependency, dependency_versions.clone()),
+            ),
+            &versions,
+            "dependency",
+            &dependency_versions,
+        );
+
+        let empty = Ranges::empty();
+        assert_dependency_tree(
+            &package_store,
+            Incompatibility::from_dependency(
+                package,
+                versions.clone(),
+                (dependency, empty.clone()),
+            ),
+            &versions,
+            "dependency",
+            &empty,
+        );
+
+        assert_dependency_tree(
+            &package_store,
+            Incompatibility::from_dependency(
+                package,
+                versions.clone(),
+                (package, dependency_versions.clone()),
+            ),
+            &versions,
+            "package",
+            &dependency_versions,
+        );
+
+        let first: Incompatibility<String, Ranges<usize>, String> =
+            Incompatibility::from_dependency(
+                package,
+                versions.clone(),
+                (dependency, dependency_versions.clone()),
+            );
+        let second = Incompatibility::from_dependency(
+            package,
+            other_versions.clone(),
+            (dependency, dependency_versions.clone()),
+        );
+        let merged = first.merge_dependents(&second).unwrap();
+        assert_dependency_tree(
+            &package_store,
+            merged,
+            &versions.union(&other_versions),
+            "dependency",
+            &dependency_versions,
+        );
     }
 
     /// Check that multiple self-dependencies are supported.


### PR DESCRIPTION
## What

Dependency incompatibilities now store only the dependent and dependency package IDs in `Kind::FromDependencyOf`. The corresponding version sets are moved directly into the incompatibility terms instead of being cloned into both representations, and the unchanged four-field `External::FromDependencyOf` report is reconstructed from those terms on the cold error-reporting path.

The latest `main` branch also indexes merge candidates by dependency-range hash. To preserve that behavior without restoring a clone or adding another field to every incompatibility, `as_dependency` borrows the optional dependency range from the terms and the merge cache hashes that optional reference. Empty dependencies remain represented by an omitted negative term; self-dependencies, duplicate dependencies, merged dependents, iteration order, and public `Incompatibility::iter` behavior are preserved.

This changes the public `Kind::FromDependencyOf` variant from four fields to two, so it is intended for a 0.5.0-or-later release. [The dependent uv draft](https://github.com/astral-sh/uv/pull/20048) updates the four consumer matches and temporarily pins this commit.

## Why

`Incompatibility::from_dependency` is on the dependency-construction hot path. Previously, it cloned both version sets into `Kind` even though the same sets were already owned by `package_terms`. With clone-counting coverage, the constructor now performs zero `VersionSet` clones for both empty and non-empty dependencies.

The clone-removal mechanism was measured against the independent [reserve-only control](https://github.com/astral-sh/pubgrub/pull/68) over five CodSpeed CPU-simulation samples:

| Benchmark | Reserve-only control | Clone removal | Change |
| --- | ---: | ---: | ---: |
| `sudoku-easy` | 4.70 ms | 3.55 ms | 24.47% faster |
| `sudoku-hard` | 4.86 ms | 4.17 ms | 14.20% faster |

Against the original baseline, the cumulative candidate was 26.35% faster on `sudoku-easy` and 18.87% faster on `sudoku-hard`. `backtracking_ranges` moved from 1.89 s to 1.90 s, a disclosed 0.53% regression; the other measured benchmarks were neutral to modestly faster. [Representative CodSpeed report](https://app.codspeed.io/astral-sh/pubgrub/runs/6a41c50ad94dafe8c8334e3a).

The full workspace and focused semantic tests pass, including zero-clone construction, empty and self-dependencies, duplicate term ordering, derivation-tree reconstruction, merged ranges, and package self-dependency behavior. Strict Clippy, formatting, documentation, and diff checks also pass. The small latest-main merge-cache adaptation is integration-only and was not measured separately from the validated clone-removal mechanism.

Upstreamed from [https://github.com/astral-sh/pubgrub/pull/67](https://github.com/astral-sh/pubgrub/pull/67).

For this upstream port, `Kind` remains private and the existing package-pair merge index is retained. The public API and `VersionSet` trait bounds are unchanged; the public-enum compatibility note above applies to the fork. The performance numbers above are measurements from the original PR.
