### PR TITLE
Cache contradicted incompatibilities inline

### DIFF
--- a/src/internal/arena.rs
+++ b/src/internal/arena.rs
@@ -2,7 +2,7 @@ use std::fmt;
 use std::hash::{Hash, Hasher};
 use std::marker::PhantomData;
 use std::num::NonZeroU32;
-use std::ops::{Index, Range};
+use std::ops::{Index, IndexMut, Range};
 
 type FnvIndexSet<V> = indexmap::IndexSet<V, rustc_hash::FxBuildHasher>;
 
@@ -129,6 +129,12 @@ impl<T> Index<Id<T>> for Arena<T> {
     type Output = T;
     fn index(&self, id: Id<T>) -> &T {
         &self.data[id.into_raw()]
+    }
+}
+
+impl<T> IndexMut<Id<T>> for Arena<T> {
+    fn index_mut(&mut self, id: Id<T>) -> &mut Self::Output {
+        &mut self.data[id.into_raw()]
     }
 }
 

--- a/src/internal/core.rs
+++ b/src/internal/core.rs
@@ -21,12 +21,6 @@ pub(crate) struct State<DP: DependencyProvider> {
     #[allow(clippy::type_complexity)]
     incompatibilities: Map<Id<DP::P>, Vec<IncompDpId<DP>>>,
 
-    /// As an optimization, store the ids of incompatibilities that are already contradicted.
-    ///
-    /// For each one keep track of the decision level when it was found to be contradicted.
-    /// These will stay contradicted until we have backtracked beyond its associated decision level.
-    contradicted_incompatibilities: Map<IncompDpId<DP>, DecisionLevel>,
-
     /// All incompatibilities expressing dependencies,
     /// with common dependents merged.
     #[allow(clippy::type_complexity)]
@@ -64,7 +58,6 @@ impl<DP: DependencyProvider> State<DP> {
             root_package,
             root_version,
             incompatibilities,
-            contradicted_incompatibilities: Map::default(),
             partial_solution: PartialSolution::empty(),
             incompatibility_store,
             package_store,
@@ -91,7 +84,12 @@ impl<DP: DependencyProvider> State<DP> {
     }
 
     /// Add an incompatibility to the state.
-    pub(crate) fn add_incompatibility(&mut self, incompat: Incompatibility<DP::P, DP::VS, DP::M>) {
+    pub(crate) fn add_incompatibility(
+        &mut self,
+        mut incompat: Incompatibility<DP::P, DP::VS, DP::M>,
+    ) {
+        // Cached contradictions are only valid in the state that recorded them.
+        incompat.reset_contradiction_cache();
         let id = self.incompatibility_store.alloc(incompat);
         self.merge_incompatibility(id);
     }
@@ -177,8 +175,8 @@ impl<DP: DependencyProvider> State<DP> {
             // We only care about incompatibilities if it contains the current package.
             for &incompat_id in self.incompatibilities[&current_package].iter().rev() {
                 if self
-                    .contradicted_incompatibilities
-                    .contains_key(&incompat_id)
+                    .partial_solution
+                    .is_contradicted(&self.incompatibility_store[incompat_id])
                 {
                     continue;
                 }
@@ -209,12 +207,12 @@ impl<DP: DependencyProvider> State<DP> {
                             &self.incompatibility_store,
                         );
                         // With the partial solution updated, the incompatibility is now contradicted.
-                        self.contradicted_incompatibilities
-                            .insert(incompat_id, self.partial_solution.current_decision_level());
+                        self.partial_solution
+                            .mark_contradicted(&mut self.incompatibility_store[incompat_id]);
                     }
                     Relation::Contradicted(_) => {
-                        self.contradicted_incompatibilities
-                            .insert(incompat_id, self.partial_solution.current_decision_level());
+                        self.partial_solution
+                            .mark_contradicted(&mut self.incompatibility_store[incompat_id]);
                     }
                     _ => {}
                 }
@@ -235,8 +233,8 @@ impl<DP: DependencyProvider> State<DP> {
                 );
                 // After conflict resolution and the partial solution update,
                 // the root cause incompatibility is now contradicted.
-                self.contradicted_incompatibilities
-                    .insert(root_cause, self.partial_solution.current_decision_level());
+                self.partial_solution
+                    .mark_contradicted(&mut self.incompatibility_store[root_cause]);
             }
         }
         // If there are no more changed packages, unit propagation is done.
@@ -330,9 +328,6 @@ impl<DP: DependencyProvider> State<DP> {
         decision_level: DecisionLevel,
     ) {
         self.partial_solution.backtrack(decision_level);
-        // Remove contradicted incompatibilities that depend on decisions we just backtracked away.
-        self.contradicted_incompatibilities
-            .retain(|_, dl| *dl <= decision_level);
         if incompat_changed {
             self.merge_incompatibility(incompat);
         }

--- a/src/internal/incompatibility.rs
+++ b/src/internal/incompatibility.rs
@@ -6,11 +6,38 @@
 use std::fmt::{Debug, Display};
 use std::sync::Arc;
 
-use crate::internal::{Arena, HashArena, Id, SmallMap};
+use crate::internal::{Arena, DecisionLevel, HashArena, Id, SmallMap};
 use crate::{
     DependencyProvider, DerivationTree, Derived, External, Map, Package, Set, Term, VersionSet,
     term,
 };
+
+#[derive(Debug, Clone)]
+struct ContradictionCache {
+    /// The decision level where this incompatibility became contradicted.
+    decision_level: DecisionLevel,
+    /// The backtrack generation for that decision level.
+    backtrack_generation: u32,
+}
+
+impl ContradictionCache {
+    fn not_contradicted() -> Self {
+        Self {
+            decision_level: DecisionLevel::MAX,
+            backtrack_generation: 0,
+        }
+    }
+
+    fn is_contradicted(&self, last_valid_decision_levels: &[DecisionLevel]) -> bool {
+        // The active generation has no backtrack target yet, so every contradiction recorded in
+        // it remains valid. Completed generations store the highest decision level that survived
+        // their first invalidating backtrack.
+        last_valid_decision_levels
+            .get(self.backtrack_generation as usize)
+            .map(|&level| self.decision_level <= level)
+            .unwrap_or(true)
+    }
+}
 
 /// An incompatibility is a set of terms for different packages
 /// that should never be satisfied all together.
@@ -31,6 +58,7 @@ use crate::{
 pub(crate) struct Incompatibility<P: Package, VS: VersionSet, M: Eq + Clone + Debug + Display> {
     package_terms: SmallMap<Id<P>, Term<VS>>,
     kind: Kind<P, VS, M>,
+    contradiction_cache: ContradictionCache,
 }
 
 /// Type alias of unique identifiers for incompatibilities.
@@ -100,6 +128,7 @@ impl<P: Package, VS: VersionSet, M: Eq + Clone + Debug + Display> Incompatibilit
                 Term::Negative(VS::singleton(version.clone())),
             )]),
             kind: Kind::NotRoot(package, version),
