### PR TITLE
Implement Default for HashArena

### DIFF
--- a/src/internal/arena.rs
+++ b/src/internal/arena.rs
@@ -168,9 +168,7 @@ impl<T: Hash + Eq + fmt::Debug> fmt::Debug for HashArena<T> {
 
 impl<T: Hash + Eq> HashArena<T> {
     pub fn new() -> Self {
-        HashArena {
-            data: FnvIndexSet::default(),
-        }
+        Self::default()
     }
 
     pub fn alloc(&mut self, value: T) -> Id<T> {
@@ -180,6 +178,14 @@ impl<T: Hash + Eq> HashArena<T> {
         );
         let (raw, _) = self.data.insert_full(value);
         Id::from_usize(raw)
+    }
+}
+
+impl<T: Hash + Eq> Default for HashArena<T> {
+    fn default() -> Self {
+        Self {
+            data: FnvIndexSet::default(),
+        }
     }
 }
 


### PR DESCRIPTION
Implement `Default` for `HashArena` and delegate `new()` to it, preserving the existing initialization.

Upstreamed from [https://github.com/astral-sh/pubgrub/commit/3f631a02e7d18c878d9af7ae7b5f8f6616247100](https://github.com/astral-sh/pubgrub/commit/3f631a02e7d18c878d9af7ae7b5f8f6616247100).
