### PR TITLE
Expose double-ended range iteration

### DIFF
--- a/version-ranges/src/lib.rs
+++ b/version-ranges/src/lib.rs
@@ -934,7 +934,7 @@ impl<V: Ord + Clone> Ranges<V> {
     }
 
     /// Iterate over the parts of the range.
-    pub fn iter(&self) -> impl Iterator<Item = (&Bound<V>, &Bound<V>)> {
+    pub fn iter(&self) -> impl DoubleEndedIterator<Item = (&Bound<V>, &Bound<V>)> {
         self.segments.iter().map(|(start, end)| (start, end))
     }
 }


### PR DESCRIPTION
## Summary

`Ranges::iter` returns a mapped slice iterator that is already double-ended, but its opaque return type only exposes `Iterator`. Callers that need reverse borrowed traversal therefore have to materialize the segments.

This exposes `DoubleEndedIterator` in the return type, allowing callers to traverse borrowed range segments in either direction without cloning or allocating while preserving existing forward iteration.

This unblocks allocation-free descending range traversal in astral-sh/uv#20026.

Upstreamed from [https://github.com/astral-sh/pubgrub/pull/62](https://github.com/astral-sh/pubgrub/pull/62).