+            contradiction_cache: ContradictionCache::not_contradicted(),
         }
     }
 
@@ -112,6 +141,7 @@ impl<P: Package, VS: VersionSet, M: Eq + Clone + Debug + Display> Incompatibilit
         Self {
             package_terms: SmallMap::One([(package, term)]),
             kind: Kind::NoVersions(package, set),
+            contradiction_cache: ContradictionCache::not_contradicted(),
         }
     }
 
@@ -125,6 +155,7 @@ impl<P: Package, VS: VersionSet, M: Eq + Clone + Debug + Display> Incompatibilit
         Self {
             package_terms: SmallMap::One([(package, term)]),
             kind: Kind::Custom(package, set, metadata),
+            contradiction_cache: ContradictionCache::not_contradicted(),
         }
     }
 
@@ -135,6 +166,7 @@ impl<P: Package, VS: VersionSet, M: Eq + Clone + Debug + Display> Incompatibilit
         Self {
             package_terms: SmallMap::One([(package, term)]),
             kind: Kind::Custom(package, set, metadata),
+            contradiction_cache: ContradictionCache::not_contradicted(),
         }
     }
 
@@ -151,6 +183,7 @@ impl<P: Package, VS: VersionSet, M: Eq + Clone + Debug + Display> Incompatibilit
                 ])
             },
             kind: Kind::FromDependencyOf(package, versions, p2, set2),
+            contradiction_cache: ContradictionCache::not_contradicted(),
         }
     }
 
@@ -232,7 +265,28 @@ impl<P: Package, VS: VersionSet, M: Eq + Clone + Debug + Display> Incompatibilit
         Self {
             package_terms,
             kind,
+            contradiction_cache: ContradictionCache::not_contradicted(),
         }
+    }
+
+    pub(crate) fn is_contradicted(&self, last_valid_decision_levels: &[DecisionLevel]) -> bool {
+        self.contradiction_cache
+            .is_contradicted(last_valid_decision_levels)
+    }
+
+    pub(crate) fn mark_contradicted(
+        &mut self,
+        decision_level: DecisionLevel,
+        backtrack_generation: u32,
+    ) {
+        self.contradiction_cache = ContradictionCache {
+            decision_level,
+            backtrack_generation,
+        };
+    }
+
+    pub(crate) fn reset_contradiction_cache(&mut self) {
+        self.contradiction_cache = ContradictionCache::not_contradicted();
     }
 
     /// Check if an incompatibility should mark the end of the algorithm
@@ -401,6 +455,67 @@ pub(crate) mod tests {
     use crate::term::tests::strategy as term_strat;
     use crate::{OfflineDependencyProvider, Ranges};
 
+    #[test]
+    fn contradiction_cache_tracks_backtrack_generations() {
+        let current_generation = ContradictionCache {
+            decision_level: DecisionLevel(3),
+            backtrack_generation: 1,
+        };
+
+        // A generation without a recorded backtrack target is still active.
+        assert!(current_generation.is_contradicted(&[DecisionLevel(0)]));
+        // Backtracking below the contradiction's decision level invalidates it.
+        assert!(!current_generation.is_contradicted(&[DecisionLevel(0), DecisionLevel(2)]));
+        // Backtracking to or above that decision level preserves it.
+        assert!(current_generation.is_contradicted(&[DecisionLevel(0), DecisionLevel(3)]));
+
+        let later_generation = ContradictionCache {
+            decision_level: DecisionLevel(5),
+            backtrack_generation: 2,
+        };
+        assert!(later_generation.is_contradicted(&[DecisionLevel(0), DecisionLevel(3)]));
+        assert!(!later_generation.is_contradicted(&[
+            DecisionLevel(0),
+            DecisionLevel(3),
+            DecisionLevel(4),
+        ]));
+    }
+
+    #[test]
+    fn cloned_incompatibility_does_not_reuse_contradiction_cache() {
+        type Provider = OfflineDependencyProvider<String, Ranges<u32>>;
+
+        let mut base: State<Provider> = State::init("root".to_string(), 0);
+        base.unit_propagation(base.root_package).unwrap();
+        base.add_package_version_dependencies(
+            base.root_package,
+            0,
+            [("foo".to_string(), Ranges::full())],
+        );
+        base.unit_propagation(base.root_package).unwrap();
+        let foo = base.package_store.alloc("foo".to_string());
+
+        let mut source = base.clone();
+        source.add_package_version_dependencies(foo, 2, []);
+        let mut incompatibility =
+            Incompatibility::custom_version(foo, 1, "foo 1 is unavailable".to_string());
+        assert_eq!(
+            source.partial_solution.relation(&incompatibility),
+            Relation::Contradicted(foo),
+        );
+        source
+            .partial_solution
+            .mark_contradicted(&mut incompatibility);
+        assert!(source.partial_solution.is_contradicted(&incompatibility));
+
+        let mut target = base;
+        target.add_package_version_dependencies(foo, 1, []);
+        target.add_incompatibility(incompatibility.clone());
+
+        let conflicts = target.unit_propagation(foo).unwrap();
+        assert!(!conflicts.is_empty());
+    }
+
     proptest! {
 
         /// For any three different packages p1, p2 and p3,
@@ -419,12 +534,14 @@ pub(crate) mod tests {
             let p3 = package_store.alloc("p3");
             let i1 = store.alloc(Incompatibility {
                 package_terms: SmallMap::Two([(p1, t1.clone()), (p2, t2.negate())]),
-                kind: Kind::<_, _, String>::FromDependencyOf(p1, Ranges::full(), p2, Ranges::full())
+                kind: Kind::<_, _, String>::FromDependencyOf(p1, Ranges::full(), p2, Ranges::full()),
+                contradiction_cache: ContradictionCache::not_contradicted(),
             });
 
             let i2 = store.alloc(Incompatibility {
                 package_terms: SmallMap::Two([(p2, t2), (p3, t3.clone())]),
-                kind: Kind::<_, _, String>::FromDependencyOf(p2, Ranges::full(), p3, Ranges::full())
+                kind: Kind::<_, _, String>::FromDependencyOf(p2, Ranges::full(), p3, Ranges::full()),
+                contradiction_cache: ContradictionCache::not_contradicted(),
             });
 
             let mut i3 = Map::default();

--- a/src/internal/partial_solution.rs
+++ b/src/internal/partial_solution.rs
@@ -22,6 +22,9 @@ type FnvIndexSet<T> = indexmap::IndexSet<T, BuildHasherDefault<FxHasher>>;
 pub(crate) struct DecisionLevel(pub(crate) u32);
 
 impl DecisionLevel {
+    /// Sentinel for a decision level not associated with a cached contradiction.
+    pub(crate) const MAX: Self = Self(u32::MAX);
+
     pub(crate) fn increment(self) -> Self {
         Self(self.0 + 1)
     }
@@ -64,8 +67,9 @@ pub(crate) struct PartialSolution<DP: DependencyProvider> {
     /// Packages whose derivations changed since the last time `prioritize` was called and need
     /// their priorities to be updated.
     outdated_priorities: FnvIndexSet<Id<DP::P>>,
-    /// Whether we have never backtracked, to enable fast path optimizations.
-    has_ever_backtracked: bool,
+    /// For each completed backtrack generation, the highest decision level that remains valid.
+    /// The active generation is represented by the missing entry after the end of this vector.
+    last_valid_decision_levels: Vec<DecisionLevel>,
 }
 
 /// A package assignment is either a decision or a list of (accumulated) derivations without a
@@ -172,13 +176,30 @@ impl<DP: DependencyProvider> PartialSolution<DP> {
             package_assignments: FnvIndexMap::default(),
             prioritized_potential_packages: PriorityQueue::default(),
             outdated_priorities: FnvIndexSet::default(),
-            has_ever_backtracked: false,
+            last_valid_decision_levels: vec![DecisionLevel(0)],
         }
     }
 
-    /// Returns whether the solver has backtracked at least once.
+    pub(crate) fn is_contradicted(
+        &self,
+        incompatibility: &Incompatibility<DP::P, DP::VS, DP::M>,
+    ) -> bool {
+        incompatibility.is_contradicted(&self.last_valid_decision_levels)
+    }
+
+    pub(crate) fn mark_contradicted(
+        &self,
+        incompatibility: &mut Incompatibility<DP::P, DP::VS, DP::M>,
+    ) {
+        incompatibility.mark_contradicted(
+            self.current_decision_level(),
+            self.last_valid_decision_levels.len() as u32,
+        );
+    }
+
+    /// Returns whether at least one backtrack generation has completed.
     pub(crate) fn has_backtracked(&self) -> bool {
-        self.has_ever_backtracked
+        self.last_valid_decision_levels.len() > 1
     }
 
     pub(crate) fn display<'a>(&'a self, package_store: &'a HashArena<DP::P>) -> impl Display + 'a {
@@ -405,7 +426,13 @@ impl<DP: DependencyProvider> PartialSolution<DP> {
                 true
             }
         });
-        self.has_ever_backtracked = true;
+        // Close the active generation, then lower every generation invalidated by this backtrack
+        // to the new highest valid decision level.
+        self.last_valid_decision_levels.push(DecisionLevel::MAX);
+        let index = self
+            .last_valid_decision_levels
+            .partition_point(|&level| level <= decision_level);
+        self.last_valid_decision_levels[index..].fill(decision_level);
     }
 
     /// Add a package version as decision if none of its dependencies conflicts with the partial


### PR DESCRIPTION
This ports x-hgg-x's [contradiction-cache optimization](https://github.com/pubgrub-rs/pubgrub/commit/5ce70ea5c34040d0eeca6b461b01037829a1c486) from #274 onto the current generic solver without taking the version-set representation changes from that experiment.

Previously, we kept contradicted incompatibilities in a separate hash map. Unit propagation hashed every incompatibility ID to consult that cache, and each backtrack scanned the map to discard entries that no longer applied.

This change stores the contradiction decision level and backtrack generation directly on each incompatibility. The partial solution records the highest surviving decision level for completed backtrack generations, so cache checks are direct arena accesses and backtracking invalidates prior entries without scanning a hash map. The public solver and version-set APIs are unchanged.

## Performance

Local CodSpeed CPU-simulation results for this exact diff against `a8ea393`:

| PubGrub benchmark | Baseline | This PR | Change |
| --- | ---: | ---: | ---: |
| `backtracking_singletons` | 4.41 s | 3.54 s | 19.7% faster |
| `backtracking_disjoint_versions` | 2.29 s | 2.01 s | 12.2% faster |
| `backtracking_ranges` | 1.89 s | 1.88 s | 0.5% faster |
| `large_case_u16_NumberVersion.ron` | 24.92 ms | 23.73 ms | 4.8% faster |
| `sudoku-easy` | 4.81 ms | 4.38 ms | 8.9% faster |
| `sudoku-hard` | 5.13 ms | 5.05 ms | 1.6% faster |

PubGrub reports: baseline ([backtracking](https://app.codspeed.io/astral-sh/pubgrub/runs/6a411ed36c85028ff4704fa7), [large case](https://app.codspeed.io/astral-sh/pubgrub/runs/6a411ee38715559a9f08580d), [Sudoku](https://app.codspeed.io/astral-sh/pubgrub/runs/6a411ef36c85028ff4704faf)) and this PR ([backtracking](https://app.codspeed.io/astral-sh/pubgrub/runs/6a413c03577a7b572671a225), [large case](https://app.codspeed.io/astral-sh/pubgrub/runs/6a413c17577a7b572671a226), [Sudoku](https://app.codspeed.io/astral-sh/pubgrub/runs/6a413c2a577a7b572671a228)).

I also patched this exact PubGrub checkout into uv at `cfa5ca8122dbdf9cc3950724500a882823102435`:

| uv benchmark | Baseline | This PR | Change |
| --- | ---: | ---: | ---: |
| `resolve_warm_jupyter` | 80.32 ms | 79.49 ms | 1.0% faster |
| `resolve_warm_jupyter_universal` | 203.64 ms | 203.59 ms | effectively unchanged |

uv reports: [baseline](https://app.codspeed.io/astral-sh/uv/runs/6a4121c48715559a9f085814) and [this PR](https://app.codspeed.io/astral-sh/uv/runs/6a413ca6577a7b572671a231). The Airflow fixture was excluded because its build-backend subprocess traps under the local Valgrind simulator.

The full all-features test suite, Clippy with warnings denied, formatting checks, and private-item documentation all pass.

Upstreamed from [https://github.com/astral-sh/pubgrub/pull/59](https://github.com/astral-sh/pubgrub/pull/59).

The performance numbers above are measurements from the original PR.
